### PR TITLE
chore: enhance ship command, add implement command, update docs

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,51 @@
+实现 Spec 的 Technical Design。Argument $ARGUMENTS: `SPEC-NNN`
+
+用法:
+- `/implement SPEC-008` — 读取 SPEC-008 的 TD，生成实现计划并执行
+
+前置条件:
+- Spec 必须处于 **Active** 状态（已有 PRD + TD）
+- TD 中必须包含 Task Breakdown 或 Implementation Steps
+
+Steps:
+
+1. **读取 Spec**: 读取 `docs/specs/active/$ARGUMENTS/technical-design.md` 和 `docs/specs/active/$ARGUMENTS/prd.md`
+   - 如果 Spec 不存在或不是 Active 状态，报错退出
+   - 提取 TD 中的 Task Breakdown / Implementation Steps / 关键文件列表
+
+2. **分析依赖**: 解析各任务之间的依赖关系
+   - 哪些任务可以并行执行
+   - 哪些任务有严格的先后顺序
+   - 标注每个任务涉及的文件和 crate
+
+3. **生成实现计划**: 基于 TD 的 Task Breakdown 创建 TaskList
+   - 每个任务包含: subject, description（来自 TD）, activeForm
+   - 设置任务依赖关系（blockedBy）
+   - 展示计划给用户确认
+
+4. **逐步实现**: 按依赖顺序执行每个任务
+   - 每个任务开始前: `TaskUpdate` 标记 `in_progress`
+   - 实现代码变更
+   - 每个任务完成后:
+     a. `cargo check --workspace` — 确保编译通过
+     b. `TaskUpdate` 标记 `completed`
+   - 如果遇到编译错误，立即修复再继续
+
+5. **质量验证**: 所有任务完成后
+   - `make fmt` — 格式化
+   - `make lint` — 确保 clippy 通过
+   - `make test` — 确保所有测试通过
+   - 如果有失败，修复后重新验证
+
+6. **结果报告**:
+   - 已完成的任务列表
+   - 新增/修改的文件列表
+   - 测试结果摘要
+   - 下一步提示: 使用 `/ship` 提交
+
+注意:
+- 不要超出 TD 定义的范围
+- 遵循项目的代码风格（见 CLAUDE.md）
+- 新增的 struct/trait 需要派生 `Serialize`/`Deserialize`（如果是公开类型）
+- 错误处理: library crate 用 `thiserror`，application crate 用 `anyhow`
+- 如果 TD 中有模糊之处，优先参考已完成 Spec 的实现模式

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,14 +1,16 @@
-端到端提交流水线。Argument $ARGUMENTS: `[--no-pr] [commit message]`
+端到端提交流水线。Argument $ARGUMENTS: `[--no-pr] [--merge] [commit message]`
 
 用法:
 - `/ship` — lint, test, commit, push, 创建 PR, 等 CI, 报告
 - `/ship "feat: xxx"` — 用指定 commit message
 - `/ship --no-pr` — 只 commit+push, 不创建 PR
 - `/ship --no-pr "feat: xxx"` — 指定 message, 只 commit+push
+- `/ship --merge` — CI 通过后自动 merge PR 并删除远程分支
+- `/ship --merge "feat: xxx"` — 指定 message + 自动 merge
 
 Steps:
 
-1. **解析参数**: 从 `$ARGUMENTS` 中提取 `--no-pr` 标志和 commit message（如有）
+1. **解析参数**: 从 `$ARGUMENTS` 中提取 `--no-pr`、`--merge` 标志和 commit message（如有）
 2. **格式化 + 检查**: Run `make fmt` + `make lint` — 发现 clippy 问题则修复代码并重新检查，直到通过
 3. **测试**: Run `make test` — 发现失败则修复并重新测试，直到通过
 4. **文档同步检查**: 检查改动是否涉及以下文件，如有则提醒同步文档:
@@ -16,11 +18,18 @@ Steps:
    - `crates/server/src/handler/` 或 `lib.rs` 路由变更 → 检查 `docs/reference/api-surface.md`
    - `crates/provider/src/` 新增 executor → 检查 `docs/playbooks/add-provider.md`
    - `crates/translator/src/` 新增翻译器 → 检查 `docs/playbooks/add-translator.md`
-5. **Spec 关联检查**: 检查是否有关联的 Spec — 如有活跃 Spec，确认 status 是否需要更新
-6. **暂存**: `git add` 改动文件（排除 `config.yaml` / `.env` 等敏感文件）
-7. **提交**: 如果参数中指定了 commit message，使用该 message；否则从分支名 + 改动推导（conventional commit 格式: `feat:`/`fix:`/`docs:`/`refactor:`/`test:`/`chore:`）。执行 `git commit`
-8. **推送**: `git push -u origin HEAD`
-9. **创建 PR**（除非 `--no-pr`）:
+5. **Spec 关联检查**: 读取 `docs/specs/_index.md`，如果有关联的 Active Spec:
+   - 检查改动是否完成了 Spec 的全部内容
+   - 如果已完成：自动执行 `/spec advance SPEC-NNN`（Active → Completed），将目录从 `active/` 移动到 `completed/`，更新 `_index.md`
+   - 将 Spec 变更一并加入本次提交
+6. **分支管理**: 如果当前在 `main` 分支:
+   - 从 commit message 推导分支名（如 `feat: add daemon support` → `feature/daemon-support`）
+   - 分支名规则: `feat:` → `feature/`, `fix:` → `fix/`, `docs:` → `docs/`, `refactor:` → `refactor/`, `test:` → `test/`, `chore:` → `chore/`
+   - 自动 `git checkout -b <branch-name>`
+7. **暂存**: `git add` 改动文件（排除 `config.yaml` / `.env` 等敏感文件）
+8. **提交**: 如果参数中指定了 commit message，使用该 message；否则从分支名 + 改动推导（conventional commit 格式: `feat:`/`fix:`/`docs:`/`refactor:`/`test:`/`chore:`）。执行 `git commit`
+9. **推送**: `git push -u origin HEAD`
+10. **创建 PR**（除非 `--no-pr`）:
    a. 从分支名和 commit 历史推导 PR 标题（conventional commit 格式，70 字符内）
    b. 生成 PR body:
       ```
@@ -40,5 +49,6 @@ Steps:
       ```
    c. `gh pr create --title "..." --body "..."`
    d. `gh pr checks --watch` — 等待 CI 完成
-   e. 报告 PR URL 和 CI 结果
-10. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）
+   e. 如果 `--merge` 且 CI 全部通过: `gh pr merge --merge --delete-branch`
+   f. 报告 PR URL 和 CI 结果（及 merge 状态）
+11. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）、merge 状态（如适用）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@ AI Proxy Gateway is a Rust/Axum multi-provider AI API gateway. It routes and tra
 
 | Path | Purpose |
 |------|---------|
-| `crates/core/` | Foundation types, config, errors, provider traits, metrics, glob, proxy, cloaking, payload rules |
+| `crates/core/` | Foundation types, config, errors, provider traits, metrics, glob, proxy, cloaking, payload rules, lifecycle |
 | `crates/core/src/types/` | Provider-specific request/response types (OpenAI, Claude, Gemini) |
 | `crates/provider/` | Provider executors (Claude, OpenAI, Gemini, OpenAICompat), credential routing, SSE parsing |
 | `crates/translator/` | Format translation between provider APIs |
 | `crates/server/` | Axum router, handlers, middleware (auth, logging, request_context), dispatch |
-| `src/` | Binary entry point |
+| `src/` | Binary entry point (subcommand CLI, Application struct, daemon support) |
 | `docs/specs/` | SDD spec registry |
 | `docs/reference/` | SSOT type definitions, API surface, architecture |
 | `docs/playbooks/` | How-to guides (add provider, add translator, etc.) |
@@ -30,14 +30,18 @@ cargo clippy --workspace -- -D warnings  # Lint
 cargo fmt                 # Format code
 cargo fmt --check         # Check formatting
 cargo check --workspace   # Type-check without building
-cargo run -- --config config.yaml  # Run locally
+cargo run -- run --config config.yaml         # Run locally (foreground)
+cargo run -- run --daemon --config config.yaml # Run as daemon
+cargo run -- status                           # Check daemon status
+cargo run -- reload                           # Reload config (SIGHUP)
+cargo run -- stop                             # Graceful shutdown
 ```
 
 ### Make Targets
 
 ```sh
 make build   # cargo build --release
-make dev     # cargo run with config.yaml
+make dev     # cargo run -- run --config config.yaml
 make test    # cargo test --workspace
 make lint    # fmt --check + clippy
 make fmt     # cargo fmt
@@ -161,7 +165,8 @@ Available commands (`.claude/commands/`):
 | Command | Purpose | Example |
 |---------|---------|---------|
 | `/spec` | Spec 生命周期管理（创建/列表/状态/推进/创建 TD） | `/spec create "WebSocket 支持"` |
-| `/ship` | 端到端提交: lint, test, commit, push, 创建 PR, 等 CI | `/ship "feat: add WebSocket support"` |
+| `/implement` | 从 TD 自动实现 Spec | `/implement SPEC-008` |
+| `/ship` | 端到端提交: lint, test, commit, push, 创建 PR, 等 CI | `/ship --merge "feat: add WebSocket support"` |
 | `/deps` | 依赖管理: 列出/合并/修复 Dependabot PRs, cargo update | `/deps merge` |
 | `/review` | Review Pull Request | `/review 42` |
 | `/doc-audit` | 文档与代码一致性审查 | `/doc-audit types` |

--- a/docs/playbooks/coding-agent-workflow.md
+++ b/docs/playbooks/coding-agent-workflow.md
@@ -13,21 +13,29 @@ Development workflow for coding agents (Claude Code, Cursor, etc.) working on th
 
 ### New Features
 
-1. **Create a spec** following the [create-new-spec.md](create-new-spec.md) playbook.
+1. **Create a spec** following the [create-new-spec.md](create-new-spec.md) playbook:
+   ```
+   /spec create "Feature Name"
+   ```
 2. Fill in the PRD (problem, goals, non-goals, user stories).
-3. Fill in the Technical Design (implementation details, API design, task breakdown).
-4. Get the spec reviewed/approved (move status from Draft to Active).
-5. Implement following the technical design.
-6. Run quality checks:
-   ```sh
-   make lint   # cargo fmt --check + cargo clippy -- -D warnings
-   make test   # cargo test --workspace
+3. Create and fill in the Technical Design:
    ```
-7. Move the spec from `active/` to `completed/` and update `_index.md`.
-8. Submit using `/ship`:
+   /spec td SPEC-NNN
    ```
-   /ship "feat: add support for new-provider streaming"
+4. Advance the spec from Draft to Active:
    ```
+   /spec advance SPEC-NNN
+   ```
+5. **Implement** using the `/implement` command (reads TD, generates task list, executes):
+   ```
+   /implement SPEC-NNN
+   ```
+   Or implement manually following the technical design.
+6. **Submit** using `/ship` (auto-advances Active spec to Completed, creates branch, PR, waits CI):
+   ```
+   /ship --merge "feat: add support for new-provider streaming"
+   ```
+   The `--merge` flag auto-merges the PR after CI passes.
 
 ### Bug Fixes
 
@@ -95,11 +103,14 @@ Use `/ship` for all commit and push operations. It handles:
 - Formatting and linting (`make fmt` + `make lint`)
 - Testing (`make test`)
 - Documentation sync checks
-- Spec association checks
+- Spec association checks (auto-advances Active → Completed if applicable)
+- Branch creation (auto-creates from main based on commit message)
 - Commit message generation (conventional commits)
 - Push and PR creation
+- Optional auto-merge after CI (`--merge` flag)
 
 Use `/ship --no-pr` when you only need to commit and push without creating a PR.
+Use `/ship --merge` when you want the PR auto-merged after CI passes.
 
 ## Commit Convention
 


### PR DESCRIPTION
## Summary

- Enhance `/ship` with `--merge` flag, auto-branch creation from main, and auto-advance of active specs
- Add new `/implement` command for automated spec TD implementation
- Update AGENTS.md, CLAUDE.md, and coding-agent-workflow playbook to reflect SPEC-008 daemon architecture

## Changes

**`.claude/commands/`**
- `ship.md`: Added `--merge` flag (auto-merge after CI), auto-branch creation from main (derives branch name from commit type), auto-advance of Active specs to Completed
- `implement.md` (new): 6-step workflow — read TD → analyze deps → generate TaskList → implement → quality verify → report

**Documentation**
- `AGENTS.md`: Added `lifecycle/` module description, `src/` subcommand architecture, daemon management commands, new dependencies (fork, sd-notify, tracing-appender)
- `CLAUDE.md`: Updated cargo run examples for subcommand CLI, key paths for lifecycle/daemon, slash commands table with `/implement`
- `docs/playbooks/coding-agent-workflow.md`: Integrated `/implement` into new feature workflow, documented `--merge` flag and auto-branch behavior

## Spec & Reference Doc Impact

None — tooling and documentation changes only.

## Test Plan

- [x] `make lint` passes
- [x] `make test` passes (37 tests)
- [ ] `/ship --merge` works in next feature implementation
- [ ] `/implement SPEC-NNN` works on next active spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)