### PR TITLE
feat: Dashboard Admin API & WebSocket (SPEC-009)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ test-config.yaml
 config.yaml
 docker-compose.override.yml
 
+# Frontend
+web/node_modules/
+web/dist/
+
 # Claude Code — track settings/commands, ignore transient data
 .claude/*
 !.claude/settings.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,10 +45,12 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "bcrypt",
  "bytes",
  "chrono",
  "fork",
  "futures",
+ "jsonwebtoken",
  "libc",
  "notify",
  "rand 0.10.0",
@@ -100,12 +102,16 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "bcrypt",
  "bytes",
  "chrono",
  "futures",
+ "jsonwebtoken",
  "rand 0.10.0",
  "serde",
  "serde_json",
+ "serde_yml",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tower",
@@ -254,6 +260,7 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -272,8 +279,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -317,6 +326,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bcrypt"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abaf6da45c74385272ddf00e1ac074c7d8a6c1a1dda376902bd6a427522a8b2c"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.3.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +357,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -408,6 +440,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -543,6 +585,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deranged"
@@ -1123,6 +1171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1247,21 @@ checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1349,10 +1421,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1402,6 +1493,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1925,6 +2026,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +2070,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -2220,6 +2344,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2514,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2565,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libc = { workspace = true }
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
-axum = { version = "0.8", features = ["macros"] }
+axum = { version = "0.8", features = ["macros", "ws"] }
 reqwest = { version = "0.13", default-features = false, features = ["stream", "json", "rustls", "socks"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -69,6 +69,8 @@ fork = "0.6"
 sd-notify = "0.4"
 tracing-appender = "0.2"
 libc = "0.2"
+jsonwebtoken = "9"
+bcrypt = "0.17"
 
 # workspace internal
 ai-proxy-core = { path = "crates/core" }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build dev test lint fmt clean check \
        docker-build docker-run docker-stop docker-logs \
-       docker-compose-up docker-compose-down audit
+       docker-compose-up docker-compose-down audit \
+       web-dev web-build web-install
 
 build:
 	cargo build --release
@@ -43,6 +44,16 @@ docker-compose-up:
 
 docker-compose-down:
 	docker compose down
+
+# Web Dashboard
+web-install:
+	cd web && npm install
+
+web-dev:
+	cd web && npm run dev
+
+web-build:
+	cd web && npm run build
 
 # Security
 audit:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,6 +27,17 @@ debug: false
 logging-to-file: false
 # log-dir: "./logs"
 
+# ─── Dashboard ─────────────────────────────────────────────────────────────
+# Web management dashboard (optional).
+# Generate password hash: htpasswd -nbBC 12 "" "your-password" | cut -d: -f2
+# dashboard:
+#   enabled: true
+#   username: "admin"
+#   password-hash: "$2b$12$..."
+#   jwt-secret: "your-jwt-secret-here"     # or set DASHBOARD_JWT_SECRET env var
+#   jwt-ttl-secs: 3600
+#   request-log-capacity: 10000
+
 # ─── Daemon ────────────────────────────────────────────────────────────────
 # daemon:
 #   pid-file: "./ai-proxy.pid"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,5 +33,8 @@ sd-notify = { workspace = true }
 libc = { workspace = true }
 fork = { workspace = true }
 
+jsonwebtoken = { workspace = true }
+bcrypt = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,4 +8,5 @@ pub mod metrics;
 pub mod payload;
 pub mod provider;
 pub mod proxy;
+pub mod request_log;
 pub mod types;

--- a/crates/core/src/request_log.rs
+++ b/crates/core/src/request_log.rs
@@ -1,0 +1,271 @@
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::RwLock;
+use tokio::sync::broadcast;
+
+/// A single request log entry for proxy requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RequestLogEntry {
+    pub timestamp: i64,
+    pub request_id: String,
+    pub method: String,
+    pub path: String,
+    pub status: u16,
+    pub latency_ms: u64,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub error: Option<String>,
+}
+
+/// Query parameters for filtering request logs.
+#[derive(Debug, Default, Deserialize)]
+pub struct LogQuery {
+    pub page: Option<usize>,
+    pub page_size: Option<usize>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub status: Option<String>,
+    pub from: Option<i64>,
+    pub to: Option<i64>,
+}
+
+/// Paged response for log queries.
+#[derive(Debug, Serialize)]
+pub struct LogPage {
+    pub items: Vec<RequestLogEntry>,
+    pub total: usize,
+    pub page: usize,
+    pub page_size: usize,
+}
+
+/// In-memory ring buffer for request logs with broadcast notification.
+pub struct RequestLogStore {
+    entries: RwLock<VecDeque<RequestLogEntry>>,
+    capacity: usize,
+    tx: broadcast::Sender<RequestLogEntry>,
+}
+
+impl RequestLogStore {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(256);
+        Self {
+            entries: RwLock::new(VecDeque::with_capacity(capacity)),
+            capacity,
+            tx,
+        }
+    }
+
+    /// Push a new log entry. Evicts the oldest if at capacity.
+    pub fn push(&self, entry: RequestLogEntry) {
+        let _ = self.tx.send(entry.clone());
+        if let Ok(mut entries) = self.entries.write() {
+            if entries.len() >= self.capacity {
+                entries.pop_front();
+            }
+            entries.push_back(entry);
+        }
+    }
+
+    /// Subscribe to new log entries.
+    pub fn subscribe(&self) -> broadcast::Receiver<RequestLogEntry> {
+        self.tx.subscribe()
+    }
+
+    /// Query logs with filtering and pagination.
+    pub fn query(&self, q: &LogQuery) -> LogPage {
+        let page = q.page.unwrap_or(1).max(1);
+        let page_size = q.page_size.unwrap_or(50).clamp(1, 200);
+
+        let entries = self.entries.read().unwrap();
+        let filtered: Vec<&RequestLogEntry> = entries
+            .iter()
+            .rev() // newest first
+            .filter(|e| {
+                if let Some(ref p) = q.provider
+                    && e.provider.as_deref() != Some(p.as_str())
+                {
+                    return false;
+                }
+                if let Some(ref m) = q.model
+                    && e.model.as_deref() != Some(m.as_str())
+                {
+                    return false;
+                }
+                if let Some(ref s) = q.status {
+                    let matches = match s.as_str() {
+                        "2xx" => (200..300).contains(&e.status),
+                        "4xx" => (400..500).contains(&e.status),
+                        "5xx" => (500..600).contains(&e.status),
+                        other => {
+                            if let Ok(code) = other.parse::<u16>() {
+                                e.status == code
+                            } else {
+                                true
+                            }
+                        }
+                    };
+                    if !matches {
+                        return false;
+                    }
+                }
+                if let Some(from) = q.from
+                    && e.timestamp < from
+                {
+                    return false;
+                }
+                if let Some(to) = q.to
+                    && e.timestamp > to
+                {
+                    return false;
+                }
+                true
+            })
+            .collect();
+
+        let total = filtered.len();
+        let start = (page - 1) * page_size;
+        let items: Vec<RequestLogEntry> = filtered
+            .into_iter()
+            .skip(start)
+            .take(page_size)
+            .cloned()
+            .collect();
+
+        LogPage {
+            items,
+            total,
+            page,
+            page_size,
+        }
+    }
+
+    /// Return summary statistics.
+    pub fn stats(&self) -> serde_json::Value {
+        let entries = self.entries.read().unwrap();
+        let total = entries.len();
+        let errors = entries.iter().filter(|e| e.status >= 400).count();
+        let avg_latency = if total > 0 {
+            entries.iter().map(|e| e.latency_ms).sum::<u64>() / total as u64
+        } else {
+            0
+        };
+        serde_json::json!({
+            "total_entries": total,
+            "capacity": self.capacity,
+            "error_count": errors,
+            "avg_latency_ms": avg_latency,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(status: u16, provider: &str, model: &str) -> RequestLogEntry {
+        RequestLogEntry {
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            request_id: uuid::Uuid::new_v4().to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            status,
+            latency_ms: 100,
+            provider: Some(provider.to_string()),
+            model: Some(model.to_string()),
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+            error: if status >= 400 {
+                Some("error".to_string())
+            } else {
+                None
+            },
+        }
+    }
+
+    #[test]
+    fn test_push_and_query() {
+        let store = RequestLogStore::new(100);
+        for i in 0..10 {
+            let status = if i % 3 == 0 { 500 } else { 200 };
+            store.push(make_entry(status, "openai", "gpt-4"));
+        }
+
+        let page = store.query(&LogQuery::default());
+        assert_eq!(page.total, 10);
+        assert_eq!(page.page, 1);
+    }
+
+    #[test]
+    fn test_capacity_eviction() {
+        let store = RequestLogStore::new(5);
+        for _ in 0..10 {
+            store.push(make_entry(200, "openai", "gpt-4"));
+        }
+        let page = store.query(&LogQuery::default());
+        assert_eq!(page.total, 5);
+    }
+
+    #[test]
+    fn test_filter_by_provider() {
+        let store = RequestLogStore::new(100);
+        store.push(make_entry(200, "openai", "gpt-4"));
+        store.push(make_entry(200, "claude", "claude-3"));
+        store.push(make_entry(200, "openai", "gpt-3.5"));
+
+        let page = store.query(&LogQuery {
+            provider: Some("openai".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(page.total, 2);
+    }
+
+    #[test]
+    fn test_filter_by_status() {
+        let store = RequestLogStore::new(100);
+        store.push(make_entry(200, "openai", "gpt-4"));
+        store.push(make_entry(429, "openai", "gpt-4"));
+        store.push(make_entry(500, "openai", "gpt-4"));
+
+        let page = store.query(&LogQuery {
+            status: Some("4xx".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(page.total, 1);
+
+        let page = store.query(&LogQuery {
+            status: Some("5xx".to_string()),
+            ..Default::default()
+        });
+        assert_eq!(page.total, 1);
+    }
+
+    #[test]
+    fn test_pagination() {
+        let store = RequestLogStore::new(100);
+        for _ in 0..25 {
+            store.push(make_entry(200, "openai", "gpt-4"));
+        }
+
+        let page = store.query(&LogQuery {
+            page: Some(2),
+            page_size: Some(10),
+            ..Default::default()
+        });
+        assert_eq!(page.total, 25);
+        assert_eq!(page.items.len(), 10);
+        assert_eq!(page.page, 2);
+    }
+
+    #[test]
+    fn test_stats() {
+        let store = RequestLogStore::new(100);
+        store.push(make_entry(200, "openai", "gpt-4"));
+        store.push(make_entry(500, "openai", "gpt-4"));
+
+        let stats = store.stats();
+        assert_eq!(stats["total_entries"], 2);
+        assert_eq!(stats["error_count"], 1);
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -23,3 +23,10 @@ async-trait = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 rand = { workspace = true }
+jsonwebtoken = { workspace = true }
+bcrypt = { workspace = true }
+serde_yml = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+tower = { workspace = true }

--- a/crates/server/src/handler/dashboard/auth.rs
+++ b/crates/server/src/handler/dashboard/auth.rs
@@ -1,0 +1,111 @@
+use crate::AppState;
+use crate::middleware::dashboard_auth::{Claims, generate_token};
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+/// POST /api/dashboard/auth/login
+pub async fn login(
+    State(state): State<AppState>,
+    Json(body): Json<LoginRequest>,
+) -> impl IntoResponse {
+    let config = state.config.load();
+    let dashboard = &config.dashboard;
+
+    if !dashboard.enabled {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "not_found", "message": "Dashboard is not enabled"})),
+        );
+    }
+
+    // Verify username
+    if body.username != dashboard.username {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(
+                json!({"error": "invalid_credentials", "message": "Invalid username or password"}),
+            ),
+        );
+    }
+
+    // Verify password against bcrypt hash
+    if dashboard.password_hash.is_empty()
+        || !bcrypt::verify(&body.password, &dashboard.password_hash).unwrap_or(false)
+    {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(
+                json!({"error": "invalid_credentials", "message": "Invalid username or password"}),
+            ),
+        );
+    }
+
+    let secret = match dashboard.resolve_jwt_secret() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "config_error", "message": "JWT secret not configured"})),
+            );
+        }
+    };
+
+    match generate_token(&body.username, &secret, dashboard.jwt_ttl_secs) {
+        Ok(token) => (
+            StatusCode::OK,
+            Json(json!({
+                "token": token,
+                "expires_in": dashboard.jwt_ttl_secs,
+                "token_type": "Bearer",
+            })),
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "token_error", "message": "Failed to generate token"})),
+        ),
+    }
+}
+
+/// POST /api/dashboard/auth/refresh
+pub async fn refresh(
+    State(state): State<AppState>,
+    claims: axum::Extension<Claims>,
+) -> impl IntoResponse {
+    let config = state.config.load();
+    let dashboard = &config.dashboard;
+
+    let secret = match dashboard.resolve_jwt_secret() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "config_error", "message": "JWT secret not configured"})),
+            );
+        }
+    };
+
+    match generate_token(&claims.sub, &secret, dashboard.jwt_ttl_secs) {
+        Ok(token) => (
+            StatusCode::OK,
+            Json(json!({
+                "token": token,
+                "expires_in": dashboard.jwt_ttl_secs,
+                "token_type": "Bearer",
+            })),
+        ),
+        Err(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "token_error", "message": "Failed to generate token"})),
+        ),
+    }
+}

--- a/crates/server/src/handler/dashboard/auth_keys.rs
+++ b/crates/server/src/handler/dashboard/auth_keys.rs
@@ -1,0 +1,83 @@
+use crate::AppState;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+fn mask_key(key: &str) -> String {
+    if key.len() <= 8 {
+        return "****".to_string();
+    }
+    format!("{}****{}", &key[..4], &key[key.len() - 4..])
+}
+
+/// GET /api/dashboard/auth-keys
+pub async fn list_auth_keys(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.config.load();
+    let keys: Vec<serde_json::Value> = config
+        .api_keys
+        .iter()
+        .enumerate()
+        .map(|(i, k)| {
+            json!({
+                "id": i,
+                "key_masked": mask_key(k),
+            })
+        })
+        .collect();
+    (StatusCode::OK, Json(json!({ "auth_keys": keys })))
+}
+
+/// POST /api/dashboard/auth-keys
+pub async fn create_auth_key(State(state): State<AppState>) -> impl IntoResponse {
+    // Generate a secure random key
+    let key = format!(
+        "sk-proxy-{}",
+        uuid::Uuid::new_v4().to_string().replace('-', "")
+    );
+
+    let full_key = key.clone();
+    match super::providers::update_config_file_public(&state, move |config| {
+        config.api_keys.push(key);
+        config.api_keys_set = config.api_keys.iter().cloned().collect();
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(json!({
+                "key": full_key,
+                "message": "API key created. Save this key - it will not be shown again.",
+            })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}
+
+/// DELETE /api/dashboard/auth-keys/:id
+pub async fn delete_auth_key(
+    State(state): State<AppState>,
+    Path(id): Path<usize>,
+) -> impl IntoResponse {
+    match super::providers::update_config_file_public(&state, move |config| {
+        if id < config.api_keys.len() {
+            config.api_keys.remove(id);
+            config.api_keys_set = config.api_keys.iter().cloned().collect();
+        }
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({"message": "API key deleted successfully"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}

--- a/crates/server/src/handler/dashboard/config_ops.rs
+++ b/crates/server/src/handler/dashboard/config_ops.rs
@@ -1,0 +1,87 @@
+use crate::AppState;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+/// POST /api/dashboard/config/validate — dry-run config validation.
+pub async fn validate_config(
+    State(_state): State<AppState>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    // Attempt to deserialize as Config
+    let result: Result<ai_proxy_core::config::Config, _> = serde_json::from_value(body);
+    match result {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(json!({"valid": true, "message": "Configuration is valid"})),
+        ),
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({
+                "valid": false,
+                "error": "validation_failed",
+                "message": e.to_string(),
+            })),
+        ),
+    }
+}
+
+/// POST /api/dashboard/config/reload — trigger hot-reload.
+pub async fn reload_config(State(state): State<AppState>) -> impl IntoResponse {
+    let config_path = match state.config_path.lock() {
+        Ok(path) => path.clone(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "lock_failed", "message": e.to_string()})),
+            );
+        }
+    };
+
+    match ai_proxy_core::config::Config::load(&config_path) {
+        Ok(new_cfg) => {
+            state.credential_router.update_from_config(&new_cfg);
+            state.config.store(std::sync::Arc::new(new_cfg));
+            (
+                StatusCode::OK,
+                Json(json!({"message": "Configuration reloaded successfully"})),
+            )
+        }
+        Err(e) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": "reload_failed", "message": e.to_string()})),
+        ),
+    }
+}
+
+/// GET /api/dashboard/config/current — get full sanitized config.
+pub async fn get_config(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.config.load();
+    let sanitized = json!({
+        "host": config.host,
+        "port": config.port,
+        "tls": { "enable": config.tls.enable },
+        "api_keys_count": config.api_keys.len(),
+        "routing": config.routing,
+        "retry": config.retry,
+        "body_limit_mb": config.body_limit_mb,
+        "streaming": config.streaming,
+        "connect_timeout": config.connect_timeout,
+        "request_timeout": config.request_timeout,
+        "dashboard": {
+            "enabled": config.dashboard.enabled,
+            "username": config.dashboard.username,
+            "jwt_ttl_secs": config.dashboard.jwt_ttl_secs,
+            "request_log_capacity": config.dashboard.request_log_capacity,
+        },
+        "providers": {
+            "claude": config.claude_api_key.len(),
+            "openai": config.openai_api_key.len(),
+            "gemini": config.gemini_api_key.len(),
+            "openai_compat": config.openai_compatibility.len(),
+        },
+    });
+    (StatusCode::OK, Json(sanitized))
+}

--- a/crates/server/src/handler/dashboard/logs.rs
+++ b/crates/server/src/handler/dashboard/logs.rs
@@ -1,0 +1,22 @@
+use crate::AppState;
+use ai_proxy_core::request_log::LogQuery;
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+/// GET /api/dashboard/logs — query request logs with filters.
+pub async fn query_logs(
+    State(state): State<AppState>,
+    Query(query): Query<LogQuery>,
+) -> impl IntoResponse {
+    let page = state.request_logs.query(&query);
+    (StatusCode::OK, Json(json!(page)))
+}
+
+/// GET /api/dashboard/logs/stats — request log statistics.
+pub async fn log_stats(State(state): State<AppState>) -> impl IntoResponse {
+    let stats = state.request_logs.stats();
+    (StatusCode::OK, Json(stats))
+}

--- a/crates/server/src/handler/dashboard/mod.rs
+++ b/crates/server/src/handler/dashboard/mod.rs
@@ -1,0 +1,8 @@
+pub mod auth;
+pub mod auth_keys;
+pub mod config_ops;
+pub mod logs;
+pub mod providers;
+pub mod routing;
+pub mod system;
+pub mod websocket;

--- a/crates/server/src/handler/dashboard/providers.rs
+++ b/crates/server/src/handler/dashboard/providers.rs
@@ -1,0 +1,368 @@
+use crate::AppState;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Serialize)]
+struct ProviderSummary {
+    id: String,
+    provider_type: String,
+    name: Option<String>,
+    api_key_masked: String,
+    base_url: Option<String>,
+    models_count: usize,
+    disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateProviderRequest {
+    pub provider_type: String,
+    pub api_key: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub prefix: Option<String>,
+    #[serde(default)]
+    pub models: Vec<ai_proxy_core::config::ModelMapping>,
+    #[serde(default)]
+    pub excluded_models: Vec<String>,
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProviderRequest {
+    #[serde(default)]
+    pub api_key: Option<String>,
+    #[serde(default)]
+    pub base_url: Option<Option<String>>,
+    #[serde(default)]
+    pub name: Option<Option<String>>,
+    #[serde(default)]
+    pub prefix: Option<Option<String>>,
+    #[serde(default)]
+    pub models: Option<Vec<ai_proxy_core::config::ModelMapping>>,
+    #[serde(default)]
+    pub excluded_models: Option<Vec<String>>,
+    #[serde(default)]
+    pub headers: Option<std::collections::HashMap<String, String>>,
+    #[serde(default)]
+    pub disabled: Option<bool>,
+}
+
+fn mask_key(key: &str) -> String {
+    if key.len() <= 8 {
+        return "****".to_string();
+    }
+    format!("{}****{}", &key[..4], &key[key.len() - 4..])
+}
+
+fn provider_type_to_field(pt: &str) -> Option<&'static str> {
+    match pt {
+        "claude" => Some("claude-api-key"),
+        "openai" => Some("openai-api-key"),
+        "gemini" => Some("gemini-api-key"),
+        "openai-compat" => Some("openai-compatibility"),
+        _ => None,
+    }
+}
+
+fn get_entries_by_type(
+    config: &ai_proxy_core::config::Config,
+    provider_type: &str,
+) -> Vec<ai_proxy_core::config::ProviderKeyEntry> {
+    match provider_type {
+        "claude" => config.claude_api_key.clone(),
+        "openai" => config.openai_api_key.clone(),
+        "gemini" => config.gemini_api_key.clone(),
+        "openai-compat" => config.openai_compatibility.clone(),
+        _ => vec![],
+    }
+}
+
+/// GET /api/dashboard/providers
+pub async fn list_providers(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.config.load();
+    let mut providers = Vec::new();
+
+    let types = [
+        ("claude", &config.claude_api_key),
+        ("openai", &config.openai_api_key),
+        ("gemini", &config.gemini_api_key),
+        ("openai-compat", &config.openai_compatibility),
+    ];
+
+    for (ptype, entries) in &types {
+        for (i, entry) in entries.iter().enumerate() {
+            providers.push(ProviderSummary {
+                id: format!("{}-{}", ptype, i),
+                provider_type: ptype.to_string(),
+                name: entry.name.clone(),
+                api_key_masked: mask_key(&entry.api_key),
+                base_url: entry.base_url.clone(),
+                models_count: entry.models.len(),
+                disabled: entry.disabled,
+            });
+        }
+    }
+
+    (StatusCode::OK, Json(json!({ "providers": providers })))
+}
+
+/// GET /api/dashboard/providers/:id
+pub async fn get_provider(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let config = state.config.load();
+    let (ptype, idx) = match parse_provider_id(&id) {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "not_found", "message": "Provider not found"})),
+            );
+        }
+    };
+
+    let entries = get_entries_by_type(&config, ptype);
+    match entries.get(idx) {
+        Some(entry) => {
+            let detail = json!({
+                "id": id,
+                "provider_type": ptype,
+                "name": entry.name,
+                "api_key_masked": mask_key(&entry.api_key),
+                "base_url": entry.base_url,
+                "prefix": entry.prefix,
+                "models": entry.models,
+                "excluded_models": entry.excluded_models,
+                "headers": entry.headers,
+                "disabled": entry.disabled,
+            });
+            (StatusCode::OK, Json(detail))
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "not_found", "message": "Provider not found"})),
+        ),
+    }
+}
+
+/// POST /api/dashboard/providers
+pub async fn create_provider(
+    State(state): State<AppState>,
+    Json(body): Json<CreateProviderRequest>,
+) -> impl IntoResponse {
+    if provider_type_to_field(&body.provider_type).is_none() {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(
+                json!({"error": "validation_failed", "message": "Invalid provider_type. Must be one of: claude, openai, gemini, openai-compat"}),
+            ),
+        );
+    }
+    if body.api_key.is_empty() {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": "validation_failed", "message": "api_key is required"})),
+        );
+    }
+
+    let new_entry = ai_proxy_core::config::ProviderKeyEntry {
+        api_key: body.api_key,
+        base_url: body.base_url,
+        proxy_url: None,
+        prefix: body.prefix,
+        models: body.models,
+        excluded_models: body.excluded_models,
+        headers: body.headers,
+        disabled: body.disabled,
+        name: body.name,
+        cloak: Default::default(),
+        wire_api: Default::default(),
+    };
+
+    match update_config_file(&state, |config| match body.provider_type.as_str() {
+        "claude" => config.claude_api_key.push(new_entry.clone()),
+        "openai" => config.openai_api_key.push(new_entry.clone()),
+        "gemini" => config.gemini_api_key.push(new_entry.clone()),
+        "openai-compat" => config.openai_compatibility.push(new_entry.clone()),
+        _ => {}
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::CREATED,
+            Json(json!({"message": "Provider created successfully"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}
+
+/// PATCH /api/dashboard/providers/:id
+pub async fn update_provider(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateProviderRequest>,
+) -> impl IntoResponse {
+    let (ptype, idx) = match parse_provider_id(&id) {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "not_found", "message": "Provider not found"})),
+            );
+        }
+    };
+
+    let ptype = ptype.to_string();
+    match update_config_file(&state, move |config| {
+        let entries = match ptype.as_str() {
+            "claude" => &mut config.claude_api_key,
+            "openai" => &mut config.openai_api_key,
+            "gemini" => &mut config.gemini_api_key,
+            "openai-compat" => &mut config.openai_compatibility,
+            _ => return,
+        };
+        if let Some(entry) = entries.get_mut(idx) {
+            if let Some(ref key) = body.api_key {
+                entry.api_key = key.clone();
+            }
+            if let Some(ref url) = body.base_url {
+                entry.base_url = url.clone();
+            }
+            if let Some(ref name) = body.name {
+                entry.name = name.clone();
+            }
+            if let Some(ref prefix) = body.prefix {
+                entry.prefix = prefix.clone();
+            }
+            if let Some(ref models) = body.models {
+                entry.models = models.clone();
+            }
+            if let Some(ref excluded) = body.excluded_models {
+                entry.excluded_models = excluded.clone();
+            }
+            if let Some(ref headers) = body.headers {
+                entry.headers = headers.clone();
+            }
+            if let Some(disabled) = body.disabled {
+                entry.disabled = disabled;
+            }
+        }
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({"message": "Provider updated successfully"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}
+
+/// DELETE /api/dashboard/providers/:id
+pub async fn delete_provider(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    let (ptype, idx) = match parse_provider_id(&id) {
+        Some(v) => v,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "not_found", "message": "Provider not found"})),
+            );
+        }
+    };
+
+    let ptype = ptype.to_string();
+    match update_config_file(&state, move |config| {
+        let entries = match ptype.as_str() {
+            "claude" => &mut config.claude_api_key,
+            "openai" => &mut config.openai_api_key,
+            "gemini" => &mut config.gemini_api_key,
+            "openai-compat" => &mut config.openai_compatibility,
+            _ => return,
+        };
+        if idx < entries.len() {
+            entries.remove(idx);
+        }
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({"message": "Provider deleted successfully"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}
+
+fn parse_provider_id(id: &str) -> Option<(&str, usize)> {
+    let (ptype, idx_str) = id.rsplit_once('-')?;
+    let idx = idx_str.parse::<usize>().ok()?;
+    // Validate provider type
+    if !["claude", "openai", "gemini", "openai-compat"].contains(&ptype) {
+        return None;
+    }
+    Some((ptype, idx))
+}
+
+/// Read current config from file, apply mutation, write back atomically.
+/// Public wrapper for use by sibling modules.
+pub async fn update_config_file_public(
+    state: &AppState,
+    mutate: impl FnOnce(&mut ai_proxy_core::config::Config),
+) -> Result<(), String> {
+    update_config_file(state, mutate).await
+}
+
+async fn update_config_file(
+    state: &AppState,
+    mutate: impl FnOnce(&mut ai_proxy_core::config::Config),
+) -> Result<(), String> {
+    let config_path = state
+        .config_path
+        .lock()
+        .map_err(|e| format!("Failed to lock config path: {e}"))?
+        .clone();
+
+    let contents =
+        std::fs::read_to_string(&config_path).map_err(|e| format!("Failed to read config: {e}"))?;
+    let mut config: ai_proxy_core::config::Config =
+        serde_yml::from_str(&contents).map_err(|e| format!("Failed to parse config: {e}"))?;
+
+    mutate(&mut config);
+
+    let yaml =
+        serde_yml::to_string(&config).map_err(|e| format!("Failed to serialize config: {e}"))?;
+
+    // Atomic write: write to temp file then rename
+    let dir = std::path::Path::new(&config_path)
+        .parent()
+        .unwrap_or(std::path::Path::new("."));
+    let tmp_path = dir.join(".config.yaml.tmp");
+    std::fs::write(&tmp_path, &yaml).map_err(|e| format!("Failed to write temp file: {e}"))?;
+    std::fs::rename(&tmp_path, &config_path)
+        .map_err(|e| format!("Failed to rename config file: {e}"))?;
+
+    Ok(())
+}

--- a/crates/server/src/handler/dashboard/routing.rs
+++ b/crates/server/src/handler/dashboard/routing.rs
@@ -1,0 +1,59 @@
+use crate::AppState;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateRoutingRequest {
+    pub strategy: String,
+}
+
+/// GET /api/dashboard/routing
+pub async fn get_routing(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.config.load();
+    (
+        StatusCode::OK,
+        Json(json!({
+            "strategy": config.routing.strategy,
+            "request_retry": config.request_retry,
+            "max_retry_interval": config.max_retry_interval,
+        })),
+    )
+}
+
+/// PATCH /api/dashboard/routing
+pub async fn update_routing(
+    State(state): State<AppState>,
+    Json(body): Json<UpdateRoutingRequest>,
+) -> impl IntoResponse {
+    let strategy = match body.strategy.as_str() {
+        "round-robin" | "RoundRobin" => ai_proxy_core::config::RoutingStrategy::RoundRobin,
+        "fill-first" | "FillFirst" => ai_proxy_core::config::RoutingStrategy::FillFirst,
+        _ => {
+            return (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(
+                    json!({"error": "validation_failed", "message": "Invalid strategy. Must be 'round-robin' or 'fill-first'"}),
+                ),
+            );
+        }
+    };
+
+    match super::providers::update_config_file_public(&state, move |config| {
+        config.routing.strategy = strategy;
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({"message": "Routing strategy updated successfully"})),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}

--- a/crates/server/src/handler/dashboard/system.rs
+++ b/crates/server/src/handler/dashboard/system.rs
@@ -1,0 +1,135 @@
+use crate::AppState;
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Deserialize;
+use serde_json::json;
+
+/// GET /api/dashboard/system/health
+pub async fn system_health(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.config.load();
+    let uptime_secs = state.start_time.elapsed().as_secs();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "ok",
+            "version": env!("CARGO_PKG_VERSION"),
+            "uptime_secs": uptime_secs,
+            "host": config.host,
+            "port": config.port,
+            "tls_enabled": config.tls.enable,
+            "providers": {
+                "claude": config.claude_api_key.iter().filter(|k| !k.disabled).count(),
+                "openai": config.openai_api_key.iter().filter(|k| !k.disabled).count(),
+                "gemini": config.gemini_api_key.iter().filter(|k| !k.disabled).count(),
+                "openai_compat": config.openai_compatibility.iter().filter(|k| !k.disabled).count(),
+            },
+        })),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LogsQuery {
+    #[serde(default = "default_page")]
+    pub page: usize,
+    #[serde(default = "default_page_size")]
+    pub page_size: usize,
+    pub level: Option<String>,
+    pub search: Option<String>,
+}
+
+fn default_page() -> usize {
+    1
+}
+fn default_page_size() -> usize {
+    100
+}
+
+/// GET /api/dashboard/system/logs
+pub async fn system_logs(
+    State(state): State<AppState>,
+    Query(query): Query<LogsQuery>,
+) -> impl IntoResponse {
+    let config = state.config.load();
+    let log_dir = config.log_dir.as_deref().unwrap_or("./logs");
+
+    let log_path = std::path::Path::new(log_dir);
+    if !log_path.exists() {
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "logs": [],
+                "total": 0,
+                "message": "Log directory not found or logging to file not enabled"
+            })),
+        );
+    }
+
+    // Find the most recent log file
+    let mut log_files: Vec<_> = match std::fs::read_dir(log_path) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|ext| ext == "log" || ext == "json")
+            })
+            .collect(),
+        Err(_) => {
+            return (StatusCode::OK, Json(json!({"logs": [], "total": 0})));
+        }
+    };
+
+    log_files.sort_by_key(|f| std::cmp::Reverse(f.metadata().and_then(|m| m.modified()).ok()));
+
+    let file_path = match log_files.first() {
+        Some(f) => f.path(),
+        None => {
+            return (StatusCode::OK, Json(json!({"logs": [], "total": 0})));
+        }
+    };
+
+    let contents = match std::fs::read_to_string(&file_path) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "read_failed", "message": e.to_string()})),
+            );
+        }
+    };
+
+    let mut lines: Vec<&str> = contents.lines().rev().collect();
+
+    // Filter by level
+    if let Some(ref level) = query.level {
+        let level_upper = level.to_uppercase();
+        lines.retain(|l| l.to_uppercase().contains(&level_upper));
+    }
+
+    // Filter by search
+    if let Some(ref search) = query.search {
+        lines.retain(|l| l.contains(search.as_str()));
+    }
+
+    let total = lines.len();
+    let start = (query.page - 1) * query.page_size;
+    let page_lines: Vec<&str> = lines
+        .into_iter()
+        .skip(start)
+        .take(query.page_size)
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "logs": page_lines,
+            "total": total,
+            "page": query.page,
+            "page_size": query.page_size,
+            "file": file_path.display().to_string(),
+        })),
+    )
+}

--- a/crates/server/src/handler/dashboard/websocket.rs
+++ b/crates/server/src/handler/dashboard/websocket.rs
@@ -1,0 +1,106 @@
+use crate::AppState;
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{Query, State, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+#[derive(Debug, Deserialize)]
+pub struct WsQuery {
+    pub token: Option<String>,
+}
+
+/// GET /ws/dashboard — WebSocket endpoint for real-time updates.
+pub async fn ws_handler(
+    State(state): State<AppState>,
+    Query(query): Query<WsQuery>,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    // Validate JWT from query param
+    let config = state.config.load();
+    if let Some(secret) = config.dashboard.resolve_jwt_secret() {
+        let token = match query.token {
+            Some(t) => t,
+            None => {
+                return (
+                    axum::http::StatusCode::UNAUTHORIZED,
+                    "Missing token query parameter",
+                )
+                    .into_response();
+            }
+        };
+        let key = jsonwebtoken::DecodingKey::from_secret(secret.as_bytes());
+        if jsonwebtoken::decode::<crate::middleware::dashboard_auth::Claims>(
+            &token,
+            &key,
+            &jsonwebtoken::Validation::default(),
+        )
+        .is_err()
+        {
+            return (
+                axum::http::StatusCode::UNAUTHORIZED,
+                "Invalid or expired token",
+            )
+                .into_response();
+        }
+    }
+
+    ws.on_upgrade(move |socket| handle_ws(socket, state))
+}
+
+async fn handle_ws(mut socket: WebSocket, state: AppState) {
+    let mut subscribed_metrics = true;
+    let mut subscribed_logs = true;
+
+    let mut log_rx: broadcast::Receiver<ai_proxy_core::request_log::RequestLogEntry> =
+        state.request_logs.subscribe();
+
+    let mut metrics_interval = tokio::time::interval(Duration::from_secs(1));
+
+    loop {
+        tokio::select! {
+            // Send metrics snapshot every second
+            _ = metrics_interval.tick(), if subscribed_metrics => {
+                let snapshot = state.metrics.snapshot();
+                let msg = json!({
+                    "type": "metrics",
+                    "data": snapshot,
+                });
+                if socket.send(Message::Text(msg.to_string().into())).await.is_err() {
+                    break;
+                }
+            }
+
+            // Forward new log entries
+            Ok(entry) = log_rx.recv(), if subscribed_logs => {
+                let msg = json!({
+                    "type": "request_log",
+                    "data": entry,
+                });
+                if socket.send(Message::Text(msg.to_string().into())).await.is_err() {
+                    break;
+                }
+            }
+
+            // Handle incoming messages (subscribe/unsubscribe)
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Ok(cmd) = serde_json::from_str::<serde_json::Value>(&text)
+                            && cmd.get("type").and_then(|t| t.as_str()) == Some("subscribe")
+                            && let Some(channels) = cmd.get("channels").and_then(|c| c.as_array())
+                        {
+                            let names: Vec<&str> = channels.iter().filter_map(|c| c.as_str()).collect();
+                            subscribed_metrics = names.contains(&"metrics");
+                            subscribed_logs = names.contains(&"request_log");
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/crates/server/src/handler/mod.rs
+++ b/crates/server/src/handler/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod chat_completions;
+pub mod dashboard;
 pub mod health;
 pub mod messages;
 pub mod models;

--- a/crates/server/src/middleware/dashboard_auth.rs
+++ b/crates/server/src/middleware/dashboard_auth.rs
@@ -1,0 +1,101 @@
+use crate::AppState;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{extract::State, http::Request, middleware::Next, response::Response};
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Claims {
+    pub sub: String,
+    pub exp: usize,
+    pub iat: usize,
+}
+
+/// JWT authentication middleware for dashboard endpoints.
+pub async fn dashboard_auth_middleware(
+    State(state): State<AppState>,
+    request: Request<axum::body::Body>,
+    next: Next,
+) -> Result<Response, Response> {
+    let config = state.config.load();
+    let secret = config.dashboard.resolve_jwt_secret().ok_or_else(|| {
+        error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "jwt_not_configured",
+            "Dashboard JWT secret not configured",
+        )
+    })?;
+
+    // Extract token from Authorization: Bearer header or query param
+    let token = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|s| s.to_string())
+        .or_else(|| {
+            request.uri().query().and_then(|q| {
+                q.split('&')
+                    .find_map(|p| p.strip_prefix("token=").map(|t| t.to_string()))
+            })
+        });
+
+    let token = token.ok_or_else(|| {
+        error_response(
+            StatusCode::UNAUTHORIZED,
+            "missing_token",
+            "Authorization header required",
+        )
+    })?;
+
+    let key = DecodingKey::from_secret(secret.as_bytes());
+    let token_data = decode::<Claims>(&token, &key, &Validation::default()).map_err(|e| {
+        let (code, msg) = match e.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                ("token_expired", "Token has expired")
+            }
+            _ => ("invalid_token", "Invalid token"),
+        };
+        error_response(StatusCode::UNAUTHORIZED, code, msg)
+    })?;
+
+    // Inject claims as extension
+    let mut request = request;
+    request.extensions_mut().insert(token_data.claims);
+
+    Ok(next.run(request).await)
+}
+
+/// Generate a JWT token for a user.
+pub fn generate_token(
+    username: &str,
+    secret: &str,
+    ttl_secs: u64,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let now = chrono::Utc::now().timestamp() as usize;
+    let claims = Claims {
+        sub: username.to_string(),
+        iat: now,
+        exp: now + ttl_secs as usize,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+}
+
+fn error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    let body = json!({
+        "error": code,
+        "message": message,
+    });
+    (
+        status,
+        [("content-type", "application/json")],
+        body.to_string(),
+    )
+        .into_response()
+}

--- a/crates/server/src/middleware/mod.rs
+++ b/crates/server/src/middleware/mod.rs
@@ -1,2 +1,3 @@
+pub mod dashboard_auth;
 pub mod request_context;
 pub mod request_logging;

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -1,0 +1,1046 @@
+use ai_proxy_core::config::{Config, DashboardConfig, RoutingStrategy};
+use ai_proxy_core::metrics::Metrics;
+use ai_proxy_core::request_log::RequestLogStore;
+use ai_proxy_provider::build_registry;
+use ai_proxy_provider::routing::CredentialRouter;
+use ai_proxy_server::{AppState, build_router};
+use arc_swap::ArcSwap;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tower::ServiceExt;
+
+// ---------------------------------------------------------------------------
+// Helper: build a test AppState backed by a real temp config file
+// ---------------------------------------------------------------------------
+
+struct TestHarness {
+    state: AppState,
+    _temp_dir: tempfile::TempDir,
+}
+
+fn create_test_harness() -> TestHarness {
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("config.yaml");
+
+    let password_hash = bcrypt::hash("test123", 4).expect("failed to hash password");
+
+    let mut config = Config::default();
+    config.dashboard = DashboardConfig {
+        enabled: true,
+        username: "admin".to_string(),
+        password_hash,
+        jwt_secret: Some("test-secret".to_string()),
+        jwt_ttl_secs: 3600,
+        request_log_capacity: 1000,
+    };
+
+    // Write the config to the temp file so update_config_file can read it back
+    let yaml = serde_yml::to_string(&config).expect("failed to serialize config");
+    std::fs::write(&config_path, &yaml).expect("failed to write config");
+
+    let config_arc = Arc::new(ArcSwap::new(Arc::new(config.clone())));
+    let credential_router = Arc::new(CredentialRouter::new(RoutingStrategy::RoundRobin));
+    credential_router.update_from_config(&config);
+
+    let executors = Arc::new(build_registry(None));
+    let translators = Arc::new(ai_proxy_translator::build_registry());
+    let metrics = Arc::new(Metrics::new());
+    let request_logs = Arc::new(RequestLogStore::new(1000));
+
+    let state = AppState {
+        config: config_arc,
+        router: credential_router.clone(),
+        executors,
+        translators,
+        metrics,
+        request_logs,
+        config_path: Arc::new(Mutex::new(config_path.to_str().unwrap().to_string())),
+        credential_router,
+        start_time: Instant::now(),
+    };
+
+    TestHarness {
+        state,
+        _temp_dir: temp_dir,
+    }
+}
+
+/// Helper: send a request to the router and return (status, body as Value).
+async fn send_request(harness: &TestHarness, request: Request<Body>) -> (StatusCode, Value) {
+    let router = build_router(harness.state.clone());
+    let response = router.oneshot(request).await.expect("request failed");
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read body");
+    let value: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+    (status, value)
+}
+
+/// Helper: login and return a JWT token string.
+async fn login_and_get_token(harness: &TestHarness) -> String {
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/dashboard/auth/login")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"username": "admin", "password": "test123"}).to_string(),
+        ))
+        .unwrap();
+
+    let (status, body) = send_request(harness, req).await;
+    assert_eq!(status, StatusCode::OK, "login failed: {body:?}");
+    body["token"]
+        .as_str()
+        .expect("no token in login response")
+        .to_string()
+}
+
+/// Helper: build a GET request with JWT auth.
+fn authed_get(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// Helper: build a POST request with JWT auth and JSON body.
+fn authed_post(uri: &str, token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+/// Helper: build a PATCH request with JWT auth and JSON body.
+fn authed_patch(uri: &str, token: &str, body: Value) -> Request<Body> {
+    Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+/// Helper: build a DELETE request with JWT auth.
+fn authed_delete(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+// ===========================================================================
+// Auth tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_login_with_valid_credentials() {
+    let harness = create_test_harness();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/dashboard/auth/login")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"username": "admin", "password": "test123"}).to_string(),
+        ))
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["token"].is_string(),
+        "response should contain a JWT token"
+    );
+    assert_eq!(body["token_type"], "Bearer");
+    assert_eq!(body["expires_in"], 3600);
+}
+
+#[tokio::test]
+async fn test_login_with_invalid_password() {
+    let harness = create_test_harness();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/dashboard/auth/login")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"username": "admin", "password": "wrong-password"}).to_string(),
+        ))
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "invalid_credentials");
+}
+
+#[tokio::test]
+async fn test_login_with_invalid_username() {
+    let harness = create_test_harness();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/dashboard/auth/login")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"username": "nobody", "password": "test123"}).to_string(),
+        ))
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "invalid_credentials");
+}
+
+#[tokio::test]
+async fn test_protected_endpoint_without_token() {
+    let harness = create_test_harness();
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/dashboard/providers")
+        .body(Body::empty())
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "missing_token");
+}
+
+#[tokio::test]
+async fn test_protected_endpoint_with_valid_token() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["providers"].is_array());
+}
+
+#[tokio::test]
+async fn test_protected_endpoint_with_invalid_token() {
+    let harness = create_test_harness();
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/dashboard/providers")
+        .header("authorization", "Bearer invalid.jwt.token")
+        .body(Body::empty())
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "invalid_token");
+}
+
+#[tokio::test]
+async fn test_protected_endpoint_with_expired_token() {
+    let harness = create_test_harness();
+
+    // Generate a token that already expired (ttl = 0 means exp == iat, immediately expired)
+    let expired_token = jsonwebtoken::encode(
+        &jsonwebtoken::Header::default(),
+        &serde_json::json!({
+            "sub": "admin",
+            "iat": 1_000_000,
+            "exp": 1_000_001, // far in the past
+        }),
+        &jsonwebtoken::EncodingKey::from_secret(b"test-secret"),
+    )
+    .unwrap();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/dashboard/providers")
+        .header("authorization", format!("Bearer {expired_token}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "token_expired");
+}
+
+#[tokio::test]
+async fn test_login_with_dashboard_disabled() {
+    let harness = create_test_harness();
+
+    // Disable dashboard in config
+    let mut config = (*harness.state.config.load_full()).clone();
+    config.dashboard.enabled = false;
+    harness.state.config.store(Arc::new(config));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/dashboard/auth/login")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({"username": "admin", "password": "test123"}).to_string(),
+        ))
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "not_found");
+}
+
+#[tokio::test]
+async fn test_token_refresh() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_post("/api/dashboard/auth/refresh", &token, json!({}));
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["token"].is_string());
+    assert_eq!(body["token_type"], "Bearer");
+    // The new token should be different from the original
+    let new_token = body["token"].as_str().unwrap();
+    // (Both are valid JWT tokens signed with the same secret, but issued at different times)
+    assert!(new_token.starts_with("ey"));
+}
+
+// ===========================================================================
+// Provider CRUD tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_list_providers_empty() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let providers = body["providers"]
+        .as_array()
+        .expect("providers should be array");
+    assert!(
+        providers.is_empty(),
+        "initially there should be no providers"
+    );
+}
+
+#[tokio::test]
+async fn test_create_provider_and_list() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a provider
+    let create_body = json!({
+        "provider_type": "openai",
+        "api_key": "sk-test-key-1234567890abcdef",
+        "name": "Test OpenAI"
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED, "create failed: {body:?}");
+
+    // Reload config into state so list sees the new provider
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // List providers
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let providers = body["providers"].as_array().unwrap();
+    assert_eq!(providers.len(), 1);
+    assert_eq!(providers[0]["provider_type"], "openai");
+    assert_eq!(providers[0]["name"], "Test OpenAI");
+    assert_eq!(providers[0]["id"], "openai-0");
+    // API key should be masked
+    let masked = providers[0]["api_key_masked"].as_str().unwrap();
+    assert!(masked.contains("****"), "API key should be masked");
+    assert!(
+        !masked.contains("sk-test-key-1234567890abcdef"),
+        "full key should not appear"
+    );
+}
+
+#[tokio::test]
+async fn test_get_provider_by_id() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a provider
+    let create_body = json!({
+        "provider_type": "claude",
+        "api_key": "sk-ant-test-1234567890abcdef",
+        "name": "Test Claude Provider",
+        "base_url": "https://api.anthropic.com"
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Reload config
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // Get the provider by ID
+    let req = authed_get("/api/dashboard/providers/claude-0", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["provider_type"], "claude");
+    assert_eq!(body["name"], "Test Claude Provider");
+    assert_eq!(body["base_url"], "https://api.anthropic.com");
+    // API key should be masked
+    let masked = body["api_key_masked"].as_str().unwrap();
+    assert!(masked.contains("****"));
+}
+
+#[tokio::test]
+async fn test_get_provider_not_found() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/providers/openai-99", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "not_found");
+}
+
+#[tokio::test]
+async fn test_update_provider() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a provider
+    let create_body = json!({
+        "provider_type": "openai",
+        "api_key": "sk-test-key-1234567890abcdef",
+        "name": "Original Name"
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Reload config
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // Update the provider
+    let update_body = json!({
+        "name": "Updated Name",
+        "disabled": true
+    });
+    let req = authed_patch("/api/dashboard/providers/openai-0", &token, update_body);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "update failed: {body:?}");
+
+    // Reload and verify
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    let req = authed_get("/api/dashboard/providers/openai-0", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["name"], "Updated Name");
+    assert_eq!(body["disabled"], true);
+}
+
+#[tokio::test]
+async fn test_delete_provider() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a provider
+    let create_body = json!({
+        "provider_type": "gemini",
+        "api_key": "gemini-test-key-1234567890abcdef",
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Reload config
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // Verify it exists
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["providers"].as_array().unwrap().len(), 1);
+
+    // Delete the provider
+    let req = authed_delete("/api/dashboard/providers/gemini-0", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "delete failed: {body:?}");
+
+    // Reload config and verify deletion
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["providers"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_create_provider_with_empty_api_key() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let create_body = json!({
+        "provider_type": "openai",
+        "api_key": "",
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["error"], "validation_failed");
+}
+
+#[tokio::test]
+async fn test_create_provider_with_invalid_type() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let create_body = json!({
+        "provider_type": "invalid-provider",
+        "api_key": "some-key-that-is-long-enough",
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["error"], "validation_failed");
+}
+
+#[tokio::test]
+async fn test_create_openai_compat_provider() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let create_body = json!({
+        "provider_type": "openai-compat",
+        "api_key": "deepseek-test-key-1234567890abcdef",
+        "base_url": "https://api.deepseek.com/v1",
+        "name": "DeepSeek"
+    });
+    let req = authed_post("/api/dashboard/providers", &token, create_body);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "create openai-compat failed: {body:?}"
+    );
+
+    // Reload and verify
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    let req = authed_get("/api/dashboard/providers/openai-compat-0", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["provider_type"], "openai-compat");
+    assert_eq!(body["name"], "DeepSeek");
+    assert_eq!(body["base_url"], "https://api.deepseek.com/v1");
+}
+
+// ===========================================================================
+// Auth key tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_list_auth_keys_empty() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/auth-keys", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let keys = body["auth_keys"]
+        .as_array()
+        .expect("auth_keys should be array");
+    assert!(keys.is_empty());
+}
+
+#[tokio::test]
+async fn test_create_auth_key() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_post("/api/dashboard/auth-keys", &token, json!({}));
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "create auth key failed: {body:?}"
+    );
+    let key = body["key"]
+        .as_str()
+        .expect("response should contain full key");
+    assert!(
+        key.starts_with("sk-proxy-"),
+        "key should start with sk-proxy-"
+    );
+    assert!(key.len() > 10, "key should be reasonably long");
+}
+
+#[tokio::test]
+async fn test_create_and_list_auth_keys() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a key
+    let req = authed_post("/api/dashboard/auth-keys", &token, json!({}));
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+    let full_key = body["key"].as_str().unwrap().to_string();
+
+    // Reload config into state
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // List keys
+    let req = authed_get("/api/dashboard/auth-keys", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let keys = body["auth_keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 1);
+    // Key should be masked in listing
+    let masked = keys[0]["key_masked"].as_str().unwrap();
+    assert!(masked.contains("****"));
+    assert_ne!(
+        masked, &full_key,
+        "listed key should be masked, not the full key"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_auth_key() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a key
+    let req = authed_post("/api/dashboard/auth-keys", &token, json!({}));
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Reload config
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // Delete the key (id = 0)
+    let req = authed_delete("/api/dashboard/auth-keys/0", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "delete auth key failed: {body:?}");
+
+    // Reload and verify deletion
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    let req = authed_get("/api/dashboard/auth-keys", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["auth_keys"].as_array().unwrap().is_empty());
+}
+
+// ===========================================================================
+// Routing tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_get_routing() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/routing", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    // Default strategy is round-robin
+    assert_eq!(body["strategy"], "round-robin");
+}
+
+#[tokio::test]
+async fn test_update_routing_strategy() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Update to fill-first
+    let req = authed_patch(
+        "/api/dashboard/routing",
+        &token,
+        json!({"strategy": "fill-first"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "update routing failed: {body:?}");
+
+    // Reload config and verify
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    let req = authed_get("/api/dashboard/routing", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["strategy"], "fill-first");
+}
+
+#[tokio::test]
+async fn test_update_routing_round_robin() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Set to fill-first first
+    let req = authed_patch(
+        "/api/dashboard/routing",
+        &token,
+        json!({"strategy": "fill-first"}),
+    );
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Reload
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // Set back to round-robin
+    let req = authed_patch(
+        "/api/dashboard/routing",
+        &token,
+        json!({"strategy": "round-robin"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "update routing failed: {body:?}");
+
+    // Reload and verify
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    let req = authed_get("/api/dashboard/routing", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["strategy"], "round-robin");
+}
+
+#[tokio::test]
+async fn test_update_routing_invalid_strategy() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_patch(
+        "/api/dashboard/routing",
+        &token,
+        json!({"strategy": "random"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["error"], "validation_failed");
+}
+
+// ===========================================================================
+// Request logs tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_query_logs_empty() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/logs", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 0);
+    assert!(body["items"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_log_stats_empty() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/logs/stats", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total_entries"], 0);
+    assert_eq!(body["error_count"], 0);
+    assert_eq!(body["avg_latency_ms"], 0);
+}
+
+#[tokio::test]
+async fn test_log_stats_with_entries() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Push some log entries directly
+    harness
+        .state
+        .request_logs
+        .push(ai_proxy_core::request_log::RequestLogEntry {
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            request_id: "req-1".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            status: 200,
+            latency_ms: 150,
+            provider: Some("openai".to_string()),
+            model: Some("gpt-4".to_string()),
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+            error: None,
+        });
+    harness
+        .state
+        .request_logs
+        .push(ai_proxy_core::request_log::RequestLogEntry {
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            request_id: "req-2".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            status: 500,
+            latency_ms: 50,
+            provider: Some("claude".to_string()),
+            model: Some("claude-3".to_string()),
+            input_tokens: None,
+            output_tokens: None,
+            error: Some("Internal Server Error".to_string()),
+        });
+
+    let req = authed_get("/api/dashboard/logs/stats", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total_entries"], 2);
+    assert_eq!(body["error_count"], 1);
+    assert_eq!(body["capacity"], 1000);
+}
+
+#[tokio::test]
+async fn test_query_logs_with_entries() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Push log entries
+    for i in 0..5 {
+        harness
+            .state
+            .request_logs
+            .push(ai_proxy_core::request_log::RequestLogEntry {
+                timestamp: chrono::Utc::now().timestamp_millis(),
+                request_id: format!("req-{i}"),
+                method: "POST".to_string(),
+                path: "/v1/chat/completions".to_string(),
+                status: if i % 2 == 0 { 200 } else { 429 },
+                latency_ms: 100,
+                provider: Some("openai".to_string()),
+                model: Some("gpt-4".to_string()),
+                input_tokens: Some(10),
+                output_tokens: Some(20),
+                error: if i % 2 != 0 {
+                    Some("rate limited".to_string())
+                } else {
+                    None
+                },
+            });
+    }
+
+    let req = authed_get("/api/dashboard/logs", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["total"], 5);
+    let items = body["items"].as_array().unwrap();
+    assert_eq!(items.len(), 5);
+}
+
+// ===========================================================================
+// System tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_system_health() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/system/health", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert!(body["uptime_secs"].is_number());
+    assert!(body["host"].is_string());
+    assert!(body["port"].is_number());
+    assert!(body["providers"].is_object());
+}
+
+#[tokio::test]
+async fn test_system_logs() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // System logs endpoint reads from log directory -- should handle missing dir gracefully
+    let req = authed_get("/api/dashboard/system/logs", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    // Even with no log directory, should return a valid response
+    assert!(body["logs"].is_array());
+    assert_eq!(body["total"], 0);
+}
+
+// ===========================================================================
+// Config ops tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_get_current_config() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_get("/api/dashboard/config/current", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    // Check sanitized config fields
+    assert!(body["host"].is_string());
+    assert!(body["port"].is_number());
+    assert!(body["dashboard"].is_object());
+    assert_eq!(body["dashboard"]["enabled"], true);
+    assert_eq!(body["dashboard"]["username"], "admin");
+    // Password hash and jwt_secret should not be in the sanitized output
+    assert!(body["dashboard"]["password_hash"].is_null());
+    assert!(body["dashboard"]["jwt_secret"].is_null());
+    // Provider counts
+    assert!(body["providers"].is_object());
+}
+
+#[tokio::test]
+async fn test_reload_config() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_post("/api/dashboard/config/reload", &token, json!({}));
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "reload failed: {body:?}");
+    assert_eq!(body["message"], "Configuration reloaded successfully");
+}
+
+#[tokio::test]
+async fn test_validate_config_valid() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // A minimal valid config as JSON
+    let valid_config = json!({
+        "host": "0.0.0.0",
+        "port": 8080
+    });
+    let req = authed_post("/api/dashboard/config/validate", &token, valid_config);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "validate failed: {body:?}");
+    assert_eq!(body["valid"], true);
+}
+
+#[tokio::test]
+async fn test_validate_config_invalid() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Invalid config: port as string instead of number
+    let invalid_config = json!({
+        "host": "0.0.0.0",
+        "port": "not-a-number"
+    });
+    let req = authed_post("/api/dashboard/config/validate", &token, invalid_config);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["valid"], false);
+    assert_eq!(body["error"], "validation_failed");
+}
+
+// ===========================================================================
+// Token via query parameter tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_protected_endpoint_with_token_query_param() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Access protected endpoint with token as query parameter
+    let uri = format!("/api/dashboard/providers?token={token}");
+    let req = Request::builder()
+        .method("GET")
+        .uri(&uri)
+        .body(Body::empty())
+        .unwrap();
+
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["providers"].is_array());
+}
+
+// ===========================================================================
+// Multiple provider types coexistence test
+// ===========================================================================
+
+#[tokio::test]
+async fn test_multiple_provider_types() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create providers of different types
+    let providers = vec![
+        json!({
+            "provider_type": "openai",
+            "api_key": "sk-openai-test-1234567890abcdef",
+            "name": "OpenAI Prod"
+        }),
+        json!({
+            "provider_type": "claude",
+            "api_key": "sk-ant-claude-test-1234567890abcdef",
+            "name": "Claude Prod"
+        }),
+        json!({
+            "provider_type": "gemini",
+            "api_key": "gemini-key-test-1234567890abcdef",
+            "name": "Gemini Prod"
+        }),
+    ];
+
+    for p in &providers {
+        let req = authed_post("/api/dashboard/providers", &token, p.clone());
+        let (status, body) = send_request(&harness, req).await;
+        assert_eq!(status, StatusCode::CREATED, "create failed: {body:?}");
+
+        // Reload config after each creation so the next write reads current state
+        let config_path = harness.state.config_path.lock().unwrap().clone();
+        let new_config = Config::load(&config_path).expect("failed to reload config");
+        harness.state.config.store(Arc::new(new_config));
+    }
+
+    // List all providers
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    let all_providers = body["providers"].as_array().unwrap();
+    assert_eq!(all_providers.len(), 3);
+
+    // Verify provider IDs
+    let ids: Vec<&str> = all_providers
+        .iter()
+        .map(|p| p["id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&"openai-0"));
+    assert!(ids.contains(&"claude-0"));
+    assert!(ids.contains(&"gemini-0"));
+}

--- a/docs/specs/_index.md
+++ b/docs/specs/_index.md
@@ -19,6 +19,9 @@ All specifications for the AI Proxy Gateway project.
 
 | ID       | Title                                          | Status    | Location                        |
 |----------|------------------------------------------------|-----------|---------------------------------|
+| SPEC-009 | Dashboard Admin API & WebSocket                | Draft     | [active/SPEC-009/](active/SPEC-009/) |
+| SPEC-010 | Web Dashboard - Monitoring                     | Draft     | [active/SPEC-010/](active/SPEC-010/) |
+| SPEC-011 | Web Dashboard - Configuration & Operations     | Draft     | [active/SPEC-011/](active/SPEC-011/) |
 
 ## How to Create a New Spec
 

--- a/docs/specs/active/SPEC-009/prd.md
+++ b/docs/specs/active/SPEC-009/prd.md
@@ -1,0 +1,177 @@
+# PRD: Dashboard Admin API & WebSocket
+
+| Field     | Value                              |
+|-----------|------------------------------------|
+| Spec ID   | SPEC-009                           |
+| Title     | Dashboard Admin API & WebSocket    |
+| Author    | AI Proxy Team                      |
+| Status    | Draft                              |
+| Created   | 2026-02-28                         |
+| Updated   | 2026-02-28                         |
+
+## Problem Statement
+
+AI Proxy Gateway 目前只有面向 AI 客户端的 API 和少量只读 Admin 端点（`/admin/config`、`/admin/metrics`、`/admin/models`）。运维人员无法通过 Web 界面管理 Provider、查看请求日志、修改配置或实时监控系统状态。需要一套完整的后端 Admin API 和 WebSocket 实时推送能力，作为 Web Dashboard 的数据基础。
+
+## Goals
+
+- **Dashboard 认证**: 独立于客户端 API 认证的 Dashboard 登录机制（JWT），保护管理端点
+- **Provider 管理 API**: 对 Provider 配置的 CRUD 操作（列表/新增/编辑/删除 Provider 及其 API Key）
+- **Auth Key 管理 API**: 对客户端 API Key 的 CRUD 操作
+- **路由配置 API**: 查看和修改路由策略（round-robin / fill-first）
+- **请求日志 API**: 存储近期请求日志并提供分页查询、按 Provider/Model/状态码过滤
+- **WebSocket 实时推送**: 实时推送 Metrics 更新和请求日志流
+- **配置校验与热重载触发**: 修改配置前校验合法性，应用后触发热重载
+- **系统运维 API**: 健康状态详情、Daemon 控制（reload/stop）、日志文件查看
+
+## Non-Goals
+
+- 前端 UI 实现（由 SPEC-010 和 SPEC-011 覆盖）
+- OAuth2 / OIDC / SSO 集成
+- 多用户角色权限（RBAC），初期只区分 "已登录 / 未登录"
+- 请求日志的持久化存储（初期使用内存 ring buffer，不引入数据库）
+- Audit log（操作审计日志）
+
+## User Stories
+
+- As an operator, I want to authenticate to the Dashboard API so that management endpoints are protected from unauthorized access.
+- As an operator, I want to list, add, edit, and delete providers via API so that I can manage upstream AI services without editing YAML files.
+- As an operator, I want to manage client API keys via API so that I can grant or revoke access dynamically.
+- As an operator, I want to query recent request logs with filters so that I can troubleshoot issues and understand traffic patterns.
+- As an operator, I want to receive real-time metrics updates via WebSocket so that the Dashboard can show live data without polling.
+- As an operator, I want to validate configuration changes before applying them so that a bad config does not break the proxy.
+- As an operator, I want to trigger config hot-reload from the API so that changes take effect immediately.
+- As an operator, I want to check detailed system health and control the daemon so that I can operate the proxy remotely.
+
+## Success Metrics
+
+- 所有管理端点在未认证时返回 401
+- Provider/Auth Key CRUD 操作正确更新运行时配置并触发热重载
+- 请求日志 ring buffer 支持至少 10,000 条记录，查询延迟 < 50ms
+- WebSocket 连接稳定，Metrics 推送间隔 ≤ 1s
+- 配置校验能拦截常见错误（缺少必填字段、无效 URL、重复 Key）
+
+## Dependencies
+
+- **SPEC-004** (Configuration System & Hot-Reload): 复用 ConfigWatcher 文件监听和热重载回调机制
+- **SPEC-006** (Security & Authentication): 复用现有 CORS permissive 策略，Dashboard 认证与客户端 API 认证并行独立
+- **SPEC-008** (Daemon Support): Daemon 控制 API (reload/stop) 复用现有 CLI 子命令的内部实现
+
+## Constraints
+
+- 所有管理 API 挂载在 `/api/dashboard/` 前缀下，与现有 `/v1/` 和 `/admin/` 路径互不干扰
+- WebSocket 端点挂载在 `/ws/` 前缀下
+- 新建 `dashboard_auth_middleware` (JWT)，与现有 `auth_middleware` (Bearer/x-api-key) 并行，各自保护不同路由组
+- 请求日志使用内存 ring buffer（`VecDeque` + `RwLock`），不引入外部存储依赖
+- CORS 已有 permissive 策略（SPEC-006），无需额外处理
+
+## Configuration Extension
+
+Dashboard 需在 `config.yaml` 新增 `dashboard` section：
+
+```yaml
+dashboard:
+  enabled: true                    # 是否启用 Dashboard API
+  username: "admin"                # 管理员用户名
+  password_hash: "bcrypt:$2b$..." # bcrypt 哈希后的密码
+  jwt_secret: "..."               # JWT 签名密钥（或从环境变量 DASHBOARD_JWT_SECRET 读取）
+  jwt_ttl_secs: 3600              # Token 有效期，默认 1 小时
+  request_log_capacity: 10000     # 请求日志 ring buffer 容量，默认 10000
+```
+
+## Config Write-Back Flow
+
+配置修改通过写回 YAML 文件 + 触发 ConfigWatcher 重载实现：
+
+1. Admin API 接收修改请求（如 `PATCH /api/dashboard/providers/{id}`）
+2. 反序列化当前 config.yaml 为 Config struct
+3. 应用修改并校验新配置的合法性
+4. 使用 atomic write（tempfile + rename）写回 config.yaml，防止部分写入
+5. ConfigWatcher（SPEC-004）检测到文件变更，通过 SHA256 去重后触发热重载回调
+6. 运行时配置通过 `ArcSwap` 原子更新，立即生效
+7. 并发写入采用 last-write-wins 策略（写操作受 `Mutex` 保护防止竞态）
+
+> **注意**: 序列化回写会丢失 YAML 注释和自定义格式。
+
+## Request Log Entry Schema
+
+请求日志只记录代理请求（`/v1/*` 路径），不记录管理端点和健康检查：
+
+```rust
+pub struct RequestLogEntry {
+    pub timestamp: i64,           // Unix timestamp (ms)
+    pub request_id: String,       // 来自 RequestContext
+    pub method: String,           // HTTP method
+    pub path: String,             // 请求路径
+    pub status: u16,              // 响应状态码
+    pub latency_ms: u64,          // 请求耗时
+    pub provider: Option<String>, // 路由到的 Provider
+    pub model: Option<String>,    // 请求的模型
+    pub input_tokens: Option<u64>,  // 输入 token 数
+    pub output_tokens: Option<u64>, // 输出 token 数
+    pub error: Option<String>,    // 错误信息（如有）
+}
+```
+
+> **安全约束**: 不记录请求/响应 body，避免 PII 泄露。
+
+## WebSocket Message Protocol
+
+WebSocket 端点使用 JSON 消息信封格式，单一连接 `/ws/dashboard`：
+
+```json
+// 服务端 → 客户端：Metrics 推送（每秒）
+{
+  "type": "metrics",
+  "data": { /* Metrics::snapshot() 输出 */ }
+}
+
+// 服务端 → 客户端：新请求日志
+{
+  "type": "request_log",
+  "data": { /* RequestLogEntry */ }
+}
+```
+
+客户端通过发送订阅消息控制接收内容：
+
+```json
+// 客户端 → 服务端：订阅控制
+{
+  "type": "subscribe",
+  "channels": ["metrics", "request_log"]
+}
+```
+
+## Error Handling
+
+| 场景 | HTTP Status | 响应 |
+|------|-------------|------|
+| JWT 缺失或无效 | 401 Unauthorized | `{"error": "invalid_token", "message": "..."}` |
+| JWT 过期 | 401 Unauthorized | `{"error": "token_expired", "message": "..."}` |
+| 配置校验失败 | 422 Unprocessable Entity | `{"error": "validation_failed", "fields": [...]}` |
+| Provider 不存在 | 404 Not Found | `{"error": "not_found", "message": "..."}` |
+| 删除使用中的 Provider | 409 Conflict | `{"error": "in_use", "message": "..."}` |
+| Ring buffer 已满 | N/A（自动淘汰最旧记录） | — |
+
+## API Key Masking
+
+Admin API 返回 Provider API Key 时一律脱敏：只返回前 4 位和后 4 位，中间用 `****` 替代。完整 Key 仅在创建时返回一次。客户端 API Key 同理。
+
+## Open Questions
+
+- [ ] Dashboard 认证是否需要支持多用户，还是单一管理员账号即可？
+- [ ] 是否需要支持从环境变量覆盖 dashboard 配置项（如 `DASHBOARD_JWT_SECRET`）？
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| 认证方案 | Session Cookie, JWT, Basic Auth | JWT | 无状态，适合独立前端 SPA，不需要服务端 Session 存储 |
+| 请求日志存储 | 内存 ring buffer, SQLite, 文件 | 内存 ring buffer | 零外部依赖，启动即用，适合初期；未来可扩展到持久化 |
+| 配置修改方式 | 直接修改内存, 写回文件+重载 | 写回文件+重载 | 复用现有 ConfigWatcher 机制，保证配置持久化和一致性 |
+| 配置写入策略 | 直接覆盖, atomic write (tempfile+rename) | atomic write | 防止部分写入导致配置损坏，ConfigWatcher SHA256 去重防止重复重载 |
+| WebSocket 库 | axum 内置 (tokio-tungstenite), warp, actix-ws | axum 内置 | 与现有 Axum 框架一致，无需引入新的 Web 框架 |
+| WebSocket 端点 | 多端点 (/ws/metrics, /ws/logs), 单端点+订阅 | 单端点+订阅 | 减少连接数，客户端按需订阅，扩展性更好 |
+| API 前缀 | `/admin/`, `/api/`, `/api/dashboard/` | `/api/dashboard/` | 避免与现有 `/admin/` 只读端点冲突，语义清晰 |
+| API Key 展示 | 完整返回, 完全隐藏, 脱敏返回 | 脱敏返回 (前4后4) | 平衡安全性和可辨识度 |


### PR DESCRIPTION
## Summary

Implements SPEC-009 — the complete backend API layer for the web dashboard:

- **Dashboard config extension**: `DashboardConfig` struct with JWT secret, bcrypt password hash, and request log capacity
- **JWT authentication middleware**: Bearer token and query param auth for dashboard endpoints
- **Provider management CRUD API**: List, create, get, update, delete with API key masking
- **Auth key management API**: Create (`sk-proxy-` prefix), list (masked), delete
- **Routing configuration API**: Get/update routing strategy
- **Request log ring buffer**: In-memory `VecDeque` + `RwLock` with broadcast channel, query/filter/stats
- **WebSocket real-time push**: `/ws/dashboard` with metrics and request_log subscription channels
- **Config operations API**: Validate (dry-run), hot-reload, get current sanitized config
- **System APIs**: Health details (uptime, version, providers), application log viewer
- **Request logging middleware**: Captures `/v1/*` proxy requests into ring buffer

## Related Issues

Closes #9

Closes #10, closes #11, closes #12, closes #13, closes #14, closes #15, closes #16, closes #17

## Test Plan

- [x] 38 integration tests covering all dashboard endpoints
- [x] 5 unit tests for request log ring buffer (push/query, eviction, filter, pagination, stats)
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes (86 tests total)

> **Stacked PR**: This is PR 1/3. PR 2 (frontend monitoring) and PR 3 (frontend config/ops) depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)