### PR TITLE
chore: remove gitnexus references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 target/
 .DS_Store
 .env
-.gitnexus/
 test-config.yaml
 config.yaml
 docker-compose.override.yml

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.local
+.env
+.env.local
+.env.*.local


### PR DESCRIPTION
## Summary
- Remove `.gitnexus/` entry from root `.gitignore`
- Track `web/.gitignore` for the dashboard frontend

## Changes
- **Root `.gitignore`**: Removed `.gitnexus/` line
- **`web/.gitignore`**: Added standard frontend ignores (node_modules, dist, env files)

## Spec & Reference Doc Impact
None

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (86/86)

🤖 Generated with [Claude Code](https://claude.com/claude-code)