### PR TITLE
chore: retro improvements — auto-TD, stacked PR safety, clippy --tests

### DIFF
--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -14,8 +14,9 @@ Steps:
    - `CLAUDE.md` 和 `AGENTS.md` — 项目约定
 
 2. **收集会话记录**: 读取最近 N 个会话的 transcript
-   - 路径: `~/.claude/projects/<project-hash>/*.jsonl`
+   - 定位路径: `ls -lt ~/.claude/projects/-Users-*/*.jsonl | head -N`（项目目录名是 cwd 路径用 `-` 替换 `/`）
    - 按修改时间倒序取最近 N 个
+   - 大文件 (>5MB) 只读首尾各 2000 行；小文件全量读取
    - 提取关键动作序列（命令调用、工具使用、手动操作）
 
 3. **分析模式**: 对比会话中的实际操作 vs 现有自动化能力，识别:

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -50,8 +50,10 @@ Steps:
    c. `gh pr create --title "..." --body "..."`
    d. `gh pr checks --watch` — 等待 CI 完成
    e. 如果 `--merge` 且 CI 全部通过:
-      - **Stacked PR 安全检查**: 合并前用 `gh pr list --base <branch> --state open --json number` 检查是否有其他 PR 以当前分支为 base
-      - 如果有依赖 PR: 先 `gh pr merge --merge`（不加 `--delete-branch`），然后逐个 `gh pr edit <dep-pr> --base main` 更新依赖 PR 的 base，最后再删除远程分支
+      - **Stacked PR 安全检查**: 合并**前**用 `gh pr list --base <branch> --state open --json number` 检查是否有其他 PR 以当前分支为 base
+      - 如果有依赖 PR:
+        1. **先**逐个 `gh pr edit <dep-pr> --base main` 更新依赖 PR 的 base（**必须在 merge 前完成**，否则 GitHub 会自动关闭依赖 PR）
+        2. 然后 `gh pr merge --merge --delete-branch`
       - 如果没有依赖 PR: `gh pr merge --merge --delete-branch`
    f. 报告 PR URL 和 CI 结果（及 merge 状态）
 11. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）、merge 状态（如适用）

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "make lint && make test && (git diff --cached --name-only | grep -q '^web/' && cd web && npx tsc --noEmit || true)"
+            "command": "make fmt && make lint && make test && (git diff --cached --name-only | grep -q '^web/' && cd web && npx tsc --noEmit || true)"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 .DS_Store
 .env
 test-config.yaml
+config.test.yaml
 config.yaml
 docker-compose.override.yml
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@ AI Proxy Gateway is a Rust/Axum multi-provider AI API gateway. It routes and tra
 
 | Path | Purpose |
 |------|---------|
-| `crates/core/` | Foundation types, config, errors, provider traits, metrics, glob, proxy, cloaking, payload rules, lifecycle |
+| `crates/core/` | Foundation types, config, errors, provider traits, metrics, rate limiting, cost tracking, glob, proxy, cloaking, payload rules, lifecycle |
 | `crates/core/src/types/` | Provider-specific request/response types (OpenAI, Claude, Gemini) |
 | `crates/provider/` | Provider executors (Claude, OpenAI, Gemini, OpenAICompat), credential routing, SSE parsing |
 | `crates/translator/` | Format translation between provider APIs |
-| `crates/server/` | Axum router, handlers, middleware (auth, logging, request_context, dashboard_auth), dispatch |
+| `crates/server/` | Axum router, handlers, middleware (auth, logging, request_context, dashboard_auth, rate_limit), dispatch |
 | `crates/server/src/handler/dashboard/` | Dashboard API handlers (auth, providers, auth_keys, routing, logs, config_ops, system, websocket) |
 | `src/` | Binary entry point (subcommand CLI, Application struct, daemon support) |
 | `web/` | React + TypeScript + Vite dashboard frontend (SPA) |

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 
 lint:
 	cargo fmt --check
-	cargo clippy --workspace -- -D warnings
+	cargo clippy --workspace --tests -- -D warnings
 
 fmt:
 	cargo fmt

--- a/docs/playbooks/coding-agent-workflow.md
+++ b/docs/playbooks/coding-agent-workflow.md
@@ -26,16 +26,26 @@ Development workflow for coding agents (Claude Code, Cursor, etc.) working on th
    ```
    /spec advance SPEC-NNN
    ```
-5. **Implement** using the `/implement` command (reads TD, generates task list, executes):
+5. **Generate GitHub Issues** for tracking (optional but recommended):
+   ```
+   /issues SPEC-NNN
+   ```
+   Creates an Epic issue + sub-task issues from the TD's Task Breakdown.
+6. **Implement** using the `/implement` command (reads TD, creates branch, generates task list, executes):
    ```
    /implement SPEC-NNN
    ```
-   Or implement manually following the technical design.
-6. **Submit** using `/ship` (auto-advances Active spec to Completed, creates branch, PR, waits CI):
+   The `/implement` command will auto-generate a TD if one doesn't exist, create a feature branch, and generate GitHub Issues if they haven't been created yet.
+7. **Submit** using `/ship` (auto-advances Active spec to Completed, creates PR, waits CI):
    ```
    /ship --merge "feat: add support for new-provider streaming"
    ```
    The `--merge` flag auto-merges the PR after CI passes.
+8. **Retrospective** (optional, recommended after multi-spec sessions):
+   ```
+   /retro
+   ```
+   Reviews the session to identify workflow improvements and updates commands/docs.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Summary
- 5-session retrospective analysis identifying 10 workflow improvements
- Enhances `/implement`, `/ship`, `/retro` commands based on actual pain points
- Adds clippy `--tests` flag for test code quality enforcement

## Changes
| # | Type | Description |
|---|------|-------------|
| 1 | AGENTS.md | Document rate_limit, cost modules from SPEC-012/013/014 |
| 2 | /implement | Auto-generate TD if missing, create feature branch, auto-create GitHub Issues |
| 3 | /implement | Create git branch at start (not on main) |
| 4 | .gitignore | Add `config.test.yaml` to prevent git noise |
| 5 | /ship | Fix stacked PR safety: update bases BEFORE merge |
| 6 | CLAUDE.md | Update Key Paths with rate limiting and cost tracking |
| 7 | /retro | Document transcript path resolution |
| 8 | /implement | Auto-invoke /issues if GitHub Issues don't exist |
| 9 | workflow | Add /issues and /retro steps to SDD lifecycle in playbook |
| 10 | Makefile + hook | Add `--tests` to clippy, add `make fmt` to pre-commit |

## Test plan
- [x] `make lint` passes (including `--tests` flag)
- [x] No code changes — only tooling/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)