### PR TITLE
chore: retro improvements — sync docs, ship cleanup

### DIFF
--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -14,7 +14,8 @@ Steps:
    - `CLAUDE.md` 和 `AGENTS.md` — 项目约定
 
 2. **收集会话记录**: 读取最近 N 个会话的 transcript
-   - 定位路径: `ls -lt ~/.claude/projects/-Users-*/*.jsonl | head -N`（项目目录名是 cwd 路径用 `-` 替换 `/`）
+   - **当前会话 (N=1)**: 无需读取 transcript — 你已有完整上下文，直接从记忆中分析
+   - **历史会话 (N>1)**: 定位路径 `ls -lt ~/.claude/projects/-Users-*/*.jsonl | head -N`（项目目录名是 cwd 路径用 `-` 替换 `/`）
    - 按修改时间倒序取最近 N 个
    - 大文件 (>5MB) 只读首尾各 2000 行；小文件全量读取
    - 提取关键动作序列（命令调用、工具使用、手动操作）

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -56,4 +56,7 @@ Steps:
         2. 然后 `gh pr merge --merge --delete-branch`
       - 如果没有依赖 PR: `gh pr merge --merge --delete-branch`
    f. 报告 PR URL 和 CI 结果（及 merge 状态）
-11. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）、merge 状态（如适用）
+11. **本地清理** (仅 `--merge` 且合并成功后):
+    - `git checkout main && git pull origin main`
+    - `git branch -d <branch-name>` — 删除本地已合并的分支
+12. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）、merge 状态（如适用）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ AI Proxy Gateway is a Rust/Axum multi-provider AI API gateway. It routes and tra
 ```sh
 cargo build --release     # Production build
 cargo test --workspace    # Run all tests
-cargo clippy --workspace -- -D warnings  # Lint
+cargo clippy --workspace --tests -- -D warnings  # Lint (includes test code)
 cargo fmt                 # Format code
 cargo fmt --check         # Check formatting
 cargo check --workspace   # Type-check without building
@@ -183,7 +183,7 @@ Available commands (`.claude/commands/`):
 
 ## Quality Gates
 
-Pre-commit hook (`.claude/settings.json`) automatically runs `make lint && make test` before every `git commit`. Push does not trigger hooks -- quality is guaranteed at commit time.
+Pre-commit hook (`.claude/settings.json`) automatically runs `make fmt && make lint && make test` before every `git commit`. Push does not trigger hooks -- quality is guaranteed at commit time. When `web/` files are staged, the hook additionally runs `npx tsc --noEmit` to type-check the frontend.
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary
- Sync CLAUDE.md with actual pre-commit hook configuration
- Add local branch cleanup to /ship --merge workflow
- Optimize /retro for current-session analysis

## Changes
- CLAUDE.md Quality Gates: `make lint && make test` → `make fmt && make lint && make test` + tsc note
- CLAUDE.md Cargo clippy: add `--tests` flag to match Makefile
- /ship: add step 11 — local branch cleanup after merge
- /retro: skip transcript reading when analyzing current session (N=1)

## Test plan
- [x] No code changes — documentation/tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)