### PR TITLE
docs: add Bailian Coding Plan example to config template

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,7 +119,7 @@ gemini-api-key:
     #   - id: "gemini-2.0-flash"
     #   - id: "gemini-2.5-pro-preview-06-05"
 
-# OpenAI-compatible providers (e.g., DeepSeek, Groq, Together AI)
+# OpenAI-compatible providers (e.g., DeepSeek, Groq, Bailian Coding Plan)
 # openai-compatibility:
 #   - api-key: "your-deepseek-key"
 #     base-url: "https://api.deepseek.com"
@@ -127,3 +127,17 @@ gemini-api-key:
 #     models:
 #       - id: "deepseek-chat"
 #       - id: "deepseek-reasoner"
+#
+#   # Alibaba Cloud Bailian Coding Plan (阿里云百炼)
+#   # Docs: https://help.aliyun.com/zh/model-studio/coding-plan-quickstart
+#   # API key format: sk-sp-xxxxx (Coding Plan dedicated, NOT the pay-as-you-go sk-xxxxx)
+#   - api-key: "sk-sp-your-bailian-coding-plan-key"
+#     base-url: "https://coding.dashscope.aliyuncs.com/v1"
+#     prefix: "bailian/"
+#     models:
+#       - id: "qwen3-coder-next"
+#       - id: "qwen3-coder-plus"
+#       - id: "qwen3.5-plus"
+#       - id: "glm-5"
+#       - id: "kimi-k2.5"
+#       - id: "MiniMax-M2.5"


### PR DESCRIPTION
## Summary
- Add Alibaba Cloud Bailian (百炼) Coding Plan configuration example to `config.example.yaml`
- Includes dedicated base URL (`https://coding.dashscope.aliyuncs.com/v1`), API key format notes, and common model list (qwen3-coder-next, qwen3-coder-plus, qwen3.5-plus, glm-5, kimi-k2.5, MiniMax-M2.5)

## Changes
- **config.example.yaml**: Added Bailian Coding Plan entry under `openai-compatibility` section with docs link and key format reminder

## Spec & Reference Doc Impact
None

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (98/98)
- [x] Config is YAML-comment-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)