### PR TITLE
feat: production-grade enhancements — auth keys, circuit breaker, cache, audit, prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "futures",
  "jsonwebtoken",
  "libc",
+ "moka",
  "notify",
  "rand 0.10.0",
  "regex",
@@ -205,6 +206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -518,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +587,15 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -648,6 +678,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1385,6 +1436,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1599,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2175,6 +2258,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tracing-appender = "0.2"
 libc = "0.2"
 jsonwebtoken = "9"
 bcrypt = "0.17"
+moka = { version = "0.12", features = ["future"] }
 
 # workspace internal
 ai-proxy-core = { path = "crates/core" }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,10 +12,23 @@ port: 8317
 #   key: "/path/to/key.pem"
 
 # ─── Client Authentication ──────────────────────────────────────────────────
-# API keys that clients must provide via Bearer token.
+# Structured auth keys with per-key settings.
 # Leave empty to disable authentication (allow all requests).
-api-keys: []
-  # - "your-client-api-key"
+auth-keys: []
+  # - key: "sk-proxy-your-api-key"
+  #   name: "Team Alpha"
+  #   tenant-id: "alpha"
+  #   allowed-models: ["claude-*", "gpt-4o*"]
+  #   rate-limit:
+  #     rpm: 100
+  #     tpm: 1000000
+  #     cost-per-day-usd: 50.0
+  #   budget:
+  #     total-usd: 5000.0
+  #     period: monthly
+  #   expires-at: "2026-12-31T00:00:00Z"
+  #   metadata:
+  #     team: "engineering"
 
 # ─── Global Proxy ───────────────────────────────────────────────────────────
 # Default upstream proxy for all providers. Supports http, https, socks5.
@@ -44,19 +57,51 @@ logging-to-file: false
 #   shutdown-timeout: 30
 
 # ─── Rate Limiting ─────────────────────────────────────────────────────────
-# Protect upstream providers from excessive requests.
+# Multi-dimensional rate limiting: RPM + TPM + Cost.
 # rate-limit:
 #   enabled: true
-#   global-rpm: 60          # Global requests per minute (0 = unlimited)
-#   per-key-rpm: 30         # Per-API-key requests per minute (0 = unlimited)
+#   global-rpm: 60            # Global requests per minute (0 = unlimited)
+#   per-key-rpm: 30           # Per-API-key requests per minute (0 = unlimited)
+#   global-tpm: 0             # Global tokens per minute (0 = unlimited)
+#   per-key-tpm: 0            # Per-API-key tokens per minute (0 = unlimited)
+#   per-key-cost-per-day-usd: 0.0   # Per-key daily cost limit in USD (0 = unlimited)
+
+# ─── Circuit Breaker ──────────────────────────────────────────────────────
+# Three-state circuit breaker for upstream provider credentials.
+# circuit-breaker:
+#   enabled: true
+#   failure-threshold: 5      # Failures before opening
+#   cooldown-secs: 30         # Seconds in open state before half-open
+#   half-open-max-probes: 1   # Requests allowed in half-open state
+#   rolling-window-secs: 60   # Window for counting failures
+
+# ─── Response Cache ───────────────────────────────────────────────────────
+# Exact-match response cache (temperature=0, non-streaming only).
+# cache:
+#   enabled: true
+#   max-entries: 10000
+#   ttl-secs: 3600
+
+# ─── Audit Logging ───────────────────────────────────────────────────────
+# Persistent JSONL audit logs with daily rotation.
+# audit:
+#   enabled: true
+#   dir: "./logs/audit"
+#   retention-days: 30
 
 # ─── Routing Strategy ───────────────────────────────────────────────────────
 routing:
-  strategy: round-robin   # round-robin | fill-first
+  strategy: round-robin   # round-robin | fill-first | latency-aware | geo-aware
+  # ewma-alpha: 0.3        # EWMA smoothing factor for latency-aware routing
+  # default-region: "us"   # Default region for geo-aware routing
 
 # ─── Retry Configuration ────────────────────────────────────────────────────
 request-retry: 3
 max-retry-interval: 30    # seconds
+# retry:
+#   max-retries: 3
+#   max-backoff-secs: 30
+#   jitter-factor: 1.0     # 0.0 = no jitter, 1.0 = full jitter
 
 # ─── Timeout Configuration ─────────────────────────────────────────────────
 connect-timeout: 30       # seconds, TCP connect timeout
@@ -81,7 +126,7 @@ streaming:
 # Each provider supports multiple API keys with optional per-key settings.
 #
 # Per-key options:
-#   api-key:          (required) API key string
+#   api-key:          (required) API key string. Supports env://VAR and file:///path.
 #   base-url:         Custom API endpoint URL
 #   proxy-url:        Per-key proxy (overrides global proxy-url)
 #                     Set to "" for direct connection (bypass global proxy)
@@ -92,11 +137,15 @@ streaming:
 #                     Use this to override User-Agent or add provider-specific
 #                     headers (similar to LiteLLM's extra_headers).
 #   weight:           Routing weight for weighted round-robin (default: 1)
+#   region:           Region tag for geo-aware routing (e.g., "us", "eu", "asia")
 
 claude-api-key:
   - api-key: "sk-ant-your-claude-key"
+    # api-key: "env://CLAUDE_API_KEY"       # Load from environment variable
+    # api-key: "file:///etc/secrets/claude"  # Load from file
     # base-url: "https://api.anthropic.com"
     # proxy-url: "http://proxy:8080"
+    # region: "us"
     # headers:
     #   user-agent: "claude-code/2.1.62"    # Override default User-Agent
     #   anthropic-beta: "max-tokens-3-5-sonnet-2024-07-15"
@@ -108,6 +157,7 @@ claude-api-key:
 openai-api-key:
   - api-key: "sk-your-openai-key"
     # base-url: "https://api.openai.com"
+    # region: "us"
     # models:
     #   - id: "gpt-4o"
     #   - id: "gpt-4o-mini"
@@ -115,6 +165,7 @@ openai-api-key:
 gemini-api-key:
   - api-key: "your-gemini-key"
     # base-url: "https://generativelanguage.googleapis.com"
+    # region: "us"
     # models:
     #   - id: "gemini-2.0-flash"
     #   - id: "gemini-2.5-pro-preview-06-05"
@@ -124,6 +175,7 @@ gemini-api-key:
 #   - api-key: "your-deepseek-key"
 #     base-url: "https://api.deepseek.com"
 #     prefix: "deepseek/"
+#     region: "asia"
 #     models:
 #       - id: "deepseek-chat"
 #       - id: "deepseek-reasoner"
@@ -134,6 +186,7 @@ gemini-api-key:
 #   - api-key: "sk-sp-your-bailian-coding-plan-key"
 #     base-url: "https://coding.dashscope.aliyuncs.com/v1"
 #     prefix: "bailian/"
+#     region: "asia"
 #     models:
 #       - id: "qwen3-coder-next"
 #       - id: "qwen3-coder-plus"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -35,6 +35,7 @@ fork = { workspace = true }
 
 jsonwebtoken = { workspace = true }
 bcrypt = { workspace = true }
+moka = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/core/src/audit.rs
+++ b/crates/core/src/audit.rs
@@ -1,0 +1,223 @@
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::Path;
+use tokio::sync::Mutex;
+
+/// Trait: pluggable audit backend (file/database/remote service etc.).
+#[async_trait]
+pub trait AuditBackend: Send + Sync {
+    async fn write(&self, entry: &AuditEntry);
+    async fn flush(&self);
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuditEntry {
+    pub timestamp: DateTime<Utc>,
+    pub request_id: String,
+    pub method: String,
+    pub path: String,
+    pub status: u16,
+    pub latency_ms: u64,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cost: Option<f64>,
+    pub error: Option<String>,
+    pub api_key_id: Option<String>,
+    pub tenant_id: Option<String>,
+    pub client_ip: Option<String>,
+}
+
+/// Default implementation: JSONL file with daily rotation.
+pub struct FileAuditBackend {
+    config: tokio::sync::RwLock<AuditConfig>,
+    writer: Mutex<Option<std::io::BufWriter<std::fs::File>>>,
+    current_date: Mutex<NaiveDate>,
+}
+
+impl FileAuditBackend {
+    pub fn new(config: AuditConfig) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&config.dir)?;
+        let today = Utc::now().date_naive();
+        let writer = Self::open_writer(&config.dir, today)?;
+        Ok(Self {
+            config: tokio::sync::RwLock::new(config),
+            writer: Mutex::new(Some(writer)),
+            current_date: Mutex::new(today),
+        })
+    }
+
+    fn open_writer(
+        dir: &str,
+        date: NaiveDate,
+    ) -> std::io::Result<std::io::BufWriter<std::fs::File>> {
+        let filename = format!("audit-{}.jsonl", date.format("%Y-%m-%d"));
+        let path = Path::new(dir).join(filename);
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        Ok(std::io::BufWriter::new(file))
+    }
+
+    async fn rotate_if_needed(&self) {
+        let today = Utc::now().date_naive();
+        let mut current = self.current_date.lock().await;
+        if *current != today {
+            let config = self.config.read().await;
+            if let Ok(new_writer) = Self::open_writer(&config.dir, today) {
+                let mut writer = self.writer.lock().await;
+                *writer = Some(new_writer);
+                *current = today;
+            }
+        }
+    }
+
+    /// Spawn a background task that removes old audit files daily.
+    pub fn spawn_cleanup_task(config: AuditConfig) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(86400));
+            loop {
+                interval.tick().await;
+                Self::cleanup_old_files(&config.dir, config.retention_days);
+            }
+        });
+    }
+
+    fn cleanup_old_files(dir: &str, retention_days: u32) {
+        let cutoff = Utc::now().date_naive() - chrono::Duration::days(retention_days as i64);
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if let Some(date_str) = name
+                    .strip_prefix("audit-")
+                    .and_then(|s| s.strip_suffix(".jsonl"))
+                    && let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+                    && date < cutoff
+                {
+                    let _ = std::fs::remove_file(entry.path());
+                    tracing::info!("Removed old audit file: {name}");
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl AuditBackend for FileAuditBackend {
+    async fn write(&self, entry: &AuditEntry) {
+        self.rotate_if_needed().await;
+        if let Ok(json) = serde_json::to_string(entry) {
+            let mut writer = self.writer.lock().await;
+            if let Some(ref mut w) = *writer {
+                let _ = writeln!(w, "{json}");
+            }
+        }
+    }
+
+    async fn flush(&self) {
+        let mut writer = self.writer.lock().await;
+        if let Some(ref mut w) = *writer {
+            let _ = w.flush();
+        }
+    }
+}
+
+/// Noop implementation: zero overhead when audit is disabled.
+pub struct NoopAuditBackend;
+
+#[async_trait]
+impl AuditBackend for NoopAuditBackend {
+    async fn write(&self, _entry: &AuditEntry) {}
+    async fn flush(&self) {}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct AuditConfig {
+    pub enabled: bool,
+    pub dir: String,
+    pub retention_days: u32,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dir: "./logs/audit".to_string(),
+            retention_days: 30,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_noop_backend() {
+        let backend = NoopAuditBackend;
+        let entry = AuditEntry {
+            timestamp: Utc::now(),
+            request_id: "test-123".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            status: 200,
+            latency_ms: 100,
+            provider: Some("openai".to_string()),
+            model: Some("gpt-4".to_string()),
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+            cost: Some(0.001),
+            error: None,
+            api_key_id: None,
+            tenant_id: None,
+            client_ip: None,
+        };
+        backend.write(&entry).await;
+        backend.flush().await;
+    }
+
+    #[tokio::test]
+    async fn test_file_backend_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = AuditConfig {
+            enabled: true,
+            dir: dir.path().to_string_lossy().to_string(),
+            retention_days: 30,
+        };
+        let backend = FileAuditBackend::new(config).unwrap();
+
+        let entry = AuditEntry {
+            timestamp: Utc::now(),
+            request_id: "test-456".to_string(),
+            method: "POST".to_string(),
+            path: "/v1/messages".to_string(),
+            status: 200,
+            latency_ms: 250,
+            provider: Some("claude".to_string()),
+            model: Some("claude-3-opus".to_string()),
+            input_tokens: Some(100),
+            output_tokens: Some(200),
+            cost: Some(0.01),
+            error: None,
+            api_key_id: Some("sk-p****1234".to_string()),
+            tenant_id: Some("alpha".to_string()),
+            client_ip: Some("1.2.3.4".to_string()),
+        };
+        backend.write(&entry).await;
+        backend.flush().await;
+
+        // Check that the file was created
+        let today = Utc::now().date_naive();
+        let filename = format!("audit-{}.jsonl", today.format("%Y-%m-%d"));
+        let path = dir.path().join(filename);
+        assert!(path.exists());
+
+        let content = std::fs::read_to_string(path).unwrap();
+        assert!(content.contains("test-456"));
+    }
+}

--- a/crates/core/src/auth_key.rs
+++ b/crates/core/src/auth_key.rs
@@ -1,0 +1,236 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthKeyEntry {
+    pub key: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    #[serde(default)]
+    pub allowed_models: Vec<String>,
+    #[serde(default)]
+    pub rate_limit: Option<KeyRateLimitConfig>,
+    #[serde(default)]
+    pub budget: Option<BudgetConfig>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct KeyRateLimitConfig {
+    pub rpm: Option<u32>,
+    pub tpm: Option<u64>,
+    pub cost_per_day_usd: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BudgetConfig {
+    pub total_usd: f64,
+    pub period: BudgetPeriod,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BudgetPeriod {
+    Daily,
+    Monthly,
+}
+
+/// Runtime fast-lookup index for auth keys.
+#[derive(Debug, Clone)]
+pub struct AuthKeyStore {
+    entries: Vec<AuthKeyEntry>,
+    by_key: HashMap<String, usize>,
+}
+
+impl AuthKeyStore {
+    pub fn new(entries: Vec<AuthKeyEntry>) -> Self {
+        let by_key = entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.key.clone(), i))
+            .collect();
+        Self { entries, by_key }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// O(1) lookup by key string.
+    pub fn lookup(&self, key: &str) -> Option<&AuthKeyEntry> {
+        self.by_key.get(key).map(|&i| &self.entries[i])
+    }
+
+    /// Check if an auth key entry has expired.
+    pub fn is_expired(entry: &AuthKeyEntry) -> bool {
+        if let Some(expires_at) = entry.expires_at {
+            Utc::now() > expires_at
+        } else {
+            false
+        }
+    }
+
+    /// Check if the entry grants access to the given model (glob patterns).
+    pub fn check_model_access(entry: &AuthKeyEntry, model: &str) -> bool {
+        if entry.allowed_models.is_empty() {
+            return true;
+        }
+        entry
+            .allowed_models
+            .iter()
+            .any(|pattern| crate::glob::glob_match(pattern, model))
+    }
+
+    /// Replace entries from a new config reload.
+    pub fn update_from_config(&mut self, entries: Vec<AuthKeyEntry>) {
+        self.by_key = entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.key.clone(), i))
+            .collect();
+        self.entries = entries;
+    }
+
+    pub fn entries(&self) -> &[AuthKeyEntry] {
+        &self.entries
+    }
+
+    /// Mask a key for display: show first 4 + last 4 chars.
+    pub fn mask_key(key: &str) -> String {
+        if key.len() <= 8 {
+            return "****".to_string();
+        }
+        format!("{}****{}", &key[..4], &key[key.len() - 4..])
+    }
+}
+
+impl Default for AuthKeyStore {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_key_store_lookup() {
+        let entries = vec![
+            AuthKeyEntry {
+                key: "sk-proxy-abc123".to_string(),
+                name: Some("Team Alpha".to_string()),
+                tenant_id: Some("alpha".to_string()),
+                allowed_models: vec!["claude-*".to_string(), "gpt-4o*".to_string()],
+                rate_limit: None,
+                budget: None,
+                expires_at: None,
+                metadata: HashMap::new(),
+            },
+            AuthKeyEntry {
+                key: "sk-proxy-def456".to_string(),
+                name: Some("Team Beta".to_string()),
+                tenant_id: Some("beta".to_string()),
+                allowed_models: vec![],
+                rate_limit: None,
+                budget: None,
+                expires_at: None,
+                metadata: HashMap::new(),
+            },
+        ];
+        let store = AuthKeyStore::new(entries);
+
+        assert!(store.lookup("sk-proxy-abc123").is_some());
+        assert!(store.lookup("sk-proxy-def456").is_some());
+        assert!(store.lookup("sk-proxy-nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_model_access_check() {
+        let entry = AuthKeyEntry {
+            key: "sk-proxy-test".to_string(),
+            name: None,
+            tenant_id: None,
+            allowed_models: vec!["claude-*".to_string(), "gpt-4o".to_string()],
+            rate_limit: None,
+            budget: None,
+            expires_at: None,
+            metadata: HashMap::new(),
+        };
+        assert!(AuthKeyStore::check_model_access(&entry, "claude-3-opus"));
+        assert!(AuthKeyStore::check_model_access(&entry, "gpt-4o"));
+        assert!(!AuthKeyStore::check_model_access(&entry, "gpt-3.5-turbo"));
+    }
+
+    #[test]
+    fn test_empty_allowed_models_allows_all() {
+        let entry = AuthKeyEntry {
+            key: "sk-proxy-test".to_string(),
+            name: None,
+            tenant_id: None,
+            allowed_models: vec![],
+            rate_limit: None,
+            budget: None,
+            expires_at: None,
+            metadata: HashMap::new(),
+        };
+        assert!(AuthKeyStore::check_model_access(&entry, "anything"));
+    }
+
+    #[test]
+    fn test_mask_key() {
+        assert_eq!(
+            AuthKeyStore::mask_key("sk-proxy-abc123def456"),
+            "sk-p****f456"
+        );
+        assert_eq!(AuthKeyStore::mask_key("short"), "****");
+    }
+
+    #[test]
+    fn test_is_expired() {
+        let not_expired = AuthKeyEntry {
+            key: "k".to_string(),
+            name: None,
+            tenant_id: None,
+            allowed_models: vec![],
+            rate_limit: None,
+            budget: None,
+            expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
+            metadata: HashMap::new(),
+        };
+        assert!(!AuthKeyStore::is_expired(&not_expired));
+
+        let expired = AuthKeyEntry {
+            key: "k".to_string(),
+            name: None,
+            tenant_id: None,
+            allowed_models: vec![],
+            rate_limit: None,
+            budget: None,
+            expires_at: Some(Utc::now() - chrono::Duration::hours(1)),
+            metadata: HashMap::new(),
+        };
+        assert!(AuthKeyStore::is_expired(&expired));
+
+        let no_expiry = AuthKeyEntry {
+            key: "k".to_string(),
+            name: None,
+            tenant_id: None,
+            allowed_models: vec![],
+            rate_limit: None,
+            budget: None,
+            expires_at: None,
+            metadata: HashMap::new(),
+        };
+        assert!(!AuthKeyStore::is_expired(&no_expiry));
+    }
+}

--- a/crates/core/src/cache.rs
+++ b/crates/core/src/cache.rs
@@ -1,0 +1,244 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+/// Trait: pluggable cache backend (exact/semantic/Redis etc.).
+#[async_trait]
+pub trait ResponseCacheBackend: Send + Sync {
+    async fn get(&self, key: &CacheKey) -> Option<CachedResponse>;
+    async fn insert(&self, key: CacheKey, response: CachedResponse);
+    async fn invalidate(&self, key: &CacheKey);
+    async fn clear(&self);
+    fn stats(&self) -> CacheStats;
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct CacheKey([u8; 32]);
+
+#[derive(Clone)]
+pub struct CachedResponse {
+    pub payload: Bytes,
+    pub provider: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub entries: u64,
+    pub hit_rate: f64,
+}
+
+impl CacheKey {
+    /// Build a cache key from model name and request body.
+    /// Returns None for non-cacheable requests (streaming, non-zero temperature).
+    pub fn build(model: &str, body: &serde_json::Value) -> Option<Self> {
+        // Don't cache streaming requests
+        if body
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            return None;
+        }
+
+        // Don't cache when temperature is non-zero
+        if let Some(temp) = body.get("temperature").and_then(|v| v.as_f64())
+            && temp != 0.0
+        {
+            return None;
+        }
+
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(model.as_bytes());
+
+        // Canonicalize relevant fields
+        let fields = [
+            "messages",
+            "temperature",
+            "top_p",
+            "max_tokens",
+            "tools",
+            "response_format",
+        ];
+        for field in &fields {
+            if let Some(val) = body.get(*field) {
+                hasher.update(field.as_bytes());
+                hasher.update(val.to_string().as_bytes());
+            }
+        }
+
+        let hash: [u8; 32] = hasher.finalize().into();
+        Some(CacheKey(hash))
+    }
+}
+
+/// Default implementation: Moka LRU cache.
+pub struct MokaCache {
+    inner: moka::future::Cache<CacheKey, CachedResponse>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl MokaCache {
+    pub fn new(config: &CacheConfig) -> Self {
+        let cache = moka::future::Cache::builder()
+            .max_capacity(config.max_entries)
+            .time_to_live(Duration::from_secs(config.ttl_secs))
+            .build();
+        Self {
+            inner: cache,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl ResponseCacheBackend for MokaCache {
+    async fn get(&self, key: &CacheKey) -> Option<CachedResponse> {
+        match self.inner.get(key).await {
+            Some(resp) => {
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                Some(resp)
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    async fn insert(&self, key: CacheKey, response: CachedResponse) {
+        self.inner.insert(key, response).await;
+    }
+
+    async fn invalidate(&self, key: &CacheKey) {
+        self.inner.invalidate(key).await;
+    }
+
+    async fn clear(&self) {
+        self.inner.invalidate_all();
+    }
+
+    fn stats(&self) -> CacheStats {
+        let hits = self.hits.load(Ordering::Relaxed);
+        let misses = self.misses.load(Ordering::Relaxed);
+        let total = hits + misses;
+        CacheStats {
+            hits,
+            misses,
+            entries: self.inner.entry_count(),
+            hit_rate: if total > 0 {
+                hits as f64 / total as f64
+            } else {
+                0.0
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CacheConfig {
+    pub enabled: bool,
+    pub max_entries: u64,
+    pub ttl_secs: u64,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_entries: 10_000,
+            ttl_secs: 3600,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_key_deterministic() {
+        let body = serde_json::json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 0,
+            "stream": false,
+        });
+        let k1 = CacheKey::build("gpt-4", &body);
+        let k2 = CacheKey::build("gpt-4", &body);
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn test_cache_key_different_models() {
+        let body = serde_json::json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 0,
+        });
+        let k1 = CacheKey::build("gpt-4", &body);
+        let k2 = CacheKey::build("gpt-3.5", &body);
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_cache_key_none_for_stream() {
+        let body = serde_json::json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": true,
+        });
+        assert!(CacheKey::build("gpt-4", &body).is_none());
+    }
+
+    #[test]
+    fn test_cache_key_none_for_nonzero_temperature() {
+        let body = serde_json::json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 0.7,
+        });
+        assert!(CacheKey::build("gpt-4", &body).is_none());
+    }
+
+    #[test]
+    fn test_cache_key_allows_zero_temperature() {
+        let body = serde_json::json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "temperature": 0.0,
+        });
+        assert!(CacheKey::build("gpt-4", &body).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_moka_cache_basic() {
+        let config = CacheConfig {
+            enabled: true,
+            max_entries: 100,
+            ttl_secs: 3600,
+        };
+        let cache = MokaCache::new(&config);
+
+        let key = CacheKey([0u8; 32]);
+        let response = CachedResponse {
+            payload: Bytes::from("test"),
+            provider: "openai".to_string(),
+            model: "gpt-4".to_string(),
+            input_tokens: 10,
+            output_tokens: 20,
+        };
+
+        assert!(cache.get(&key).await.is_none());
+        assert_eq!(cache.stats().misses, 1);
+
+        cache.insert(key.clone(), response).await;
+        let cached = cache.get(&key).await;
+        assert!(cached.is_some());
+        assert_eq!(cache.stats().hits, 1);
+    }
+}

--- a/crates/core/src/circuit_breaker.rs
+++ b/crates/core/src/circuit_breaker.rs
@@ -1,0 +1,276 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Trait: pluggable circuit breaker policy.
+pub trait CircuitBreakerPolicy: Send + Sync {
+    fn can_execute(&self) -> bool;
+    fn record_success(&self);
+    fn record_failure(&self);
+    fn state(&self) -> CircuitState;
+    fn reset(&self);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+struct CircuitStateInner {
+    state: CircuitState,
+    failure_count: u32,
+    last_failure: Option<Instant>,
+    opened_at: Option<Instant>,
+    half_open_probes: u32,
+}
+
+/// Default implementation: three-state circuit breaker (Closed → Open → HalfOpen → Closed).
+pub struct ThreeStateCircuitBreaker {
+    inner: Mutex<CircuitStateInner>,
+    config: CircuitBreakerConfig,
+}
+
+impl ThreeStateCircuitBreaker {
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            inner: Mutex::new(CircuitStateInner {
+                state: CircuitState::Closed,
+                failure_count: 0,
+                last_failure: None,
+                opened_at: None,
+                half_open_probes: 0,
+            }),
+            config,
+        }
+    }
+}
+
+impl CircuitBreakerPolicy for ThreeStateCircuitBreaker {
+    fn can_execute(&self) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        match inner.state {
+            CircuitState::Closed => true,
+            CircuitState::Open => {
+                if let Some(opened_at) = inner.opened_at {
+                    if opened_at.elapsed().as_secs() >= self.config.cooldown_secs {
+                        inner.state = CircuitState::HalfOpen;
+                        inner.half_open_probes = 0;
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            CircuitState::HalfOpen => inner.half_open_probes < self.config.half_open_max_probes,
+        }
+    }
+
+    fn record_success(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        match inner.state {
+            CircuitState::HalfOpen => {
+                // Recovery confirmed — close the circuit
+                inner.state = CircuitState::Closed;
+                inner.failure_count = 0;
+                inner.last_failure = None;
+                inner.opened_at = None;
+                inner.half_open_probes = 0;
+            }
+            CircuitState::Closed => {
+                inner.failure_count = inner.failure_count.saturating_sub(1);
+            }
+            CircuitState::Open => {}
+        }
+    }
+
+    fn record_failure(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        let now = Instant::now();
+        match inner.state {
+            CircuitState::Closed => {
+                // Expire old failures outside the rolling window
+                if let Some(last) = inner.last_failure
+                    && last.elapsed().as_secs() > self.config.rolling_window_secs
+                {
+                    inner.failure_count = 0;
+                }
+                inner.failure_count += 1;
+                inner.last_failure = Some(now);
+                if inner.failure_count >= self.config.failure_threshold {
+                    inner.state = CircuitState::Open;
+                    inner.opened_at = Some(now);
+                }
+            }
+            CircuitState::HalfOpen => {
+                // Probe failed — re-open the circuit
+                inner.state = CircuitState::Open;
+                inner.opened_at = Some(now);
+                inner.half_open_probes = 0;
+            }
+            CircuitState::Open => {}
+        }
+    }
+
+    fn state(&self) -> CircuitState {
+        self.inner.lock().unwrap().state
+    }
+
+    fn reset(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.state = CircuitState::Closed;
+        inner.failure_count = 0;
+        inner.last_failure = None;
+        inner.opened_at = None;
+        inner.half_open_probes = 0;
+    }
+}
+
+/// Noop implementation — always allows execution. Used when circuit breaking is disabled.
+pub struct NoopCircuitBreaker;
+
+impl CircuitBreakerPolicy for NoopCircuitBreaker {
+    fn can_execute(&self) -> bool {
+        true
+    }
+    fn record_success(&self) {}
+    fn record_failure(&self) {}
+    fn state(&self) -> CircuitState {
+        CircuitState::Closed
+    }
+    fn reset(&self) {}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CircuitBreakerConfig {
+    pub enabled: bool,
+    pub failure_threshold: u32,
+    pub cooldown_secs: u64,
+    pub half_open_max_probes: u32,
+    pub rolling_window_secs: u64,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            failure_threshold: 5,
+            cooldown_secs: 30,
+            half_open_max_probes: 1,
+            rolling_window_secs: 60,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_closed_allows_execution() {
+        let cb = ThreeStateCircuitBreaker::new(CircuitBreakerConfig::default());
+        assert!(cb.can_execute());
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_opens_after_threshold_failures() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 3,
+            ..Default::default()
+        };
+        let cb = ThreeStateCircuitBreaker::new(config);
+
+        cb.record_failure();
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+        assert!(!cb.can_execute());
+    }
+
+    #[test]
+    fn test_success_decrements_failure_count() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 3,
+            ..Default::default()
+        };
+        let cb = ThreeStateCircuitBreaker::new(config);
+
+        cb.record_failure();
+        cb.record_failure();
+        cb.record_success();
+        // failure_count should be 1 now, one more failure shouldn't open
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_noop_always_allows() {
+        let cb = NoopCircuitBreaker;
+        assert!(cb.can_execute());
+        cb.record_failure();
+        assert!(cb.can_execute());
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_reset_returns_to_closed() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            ..Default::default()
+        };
+        let cb = ThreeStateCircuitBreaker::new(config);
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        cb.reset();
+        assert_eq!(cb.state(), CircuitState::Closed);
+        assert!(cb.can_execute());
+    }
+
+    #[test]
+    fn test_half_open_success_closes() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            cooldown_secs: 0, // Instant cooldown for testing
+            half_open_max_probes: 1,
+            ..Default::default()
+        };
+        let cb = ThreeStateCircuitBreaker::new(config);
+
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+
+        // Cooldown elapsed (0 seconds), should transition to HalfOpen
+        assert!(cb.can_execute());
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        cb.record_success();
+        assert_eq!(cb.state(), CircuitState::Closed);
+    }
+
+    #[test]
+    fn test_half_open_failure_reopens() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            cooldown_secs: 0,
+            half_open_max_probes: 1,
+            ..Default::default()
+        };
+        let cb = ThreeStateCircuitBreaker::new(config);
+
+        cb.record_failure();
+        assert!(cb.can_execute()); // transitions to half-open
+        assert_eq!(cb.state(), CircuitState::HalfOpen);
+
+        cb.record_failure();
+        assert_eq!(cb.state(), CircuitState::Open);
+    }
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,9 +1,13 @@
+use crate::audit::AuditConfig;
+use crate::auth_key::{AuthKeyEntry, AuthKeyStore};
+use crate::cache::CacheConfig;
+use crate::circuit_breaker::CircuitBreakerConfig;
 use crate::payload::PayloadConfig;
 use arc_swap::ArcSwap;
 use notify::{RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,10 +22,10 @@ pub struct Config {
     pub port: u16,
     pub tls: TlsConfig,
 
-    // Client auth
-    pub api_keys: Vec<String>,
+    // Client auth — structured auth keys
+    pub auth_keys: Vec<AuthKeyEntry>,
     #[serde(skip)]
-    pub api_keys_set: HashSet<String>,
+    pub auth_key_store: AuthKeyStore,
 
     // Global proxy
     pub proxy_url: Option<String>,
@@ -62,7 +66,6 @@ pub struct Config {
     pub force_model_prefix: bool,
 
     // Non-stream keepalive interval in seconds (0 = disabled).
-    // When enabled, sends periodic whitespace to prevent intermediate proxy timeouts.
     pub non_stream_keepalive_secs: u64,
 
     // Cost tracking: custom model price overrides (USD per 1M tokens).
@@ -70,6 +73,15 @@ pub struct Config {
 
     // Rate limiting
     pub rate_limit: RateLimitConfig,
+
+    // Circuit breaker
+    pub circuit_breaker: CircuitBreakerConfig,
+
+    // Response cache
+    pub cache: CacheConfig,
+
+    // Audit logging
+    pub audit: AuditConfig,
 
     // Dashboard
     pub dashboard: DashboardConfig,
@@ -90,8 +102,8 @@ impl Default for Config {
             host: "0.0.0.0".to_string(),
             port: 8317,
             tls: TlsConfig::default(),
-            api_keys: Vec::new(),
-            api_keys_set: HashSet::new(),
+            auth_keys: Vec::new(),
+            auth_key_store: AuthKeyStore::default(),
             proxy_url: None,
             debug: false,
             logging_to_file: false,
@@ -111,6 +123,9 @@ impl Default for Config {
             non_stream_keepalive_secs: 0,
             model_prices: HashMap::new(),
             rate_limit: RateLimitConfig::default(),
+            circuit_breaker: CircuitBreakerConfig::default(),
+            cache: CacheConfig::default(),
+            audit: AuditConfig::default(),
             dashboard: DashboardConfig::default(),
             daemon: DaemonConfig::default(),
             claude_api_key: Vec::new(),
@@ -155,8 +170,14 @@ impl Config {
         sanitize_entries(&mut self.gemini_api_key);
         sanitize_entries(&mut self.openai_compatibility);
 
-        // Build HashSet for O(1) API key lookups
-        self.api_keys_set = self.api_keys.iter().cloned().collect();
+        // Resolve secrets in provider API keys
+        resolve_provider_secrets(&mut self.claude_api_key);
+        resolve_provider_secrets(&mut self.openai_api_key);
+        resolve_provider_secrets(&mut self.gemini_api_key);
+        resolve_provider_secrets(&mut self.openai_compatibility);
+
+        // Build AuthKeyStore for O(1) auth key lookups
+        self.auth_key_store = AuthKeyStore::new(self.auth_keys.clone());
     }
 
     /// Returns an iterator over all provider key entries.
@@ -169,13 +190,22 @@ impl Config {
     }
 }
 
+/// Resolve env:// and file:// secrets in provider API keys.
+fn resolve_provider_secrets(entries: &mut [ProviderKeyEntry]) {
+    for entry in entries.iter_mut() {
+        if let Ok(resolved) = crate::secret::resolve(&entry.api_key) {
+            entry.api_key = resolved;
+        }
+    }
+}
+
 /// Remove entries with empty api_key, deduplicate, normalize base_url.
 fn sanitize_entries(entries: &mut Vec<ProviderKeyEntry>) {
     // Remove entries with empty API keys
     entries.retain(|e| !e.api_key.is_empty());
 
     // Deduplicate by api_key
-    let mut seen = HashSet::new();
+    let mut seen = std::collections::HashSet::new();
     entries.retain(|e| seen.insert(e.api_key.clone()));
 
     // Normalize entries
@@ -198,7 +228,7 @@ fn sanitize_entries(entries: &mut Vec<ProviderKeyEntry>) {
 
 // ─── Rate limit config ─────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct RateLimitConfig {
     /// Enable rate limiting.
@@ -207,6 +237,25 @@ pub struct RateLimitConfig {
     pub global_rpm: u32,
     /// Per-API-key requests per minute limit (0 = unlimited).
     pub per_key_rpm: u32,
+    /// Global tokens per minute limit (0 = unlimited).
+    pub global_tpm: u64,
+    /// Per-API-key tokens per minute limit (0 = unlimited).
+    pub per_key_tpm: u64,
+    /// Per-API-key cost per day in USD (0.0 = unlimited).
+    pub per_key_cost_per_day_usd: f64,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            global_rpm: 0,
+            per_key_rpm: 0,
+            global_tpm: 0,
+            per_key_tpm: 0,
+            per_key_cost_per_day_usd: 0.0,
+        }
+    }
 }
 
 // ─── Dashboard config ──────────────────────────────────────────────────────
@@ -285,6 +334,10 @@ pub struct TlsConfig {
 pub struct RoutingConfig {
     pub strategy: RoutingStrategy,
     pub fallback_enabled: bool,
+    /// EWMA smoothing factor for latency-aware routing (0.0-1.0, default 0.3).
+    pub ewma_alpha: f64,
+    /// Default region for geo-aware routing.
+    pub default_region: Option<String>,
 }
 
 impl Default for RoutingConfig {
@@ -292,6 +345,8 @@ impl Default for RoutingConfig {
         Self {
             strategy: RoutingStrategy::RoundRobin,
             fallback_enabled: true,
+            ewma_alpha: 0.3,
+            default_region: None,
         }
     }
 }
@@ -301,6 +356,8 @@ impl Default for RoutingConfig {
 pub enum RoutingStrategy {
     RoundRobin,
     FillFirst,
+    LatencyAware,
+    GeoAware,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -328,6 +385,8 @@ pub struct RetryConfig {
     pub cooldown_429_secs: u64,
     pub cooldown_5xx_secs: u64,
     pub cooldown_network_secs: u64,
+    /// Jitter factor for retry backoff (0.0 = no jitter, 1.0 = full jitter).
+    pub jitter_factor: f64,
 }
 
 impl Default for RetryConfig {
@@ -338,6 +397,7 @@ impl Default for RetryConfig {
             cooldown_429_secs: 60,
             cooldown_5xx_secs: 15,
             cooldown_network_secs: 10,
+            jitter_factor: 1.0,
         }
     }
 }
@@ -383,6 +443,9 @@ pub struct ProviderKeyEntry {
     /// Weight for weighted round-robin routing (default: 1, range 1-100).
     #[serde(default = "default_weight")]
     pub weight: u32,
+    /// Region identifier for geo-aware routing.
+    #[serde(default)]
+    pub region: Option<String>,
 }
 
 fn default_weight() -> u32 {
@@ -482,6 +545,9 @@ mod tests {
         assert_eq!(cfg.retry.cooldown_429_secs, 60);
         assert_eq!(cfg.retry.cooldown_5xx_secs, 15);
         assert_eq!(cfg.retry.cooldown_network_secs, 10);
+        assert!(!cfg.cache.enabled);
+        assert!(!cfg.audit.enabled);
+        assert!(cfg.circuit_breaker.enabled);
     }
 
     #[test]
@@ -500,6 +566,7 @@ mod tests {
                 cloak: Default::default(),
                 wire_api: crate::provider::WireApi::default(),
                 weight: 1,
+                region: None,
             },
             ProviderKeyEntry {
                 api_key: "".into(),
@@ -514,6 +581,7 @@ mod tests {
                 cloak: Default::default(),
                 wire_api: crate::provider::WireApi::default(),
                 weight: 1,
+                region: None,
             },
             ProviderKeyEntry {
                 api_key: "key1".into(), // duplicate
@@ -528,6 +596,7 @@ mod tests {
                 cloak: Default::default(),
                 wire_api: crate::provider::WireApi::default(),
                 weight: 1,
+                region: None,
             },
         ];
         sanitize_entries(&mut entries);
@@ -544,8 +613,11 @@ mod tests {
         let yaml = r#"
 host: "127.0.0.1"
 port: 9000
-api-keys:
-  - "test-key"
+auth-keys:
+  - key: "test-key"
+    name: "Test"
+    tenant-id: "t1"
+    allowed-models: ["claude-*"]
 routing:
   strategy: fill-first
 claude-api-key:
@@ -558,7 +630,9 @@ claude-api-key:
         let config: Config = serde_yml::from_str(yaml).unwrap();
         assert_eq!(config.host, "127.0.0.1");
         assert_eq!(config.port, 9000);
-        assert_eq!(config.api_keys, vec!["test-key"]);
+        assert_eq!(config.auth_keys.len(), 1);
+        assert_eq!(config.auth_keys[0].key, "test-key");
+        assert_eq!(config.auth_keys[0].tenant_id.as_deref(), Some("t1"));
         assert_eq!(config.routing.strategy, RoutingStrategy::FillFirst);
         assert_eq!(config.claude_api_key.len(), 1);
         assert_eq!(config.claude_api_key[0].models.len(), 1);
@@ -587,5 +661,34 @@ daemon:
         let config2: Config = serde_yml::from_str(&serialized).unwrap();
         assert_eq!(config2.daemon.pid_file, "/run/ai-proxy.pid");
         assert_eq!(config2.daemon.shutdown_timeout, 60);
+    }
+
+    #[test]
+    fn test_rate_limit_config_new_fields() {
+        let yaml = r#"
+rate-limit:
+  enabled: true
+  global-rpm: 100
+  per-key-rpm: 50
+  global-tpm: 1000000
+  per-key-tpm: 500000
+  per-key-cost-per-day-usd: 10.0
+"#;
+        let config: Config = serde_yml::from_str(yaml).unwrap();
+        assert!(config.rate_limit.enabled);
+        assert_eq!(config.rate_limit.global_tpm, 1_000_000);
+        assert_eq!(config.rate_limit.per_key_tpm, 500_000);
+        assert_eq!(config.rate_limit.per_key_cost_per_day_usd, 10.0);
+    }
+
+    #[test]
+    fn test_routing_strategy_variants() {
+        let yaml = r#"routing: { strategy: latency-aware }"#;
+        let config: Config = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.routing.strategy, RoutingStrategy::LatencyAware);
+
+        let yaml = r#"routing: { strategy: geo-aware }"#;
+        let config: Config = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(config.routing.strategy, RoutingStrategy::GeoAware);
     }
 }

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -1,3 +1,4 @@
+use crate::auth_key::AuthKeyEntry;
 use std::time::Instant;
 
 /// Per-request context carrying metadata for logging, metrics, and audit.
@@ -10,6 +11,14 @@ pub struct RequestContext {
     pub start_time: Instant,
     /// Client IP address, if available.
     pub client_ip: Option<String>,
+    /// Masked API key (first 4 + last 4 chars).
+    pub api_key_id: Option<String>,
+    /// Tenant ID from auth key entry.
+    pub tenant_id: Option<String>,
+    /// Full auth key entry (for model ACL, rate limits, etc.).
+    pub auth_key: Option<AuthKeyEntry>,
+    /// Client region from X-Client-Region / CDN headers.
+    pub client_region: Option<String>,
 }
 
 impl RequestContext {
@@ -18,6 +27,10 @@ impl RequestContext {
             request_id: uuid::Uuid::new_v4().to_string(),
             start_time: Instant::now(),
             client_ip,
+            api_key_id: None,
+            tenant_id: None,
+            auth_key: None,
+            client_region: None,
         }
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -40,6 +40,12 @@ pub enum ProxyError {
     #[error("rate limit exceeded: {0}")]
     RateLimited(String),
 
+    #[error("model access denied: {0}")]
+    ModelNotAllowed(String),
+
+    #[error("API key expired")]
+    KeyExpired,
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -48,7 +54,8 @@ impl ProxyError {
     pub fn status_code(&self) -> StatusCode {
         match self {
             Self::Config(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::Auth(_) => StatusCode::UNAUTHORIZED,
+            Self::Auth(_) | Self::KeyExpired => StatusCode::UNAUTHORIZED,
+            Self::ModelNotAllowed(_) => StatusCode::FORBIDDEN,
             Self::NoCredentials { .. } => StatusCode::SERVICE_UNAVAILABLE,
             Self::ModelCooldown { .. } | Self::RateLimited(_) => StatusCode::TOO_MANY_REQUESTS,
             Self::Upstream { status, .. } => {
@@ -63,7 +70,8 @@ impl ProxyError {
 
     fn error_type(&self) -> &str {
         match self {
-            Self::Auth(_) => "authentication_error",
+            Self::Auth(_) | Self::KeyExpired => "authentication_error",
+            Self::ModelNotAllowed(_) => "permission_error",
             Self::NoCredentials { .. } => "insufficient_quota",
             Self::ModelCooldown { .. } | Self::RateLimited(_) => "rate_limit_error",
             Self::BadRequest(_) => "invalid_request_error",
@@ -75,7 +83,8 @@ impl ProxyError {
 
     fn error_code(&self) -> &str {
         match self {
-            Self::Auth(_) => "invalid_api_key",
+            Self::Auth(_) | Self::KeyExpired => "invalid_api_key",
+            Self::ModelNotAllowed(_) => "model_not_allowed",
             Self::NoCredentials { .. } => "insufficient_quota",
             Self::ModelCooldown { .. } | Self::RateLimited(_) => "rate_limit_exceeded",
             Self::ModelNotFound(_) => "model_not_found",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod audit;
+pub mod auth_key;
+pub mod cache;
+pub mod circuit_breaker;
 pub mod cloak;
 pub mod config;
 pub mod context;
@@ -7,8 +11,10 @@ pub mod glob;
 pub mod lifecycle;
 pub mod metrics;
 pub mod payload;
+pub mod prometheus;
 pub mod provider;
 pub mod proxy;
 pub mod rate_limit;
 pub mod request_log;
+pub mod secret;
 pub mod types;

--- a/crates/core/src/metrics.rs
+++ b/crates/core/src/metrics.rs
@@ -22,6 +22,17 @@ pub struct Metrics {
     pub latency_buckets: [AtomicU64; 6],
     /// Total latency sum in ms (for computing average).
     total_latency_ms: AtomicU64,
+    /// TTFT histogram buckets (ms): <50, <100, <500, <1000, <5000, >=5000.
+    ttft_buckets: [AtomicU64; 6],
+    /// Per-tenant request counts.
+    tenant_request_counts: RwLock<HashMap<String, AtomicU64>>,
+    /// Per-tenant token counts (input + output).
+    tenant_token_counts: RwLock<HashMap<String, AtomicU64>>,
+    /// Per-tenant cost tracking (micro-USD).
+    tenant_cost_micro: RwLock<HashMap<String, AtomicU64>>,
+    /// Cache hit/miss counters.
+    pub cache_hits: AtomicU64,
+    pub cache_misses: AtomicU64,
     /// When the metrics instance was created (for uptime).
     created_at: Instant,
 }
@@ -46,6 +57,19 @@ impl Metrics {
                 AtomicU64::new(0),
             ],
             total_latency_ms: AtomicU64::new(0),
+            ttft_buckets: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+            tenant_request_counts: RwLock::new(HashMap::new()),
+            tenant_token_counts: RwLock::new(HashMap::new()),
+            tenant_cost_micro: RwLock::new(HashMap::new()),
+            cache_hits: AtomicU64::new(0),
+            cache_misses: AtomicU64::new(0),
             created_at: Instant::now(),
         }
     }
@@ -88,6 +112,99 @@ impl Metrics {
         if let Ok(mut costs) = self.model_costs.lock() {
             *costs.entry(model.to_string()).or_insert(0.0) += cost;
         }
+    }
+
+    /// Record Time-To-First-Token in milliseconds.
+    pub fn record_ttft_ms(&self, ms: u64) {
+        let bucket = match ms {
+            0..=49 => 0,
+            50..=99 => 1,
+            100..=499 => 2,
+            500..=999 => 3,
+            1000..=4999 => 4,
+            _ => 5,
+        };
+        self.ttft_buckets[bucket].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record per-tenant request.
+    pub fn record_tenant_request(&self, tenant_id: &str) {
+        increment_map(&self.tenant_request_counts, tenant_id);
+    }
+
+    /// Record per-tenant tokens.
+    pub fn record_tenant_tokens(&self, tenant_id: &str, tokens: u64) {
+        increment_map_by(&self.tenant_token_counts, tenant_id, tokens);
+    }
+
+    /// Record per-tenant cost.
+    pub fn record_tenant_cost(&self, tenant_id: &str, cost: f64) {
+        let micro = (cost * 1_000_000.0) as u64;
+        increment_map_by(&self.tenant_cost_micro, tenant_id, micro);
+    }
+
+    /// Record a cache hit.
+    pub fn record_cache_hit(&self) {
+        self.cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a cache miss.
+    pub fn record_cache_miss(&self) {
+        self.cache_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Raw latency bucket values for Prometheus rendering.
+    pub fn latency_bucket_values(&self) -> [u64; 6] {
+        [
+            self.latency_buckets[0].load(Ordering::Relaxed),
+            self.latency_buckets[1].load(Ordering::Relaxed),
+            self.latency_buckets[2].load(Ordering::Relaxed),
+            self.latency_buckets[3].load(Ordering::Relaxed),
+            self.latency_buckets[4].load(Ordering::Relaxed),
+            self.latency_buckets[5].load(Ordering::Relaxed),
+        ]
+    }
+
+    /// Raw TTFT bucket values for Prometheus rendering.
+    pub fn ttft_bucket_values(&self) -> [u64; 6] {
+        [
+            self.ttft_buckets[0].load(Ordering::Relaxed),
+            self.ttft_buckets[1].load(Ordering::Relaxed),
+            self.ttft_buckets[2].load(Ordering::Relaxed),
+            self.ttft_buckets[3].load(Ordering::Relaxed),
+            self.ttft_buckets[4].load(Ordering::Relaxed),
+            self.ttft_buckets[5].load(Ordering::Relaxed),
+        ]
+    }
+
+    /// Per-tenant metrics snapshot.
+    pub fn tenant_snapshot(&self) -> serde_json::Value {
+        let mut tenants = serde_json::Map::new();
+        if let Ok(req_counts) = self.tenant_request_counts.read() {
+            for (tenant, count) in req_counts.iter() {
+                let tokens = self
+                    .tenant_token_counts
+                    .read()
+                    .ok()
+                    .and_then(|m| m.get(tenant).map(|v| v.load(Ordering::Relaxed)))
+                    .unwrap_or(0);
+                let cost_micro = self
+                    .tenant_cost_micro
+                    .read()
+                    .ok()
+                    .and_then(|m| m.get(tenant).map(|v| v.load(Ordering::Relaxed)))
+                    .unwrap_or(0);
+                tenants.insert(
+                    tenant.clone(),
+                    serde_json::json!({
+                        "requests": count.load(Ordering::Relaxed),
+                        "tokens": tokens,
+                        "cost_usd": cost_micro as f64 / 1_000_000.0,
+                    }),
+                );
+            }
+        }
+        serde_json::Value::Object(tenants)
     }
 
     /// Snapshot current metrics as a JSON-serializable value.
@@ -147,9 +264,22 @@ impl Metrics {
                 "5000-29999": self.latency_buckets[4].load(Ordering::Relaxed),
                 ">=30000": self.latency_buckets[5].load(Ordering::Relaxed),
             },
+            "ttft_ms": {
+                "<50": self.ttft_buckets[0].load(Ordering::Relaxed),
+                "50-99": self.ttft_buckets[1].load(Ordering::Relaxed),
+                "100-499": self.ttft_buckets[2].load(Ordering::Relaxed),
+                "500-999": self.ttft_buckets[3].load(Ordering::Relaxed),
+                "1000-4999": self.ttft_buckets[4].load(Ordering::Relaxed),
+                ">=5000": self.ttft_buckets[5].load(Ordering::Relaxed),
+            },
+            "cache": {
+                "hits": self.cache_hits.load(Ordering::Relaxed),
+                "misses": self.cache_misses.load(Ordering::Relaxed),
+            },
             "by_model": model_counts,
             "by_provider": provider_counts,
             "cost_by_model": model_costs,
+            "by_tenant": self.tenant_snapshot(),
             // Computed fields for dashboard frontend
             "total_tokens": total_tokens,
             "active_providers": active_providers,
@@ -180,6 +310,25 @@ fn increment_map(map: &RwLock<HashMap<String, AtomicU64>>, key: &str) {
         m.entry(key.to_string())
             .or_insert_with(|| AtomicU64::new(0))
             .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn increment_map_by(map: &RwLock<HashMap<String, AtomicU64>>, key: &str, amount: u64) {
+    if amount == 0 {
+        return;
+    }
+    // Fast path: read lock
+    if let Ok(m) = map.read()
+        && let Some(counter) = m.get(key)
+    {
+        counter.fetch_add(amount, Ordering::Relaxed);
+        return;
+    }
+    // Slow path: write lock to insert
+    if let Ok(mut m) = map.write() {
+        m.entry(key.to_string())
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(amount, Ordering::Relaxed);
     }
 }
 
@@ -220,5 +369,51 @@ mod tests {
         assert_eq!(snap["latency_ms"]["<100"], 1);
         assert_eq!(snap["latency_ms"]["100-499"], 1);
         assert_eq!(snap["latency_ms"]["5000-29999"], 1);
+    }
+
+    #[test]
+    fn test_ttft_recording() {
+        let m = Metrics::new();
+        m.record_ttft_ms(30);
+        m.record_ttft_ms(80);
+        m.record_ttft_ms(200);
+        m.record_ttft_ms(800);
+        m.record_ttft_ms(2000);
+        m.record_ttft_ms(10000);
+
+        let snap = m.snapshot();
+        assert_eq!(snap["ttft_ms"]["<50"], 1);
+        assert_eq!(snap["ttft_ms"]["50-99"], 1);
+        assert_eq!(snap["ttft_ms"]["100-499"], 1);
+        assert_eq!(snap["ttft_ms"]["500-999"], 1);
+        assert_eq!(snap["ttft_ms"]["1000-4999"], 1);
+        assert_eq!(snap["ttft_ms"][">=5000"], 1);
+    }
+
+    #[test]
+    fn test_tenant_metrics() {
+        let m = Metrics::new();
+        m.record_tenant_request("alpha");
+        m.record_tenant_request("alpha");
+        m.record_tenant_request("beta");
+        m.record_tenant_tokens("alpha", 1000);
+        m.record_tenant_cost("alpha", 0.05);
+
+        let snap = m.snapshot();
+        assert_eq!(snap["by_tenant"]["alpha"]["requests"], 2);
+        assert_eq!(snap["by_tenant"]["alpha"]["tokens"], 1000);
+        assert_eq!(snap["by_tenant"]["beta"]["requests"], 1);
+    }
+
+    #[test]
+    fn test_cache_counters() {
+        let m = Metrics::new();
+        m.record_cache_hit();
+        m.record_cache_hit();
+        m.record_cache_miss();
+
+        let snap = m.snapshot();
+        assert_eq!(snap["cache"]["hits"], 2);
+        assert_eq!(snap["cache"]["misses"], 1);
     }
 }

--- a/crates/core/src/prometheus.rs
+++ b/crates/core/src/prometheus.rs
@@ -1,0 +1,216 @@
+use crate::cache::CacheStats;
+use crate::metrics::Metrics;
+use std::fmt::Write;
+
+/// Write a Prometheus counter line.
+fn write_counter(out: &mut String, name: &str, labels: &str, value: u64) {
+    if labels.is_empty() {
+        let _ = writeln!(out, "{name} {value}");
+    } else {
+        let _ = writeln!(out, "{name}{{{labels}}} {value}");
+    }
+}
+
+/// Write a Prometheus gauge line.
+fn write_gauge(out: &mut String, name: &str, labels: &str, value: f64) {
+    if labels.is_empty() {
+        let _ = writeln!(out, "{name} {value}");
+    } else {
+        let _ = writeln!(out, "{name}{{{labels}}} {value}");
+    }
+}
+
+/// Write a Prometheus histogram bucket line.
+fn write_histogram_bucket(out: &mut String, name: &str, le: &str, count: u64) {
+    let _ = writeln!(out, "{name}_bucket{{le=\"{le}\"}} {count}");
+}
+
+/// Render all metrics in Prometheus text exposition format.
+pub fn render_metrics(
+    metrics: &Metrics,
+    cache_stats: Option<&CacheStats>,
+    circuit_breaker_states: &[(String, bool)],
+) -> String {
+    let mut out = String::with_capacity(4096);
+    let snap = metrics.snapshot();
+
+    // ── ai_proxy_requests_total ──
+    let _ = writeln!(
+        out,
+        "# HELP ai_proxy_requests_total Total number of requests."
+    );
+    let _ = writeln!(out, "# TYPE ai_proxy_requests_total counter");
+    if let Some(by_model) = snap["by_model"].as_object() {
+        for (model, count) in by_model {
+            if let Some(c) = count.as_u64() {
+                write_counter(
+                    &mut out,
+                    "ai_proxy_requests_total",
+                    &format!("model=\"{model}\""),
+                    c,
+                );
+            }
+        }
+    }
+    if let Some(by_provider) = snap["by_provider"].as_object() {
+        for (provider, count) in by_provider {
+            if let Some(c) = count.as_u64() {
+                write_counter(
+                    &mut out,
+                    "ai_proxy_requests_total",
+                    &format!("provider=\"{provider}\""),
+                    c,
+                );
+            }
+        }
+    }
+
+    // ── ai_proxy_errors_total ──
+    let _ = writeln!(out, "# HELP ai_proxy_errors_total Total number of errors.");
+    let _ = writeln!(out, "# TYPE ai_proxy_errors_total counter");
+    write_counter(
+        &mut out,
+        "ai_proxy_errors_total",
+        "",
+        snap["total_errors"].as_u64().unwrap_or(0),
+    );
+
+    // ── ai_proxy_tokens_total ──
+    let _ = writeln!(out, "# HELP ai_proxy_tokens_total Total tokens processed.");
+    let _ = writeln!(out, "# TYPE ai_proxy_tokens_total counter");
+    write_counter(
+        &mut out,
+        "ai_proxy_tokens_total",
+        "direction=\"input\"",
+        snap["total_input_tokens"].as_u64().unwrap_or(0),
+    );
+    write_counter(
+        &mut out,
+        "ai_proxy_tokens_total",
+        "direction=\"output\"",
+        snap["total_output_tokens"].as_u64().unwrap_or(0),
+    );
+
+    // ── ai_proxy_cost_usd_total ──
+    let _ = writeln!(out, "# HELP ai_proxy_cost_usd_total Total cost in USD.");
+    let _ = writeln!(out, "# TYPE ai_proxy_cost_usd_total counter");
+    write_gauge(
+        &mut out,
+        "ai_proxy_cost_usd_total",
+        "",
+        snap["total_cost_usd"].as_f64().unwrap_or(0.0),
+    );
+
+    // ── ai_proxy_request_duration_seconds ──
+    let _ = writeln!(
+        out,
+        "# HELP ai_proxy_request_duration_seconds Request duration histogram."
+    );
+    let _ = writeln!(out, "# TYPE ai_proxy_request_duration_seconds histogram");
+    // Map existing ms-based buckets (<100, 100-499, 500-999, 1000-4999, 5000-29999, >=30000)
+    // to Prometheus seconds buckets (le=0.1, 0.5, 1, 5, 30, +Inf)
+    let bucket_values = metrics.latency_bucket_values();
+    let le_values = ["0.1", "0.5", "1", "5", "30", "+Inf"];
+    let mut cumulative = 0u64;
+    for (i, &count) in bucket_values.iter().enumerate() {
+        cumulative += count;
+        write_histogram_bucket(
+            &mut out,
+            "ai_proxy_request_duration_seconds",
+            le_values[i],
+            cumulative,
+        );
+    }
+    let total_reqs = snap["total_requests"].as_u64().unwrap_or(0);
+    let _ = writeln!(out, "ai_proxy_request_duration_seconds_count {total_reqs}");
+
+    // ── TTFT ──
+    let ttft_buckets = metrics.ttft_bucket_values();
+    if ttft_buckets.iter().any(|&v| v > 0) {
+        let _ = writeln!(
+            out,
+            "# HELP ai_proxy_ttft_seconds Time to first token histogram."
+        );
+        let _ = writeln!(out, "# TYPE ai_proxy_ttft_seconds histogram");
+        let ttft_le = ["0.05", "0.1", "0.5", "1", "5", "+Inf"];
+        let mut cum = 0u64;
+        for (i, &count) in ttft_buckets.iter().enumerate() {
+            cum += count;
+            write_histogram_bucket(&mut out, "ai_proxy_ttft_seconds", ttft_le[i], cum);
+        }
+    }
+
+    // ── ai_proxy_cache_hits_total / misses ──
+    if let Some(stats) = cache_stats {
+        let _ = writeln!(out, "# HELP ai_proxy_cache_hits_total Total cache hits.");
+        let _ = writeln!(out, "# TYPE ai_proxy_cache_hits_total counter");
+        write_counter(&mut out, "ai_proxy_cache_hits_total", "", stats.hits);
+        let _ = writeln!(
+            out,
+            "# HELP ai_proxy_cache_misses_total Total cache misses."
+        );
+        let _ = writeln!(out, "# TYPE ai_proxy_cache_misses_total counter");
+        write_counter(&mut out, "ai_proxy_cache_misses_total", "", stats.misses);
+    }
+
+    // ── ai_proxy_circuit_breaker_open ──
+    if !circuit_breaker_states.is_empty() {
+        let _ = writeln!(
+            out,
+            "# HELP ai_proxy_circuit_breaker_open Whether circuit breaker is open."
+        );
+        let _ = writeln!(out, "# TYPE ai_proxy_circuit_breaker_open gauge");
+        for (credential, is_open) in circuit_breaker_states {
+            write_gauge(
+                &mut out,
+                "ai_proxy_circuit_breaker_open",
+                &format!("credential=\"{credential}\""),
+                if *is_open { 1.0 } else { 0.0 },
+            );
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_basic_metrics() {
+        let metrics = Metrics::new();
+        metrics.record_request("gpt-4", "openai");
+        metrics.record_error();
+
+        let output = render_metrics(&metrics, None, &[]);
+        assert!(output.contains("ai_proxy_requests_total"));
+        assert!(output.contains("ai_proxy_errors_total"));
+        assert!(output.contains("ai_proxy_tokens_total"));
+        assert!(output.contains("ai_proxy_cost_usd_total"));
+        assert!(output.contains("ai_proxy_request_duration_seconds"));
+    }
+
+    #[test]
+    fn test_render_with_cache_stats() {
+        let metrics = Metrics::new();
+        let stats = CacheStats {
+            hits: 42,
+            misses: 8,
+            entries: 100,
+            hit_rate: 0.84,
+        };
+        let output = render_metrics(&metrics, Some(&stats), &[]);
+        assert!(output.contains("ai_proxy_cache_hits_total 42"));
+        assert!(output.contains("ai_proxy_cache_misses_total 8"));
+    }
+
+    #[test]
+    fn test_render_with_circuit_breaker() {
+        let metrics = Metrics::new();
+        let cb_states = vec![("cred-1".to_string(), true), ("cred-2".to_string(), false)];
+        let output = render_metrics(&metrics, None, &cb_states);
+        assert!(output.contains("ai_proxy_circuit_breaker_open{credential=\"cred-1\"} 1"));
+        assert!(output.contains("ai_proxy_circuit_breaker_open{credential=\"cred-2\"} 0"));
+    }
+}

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,9 +1,11 @@
+use crate::circuit_breaker::{CircuitBreakerPolicy, CircuitState};
 use crate::error::ProxyError;
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
 use tokio_stream::Stream;
 
 /// Supported provider/API format identifiers.
@@ -57,7 +59,7 @@ pub enum WireApi {
 }
 
 /// Credentials for executing a request against a specific provider.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AuthRecord {
     pub id: String,
     pub provider: Format,
@@ -69,7 +71,7 @@ pub struct AuthRecord {
     pub excluded_models: Vec<String>,
     pub prefix: Option<String>,
     pub disabled: bool,
-    pub cooldown_until: Option<std::time::Instant>,
+    pub circuit_breaker: Arc<dyn CircuitBreakerPolicy>,
     pub cloak: Option<crate::cloak::CloakConfig>,
     /// Wire API format for OpenAI-compatible providers.
     pub wire_api: WireApi,
@@ -77,6 +79,19 @@ pub struct AuthRecord {
     pub credential_name: Option<String>,
     /// Weight for weighted round-robin routing (default: 1).
     pub weight: u32,
+    /// Region for geo-aware routing.
+    pub region: Option<String>,
+}
+
+impl std::fmt::Debug for AuthRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthRecord")
+            .field("id", &self.id)
+            .field("provider", &self.provider)
+            .field("api_key", &"***")
+            .field("circuit_breaker_state", &self.circuit_state())
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -171,12 +186,12 @@ impl AuthRecord {
         if self.disabled {
             return false;
         }
-        if let Some(until) = self.cooldown_until
-            && std::time::Instant::now() < until
-        {
-            return false;
-        }
-        true
+        self.circuit_breaker.can_execute()
+    }
+
+    /// Get circuit breaker state for this credential.
+    pub fn circuit_state(&self) -> CircuitState {
+        self.circuit_breaker.state()
     }
 }
 

--- a/crates/core/src/rate_limit.rs
+++ b/crates/core/src/rate_limit.rs
@@ -4,40 +4,6 @@ use std::time::Instant;
 
 use crate::config::RateLimitConfig;
 
-/// Sliding window rate limiter using in-memory timestamp tracking.
-pub struct RateLimiter {
-    /// Global request timestamps (sliding window).
-    global: Mutex<SlidingWindow>,
-    /// Per-key request timestamps (sliding window per key).
-    per_key: RwLock<HashMap<String, Mutex<SlidingWindow>>>,
-    /// Current configuration.
-    config: RwLock<RateLimitConfig>,
-}
-
-struct SlidingWindow {
-    timestamps: Vec<Instant>,
-}
-
-impl SlidingWindow {
-    fn new() -> Self {
-        Self {
-            timestamps: Vec::new(),
-        }
-    }
-
-    /// Remove timestamps older than 60 seconds and return current count.
-    fn count_and_prune(&mut self, now: Instant) -> u32 {
-        let cutoff = now - std::time::Duration::from_secs(60);
-        self.timestamps.retain(|&t| t > cutoff);
-        self.timestamps.len() as u32
-    }
-
-    /// Record a new request timestamp.
-    fn record(&mut self, now: Instant) {
-        self.timestamps.push(now);
-    }
-}
-
 /// Result of a rate limit check.
 pub struct RateLimitInfo {
     /// Whether the request is allowed.
@@ -50,28 +16,211 @@ pub struct RateLimitInfo {
     pub reset_secs: u64,
 }
 
-impl RateLimiter {
-    pub fn new(config: &RateLimitConfig) -> Self {
+/// Trait for a single rate limit dimension.
+pub trait RateLimitDimension: Send + Sync {
+    fn check(&self, key: Option<&str>) -> RateLimitInfo;
+    fn record(&self, key: Option<&str>, amount: u64);
+    fn dimension_name(&self) -> &str;
+}
+
+// ─── Sliding Window Limiter (reused for RPM and TPM) ─────────────────────
+
+struct SlidingWindow {
+    timestamps: Vec<(Instant, u64)>,
+}
+
+impl SlidingWindow {
+    fn new() -> Self {
         Self {
+            timestamps: Vec::new(),
+        }
+    }
+
+    fn count_and_prune(&mut self, now: Instant, window_secs: u64) -> u64 {
+        let cutoff = now - std::time::Duration::from_secs(window_secs);
+        self.timestamps.retain(|&(t, _)| t > cutoff);
+        self.timestamps.iter().map(|&(_, amount)| amount).sum()
+    }
+
+    fn record(&mut self, now: Instant, amount: u64) {
+        self.timestamps.push((now, amount));
+    }
+
+    fn estimate_reset(&self, now: Instant, window_secs: u64) -> u64 {
+        if let Some(&(oldest, _)) = self.timestamps.first() {
+            let age = now.duration_since(oldest);
+            window_secs.saturating_sub(age.as_secs())
+        } else {
+            window_secs
+        }
+    }
+}
+
+/// Sliding window limiter — reusable for RPM and TPM.
+pub struct SlidingWindowLimiter {
+    name: String,
+    window_secs: u64,
+    global_limit: RwLock<u64>,
+    per_key_limit: RwLock<u64>,
+    global: Mutex<SlidingWindow>,
+    per_key: RwLock<HashMap<String, Mutex<SlidingWindow>>>,
+}
+
+impl SlidingWindowLimiter {
+    pub fn new(name: &str, window_secs: u64, global_limit: u64, per_key_limit: u64) -> Self {
+        Self {
+            name: name.to_string(),
+            window_secs,
+            global_limit: RwLock::new(global_limit),
+            per_key_limit: RwLock::new(per_key_limit),
             global: Mutex::new(SlidingWindow::new()),
             per_key: RwLock::new(HashMap::new()),
-            config: RwLock::new(config.clone()),
         }
     }
 
-    /// Update configuration (called on hot-reload).
-    pub fn update_config(&self, config: &RateLimitConfig) {
-        if let Ok(mut cfg) = self.config.write() {
-            *cfg = config.clone();
+    pub fn update_limits(&self, global_limit: u64, per_key_limit: u64) {
+        if let Ok(mut g) = self.global_limit.write() {
+            *g = global_limit;
+        }
+        if let Ok(mut p) = self.per_key_limit.write() {
+            *p = per_key_limit;
+        }
+    }
+}
+
+impl RateLimitDimension for SlidingWindowLimiter {
+    fn check(&self, key: Option<&str>) -> RateLimitInfo {
+        let now = Instant::now();
+        let global_limit = *self.global_limit.read().unwrap();
+        let per_key_limit = *self.per_key_limit.read().unwrap();
+
+        let mut most_restrictive = RateLimitInfo {
+            allowed: true,
+            remaining: u32::MAX,
+            limit: 0,
+            reset_secs: self.window_secs,
+        };
+
+        // Check global limit
+        if global_limit > 0 {
+            let mut global = self.global.lock().unwrap();
+            let count = global.count_and_prune(now, self.window_secs);
+            let remaining = (global_limit).saturating_sub(count) as u32;
+            if count >= global_limit {
+                return RateLimitInfo {
+                    allowed: false,
+                    remaining: 0,
+                    limit: global_limit as u32,
+                    reset_secs: global.estimate_reset(now, self.window_secs),
+                };
+            }
+            if remaining < most_restrictive.remaining {
+                most_restrictive = RateLimitInfo {
+                    allowed: true,
+                    remaining,
+                    limit: global_limit as u32,
+                    reset_secs: self.window_secs,
+                };
+            }
+        }
+
+        // Check per-key limit
+        if per_key_limit > 0
+            && let Some(key) = key
+        {
+            let per_key = self.per_key.read().unwrap();
+            if let Some(window) = per_key.get(key) {
+                let mut window = window.lock().unwrap();
+                let count = window.count_and_prune(now, self.window_secs);
+                let remaining = (per_key_limit).saturating_sub(count) as u32;
+                if count >= per_key_limit {
+                    return RateLimitInfo {
+                        allowed: false,
+                        remaining: 0,
+                        limit: per_key_limit as u32,
+                        reset_secs: window.estimate_reset(now, self.window_secs),
+                    };
+                }
+                if remaining < most_restrictive.remaining {
+                    most_restrictive = RateLimitInfo {
+                        allowed: true,
+                        remaining,
+                        limit: per_key_limit as u32,
+                        reset_secs: self.window_secs,
+                    };
+                }
+            }
+        }
+
+        most_restrictive
+    }
+
+    fn record(&self, key: Option<&str>, amount: u64) {
+        let now = Instant::now();
+        let global_limit = *self.global_limit.read().unwrap();
+        let per_key_limit = *self.per_key_limit.read().unwrap();
+
+        if global_limit > 0 {
+            let mut global = self.global.lock().unwrap();
+            global.record(now, amount);
+        }
+
+        if per_key_limit > 0
+            && let Some(key) = key
+        {
+            // Fast path: read lock
+            {
+                let per_key = self.per_key.read().unwrap();
+                if let Some(window) = per_key.get(key) {
+                    let mut window = window.lock().unwrap();
+                    window.record(now, amount);
+                    return;
+                }
+            }
+            // Slow path: write lock
+            {
+                let mut per_key = self.per_key.write().unwrap();
+                let window = per_key
+                    .entry(key.to_string())
+                    .or_insert_with(|| Mutex::new(SlidingWindow::new()));
+                let window = window.get_mut().unwrap();
+                window.record(now, amount);
+            }
         }
     }
 
-    /// Check rate limits. Returns info about the most restrictive limit.
-    /// `api_key` is None for unauthenticated requests.
-    pub fn check(&self, api_key: Option<&str>) -> RateLimitInfo {
-        let config = self.config.read().unwrap();
+    fn dimension_name(&self) -> &str {
+        &self.name
+    }
+}
 
-        if !config.enabled {
+type CostEntries = Vec<(Instant, f64)>;
+
+/// Cost limiter — daily sliding window for per-key cost limits.
+pub struct CostLimiter {
+    per_key_daily_limit: RwLock<f64>,
+    per_key: RwLock<HashMap<String, Mutex<CostEntries>>>,
+}
+
+impl CostLimiter {
+    pub fn new(per_key_daily_limit: f64) -> Self {
+        Self {
+            per_key_daily_limit: RwLock::new(per_key_daily_limit),
+            per_key: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn update_limit(&self, limit: f64) {
+        if let Ok(mut l) = self.per_key_daily_limit.write() {
+            *l = limit;
+        }
+    }
+}
+
+impl RateLimitDimension for CostLimiter {
+    fn check(&self, key: Option<&str>) -> RateLimitInfo {
+        let limit = *self.per_key_daily_limit.read().unwrap();
+        if limit <= 0.0 {
             return RateLimitInfo {
                 allowed: true,
                 remaining: u32::MAX,
@@ -80,127 +229,171 @@ impl RateLimiter {
             };
         }
 
-        let now = Instant::now();
-        let mut most_restrictive = RateLimitInfo {
-            allowed: true,
-            remaining: u32::MAX,
-            limit: 0,
-            reset_secs: 60,
+        let Some(key) = key else {
+            return RateLimitInfo {
+                allowed: true,
+                remaining: u32::MAX,
+                limit: 0,
+                reset_secs: 0,
+            };
         };
 
-        // Check global RPM
-        if config.global_rpm > 0 {
-            let mut global = self.global.lock().unwrap();
-            let count = global.count_and_prune(now);
-            let remaining = config.global_rpm.saturating_sub(count);
-            if count >= config.global_rpm {
+        let now = Instant::now();
+        let day_secs = 86400u64;
+        let cutoff = now - std::time::Duration::from_secs(day_secs);
+
+        let per_key = self.per_key.read().unwrap();
+        if let Some(entries) = per_key.get(key) {
+            let mut entries = entries.lock().unwrap();
+            entries.retain(|&(t, _)| t > cutoff);
+            let total_cost: f64 = entries.iter().map(|&(_, c)| c).sum();
+            if total_cost >= limit {
                 return RateLimitInfo {
                     allowed: false,
                     remaining: 0,
-                    limit: config.global_rpm,
-                    reset_secs: self.estimate_reset(&global, now),
-                };
-            }
-            if remaining < most_restrictive.remaining {
-                most_restrictive = RateLimitInfo {
-                    allowed: true,
-                    remaining,
-                    limit: config.global_rpm,
-                    reset_secs: 60,
+                    limit: (limit * 100.0) as u32, // cents
+                    reset_secs: entries
+                        .first()
+                        .map(|&(t, _)| day_secs.saturating_sub(now.duration_since(t).as_secs()))
+                        .unwrap_or(day_secs),
                 };
             }
         }
 
-        // Check per-key RPM
-        if config.per_key_rpm > 0
-            && let Some(key) = api_key
-        {
-            let info = self.check_per_key(key, config.per_key_rpm, now);
-            if !info.allowed {
-                return info;
-            }
-            if info.remaining < most_restrictive.remaining {
-                most_restrictive = info;
-            }
+        RateLimitInfo {
+            allowed: true,
+            remaining: u32::MAX,
+            limit: 0,
+            reset_secs: day_secs,
         }
-
-        most_restrictive
     }
 
-    /// Record a request. Call after check() returns allowed=true.
-    pub fn record(&self, api_key: Option<&str>) {
-        let config = self.config.read().unwrap();
-        if !config.enabled {
-            return;
-        }
+    fn record(&self, key: Option<&str>, _amount: u64) {
+        // Cost recording is done via record_cost() below
+        let _ = key;
+    }
 
+    fn dimension_name(&self) -> &str {
+        "cost"
+    }
+}
+
+impl CostLimiter {
+    /// Record cost for a key (in USD).
+    pub fn record_cost(&self, key: &str, cost: f64) {
         let now = Instant::now();
-
-        if config.global_rpm > 0 {
-            let mut global = self.global.lock().unwrap();
-            global.record(now);
-        }
-
-        if config.per_key_rpm > 0
-            && let Some(key) = api_key
-        {
-            self.record_per_key(key, now);
-        }
-    }
-
-    fn check_per_key(&self, key: &str, limit: u32, now: Instant) -> RateLimitInfo {
-        let per_key = self.per_key.read().unwrap();
-        if let Some(window) = per_key.get(key) {
-            let mut window = window.lock().unwrap();
-            let count = window.count_and_prune(now);
-            let remaining = limit.saturating_sub(count);
-            RateLimitInfo {
-                allowed: count < limit,
-                remaining,
-                limit,
-                reset_secs: if count >= limit {
-                    self.estimate_reset(&window, now)
-                } else {
-                    60
-                },
-            }
-        } else {
-            RateLimitInfo {
-                allowed: true,
-                remaining: limit,
-                limit,
-                reset_secs: 60,
-            }
-        }
-    }
-
-    fn record_per_key(&self, key: &str, now: Instant) {
-        // Fast path: read lock
+        // Fast path
         {
             let per_key = self.per_key.read().unwrap();
-            if let Some(window) = per_key.get(key) {
-                let mut window = window.lock().unwrap();
-                window.record(now);
+            if let Some(entries) = per_key.get(key) {
+                let mut entries = entries.lock().unwrap();
+                entries.push((now, cost));
                 return;
             }
         }
-        // Slow path: write lock to insert
+        // Slow path
         {
             let mut per_key = self.per_key.write().unwrap();
-            let window = per_key
+            let entries = per_key
                 .entry(key.to_string())
-                .or_insert_with(|| Mutex::new(SlidingWindow::new()));
-            let window = window.get_mut().unwrap();
-            window.record(now);
+                .or_insert_with(|| Mutex::new(Vec::new()));
+            entries.get_mut().unwrap().push((now, cost));
+        }
+    }
+}
+
+/// Composite rate limiter — checks all dimensions, returns most restrictive.
+pub struct CompositeRateLimiter {
+    rpm: SlidingWindowLimiter,
+    tpm: SlidingWindowLimiter,
+    cost: CostLimiter,
+    enabled: RwLock<bool>,
+}
+
+impl CompositeRateLimiter {
+    pub fn new(config: &RateLimitConfig) -> Self {
+        Self {
+            rpm: SlidingWindowLimiter::new(
+                "rpm",
+                60,
+                config.global_rpm as u64,
+                config.per_key_rpm as u64,
+            ),
+            tpm: SlidingWindowLimiter::new("tpm", 60, config.global_tpm, config.per_key_tpm),
+            cost: CostLimiter::new(config.per_key_cost_per_day_usd),
+            enabled: RwLock::new(config.enabled),
         }
     }
 
-    fn estimate_reset(&self, window: &SlidingWindow, now: Instant) -> u64 {
-        if let Some(&oldest) = window.timestamps.first() {
-            let age = now.duration_since(oldest);
-            60u64.saturating_sub(age.as_secs())
-        } else {
-            60
+    /// Update configuration (called on hot-reload).
+    pub fn update_config(&self, config: &RateLimitConfig) {
+        if let Ok(mut e) = self.enabled.write() {
+            *e = config.enabled;
+        }
+        self.rpm
+            .update_limits(config.global_rpm as u64, config.per_key_rpm as u64);
+        self.tpm
+            .update_limits(config.global_tpm, config.per_key_tpm);
+        self.cost.update_limit(config.per_key_cost_per_day_usd);
+    }
+
+    /// Check rate limits. Returns info about the most restrictive limit.
+    pub fn check(&self, api_key: Option<&str>) -> RateLimitInfo {
+        if !*self.enabled.read().unwrap() {
+            return RateLimitInfo {
+                allowed: true,
+                remaining: u32::MAX,
+                limit: 0,
+                reset_secs: 0,
+            };
+        }
+
+        let rpm_info = self.rpm.check(api_key);
+        if !rpm_info.allowed {
+            return rpm_info;
+        }
+
+        let tpm_info = self.tpm.check(api_key);
+        if !tpm_info.allowed {
+            return tpm_info;
+        }
+
+        let cost_info = self.cost.check(api_key);
+        if !cost_info.allowed {
+            return cost_info;
+        }
+
+        // Return the most restrictive remaining
+        let mut result = rpm_info;
+        if tpm_info.remaining < result.remaining {
+            result = tpm_info;
+        }
+        result
+    }
+
+    /// Record a request (RPM dimension). Call after check() returns allowed=true.
+    pub fn record_request(&self, api_key: Option<&str>) {
+        if !*self.enabled.read().unwrap() {
+            return;
+        }
+        self.rpm.record(api_key, 1);
+    }
+
+    /// Record tokens (TPM dimension). Call after response is received.
+    pub fn record_tokens(&self, api_key: Option<&str>, tokens: u64) {
+        if !*self.enabled.read().unwrap() {
+            return;
+        }
+        self.tpm.record(api_key, tokens);
+    }
+
+    /// Record cost (Cost dimension). Call after response is received.
+    pub fn record_cost(&self, api_key: Option<&str>, cost: f64) {
+        if !*self.enabled.read().unwrap() || cost <= 0.0 {
+            return;
+        }
+        if let Some(key) = api_key {
+            self.cost.record_cost(key, cost);
         }
     }
 }
@@ -215,8 +408,9 @@ mod tests {
             enabled: false,
             global_rpm: 10,
             per_key_rpm: 5,
+            ..Default::default()
         };
-        let limiter = RateLimiter::new(&config);
+        let limiter = CompositeRateLimiter::new(&config);
         let info = limiter.check(Some("key1"));
         assert!(info.allowed);
     }
@@ -227,13 +421,14 @@ mod tests {
             enabled: true,
             global_rpm: 3,
             per_key_rpm: 0,
+            ..Default::default()
         };
-        let limiter = RateLimiter::new(&config);
+        let limiter = CompositeRateLimiter::new(&config);
 
         for _ in 0..3 {
             let info = limiter.check(None);
             assert!(info.allowed);
-            limiter.record(None);
+            limiter.record_request(None);
         }
 
         let info = limiter.check(None);
@@ -248,14 +443,15 @@ mod tests {
             enabled: true,
             global_rpm: 0,
             per_key_rpm: 2,
+            ..Default::default()
         };
-        let limiter = RateLimiter::new(&config);
+        let limiter = CompositeRateLimiter::new(&config);
 
         // key1 uses 2 requests
         for _ in 0..2 {
             let info = limiter.check(Some("key1"));
             assert!(info.allowed);
-            limiter.record(Some("key1"));
+            limiter.record_request(Some("key1"));
         }
 
         // key1 is now rate limited
@@ -268,21 +464,19 @@ mod tests {
     }
 
     #[test]
-    fn test_remaining_count() {
+    fn test_tpm_limit() {
         let config = RateLimitConfig {
             enabled: true,
-            global_rpm: 5,
-            per_key_rpm: 0,
+            global_tpm: 1000,
+            ..Default::default()
         };
-        let limiter = RateLimiter::new(&config);
+        let limiter = CompositeRateLimiter::new(&config);
 
-        limiter.record(None);
-        limiter.record(None);
+        // Record 1000 tokens
+        limiter.tpm.record(None, 1000);
 
         let info = limiter.check(None);
-        assert!(info.allowed);
-        assert_eq!(info.remaining, 3);
-        assert_eq!(info.limit, 5);
+        assert!(!info.allowed);
     }
 
     #[test]
@@ -291,11 +485,12 @@ mod tests {
             enabled: true,
             global_rpm: 2,
             per_key_rpm: 0,
+            ..Default::default()
         };
-        let limiter = RateLimiter::new(&config);
+        let limiter = CompositeRateLimiter::new(&config);
 
-        limiter.record(None);
-        limiter.record(None);
+        limiter.record_request(None);
+        limiter.record_request(None);
         assert!(!limiter.check(None).allowed);
 
         // Increase limit
@@ -303,6 +498,7 @@ mod tests {
             enabled: true,
             global_rpm: 5,
             per_key_rpm: 0,
+            ..Default::default()
         });
 
         assert!(limiter.check(None).allowed);

--- a/crates/core/src/request_log.rs
+++ b/crates/core/src/request_log.rs
@@ -18,6 +18,9 @@ pub struct RequestLogEntry {
     pub output_tokens: Option<u64>,
     pub cost: Option<f64>,
     pub error: Option<String>,
+    pub api_key_id: Option<String>,
+    pub tenant_id: Option<String>,
+    pub client_ip: Option<String>,
 }
 
 /// Query parameters for filtering request logs.
@@ -183,6 +186,9 @@ mod tests {
             } else {
                 None
             },
+            api_key_id: None,
+            tenant_id: None,
+            client_ip: None,
         }
     }
 

--- a/crates/core/src/secret.rs
+++ b/crates/core/src/secret.rs
@@ -1,0 +1,63 @@
+/// Resolve a secret value from plain text, environment variable, or file.
+///
+/// Supported URI schemes:
+///   - `env://VAR_NAME` — reads from environment variable
+///   - `file:///path/to/secret` — reads from file (trimmed)
+///   - anything else — returned as-is (plain text)
+pub fn resolve(value: &str) -> Result<String, anyhow::Error> {
+    if let Some(var) = value.strip_prefix("env://") {
+        std::env::var(var).map_err(|_| anyhow::anyhow!("environment variable '{var}' not set"))
+    } else if let Some(path) = value.strip_prefix("file://") {
+        std::fs::read_to_string(path)
+            .map(|s| s.trim().to_string())
+            .map_err(|e| anyhow::anyhow!("failed to read secret file '{path}': {e}"))
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plain_text_passthrough() {
+        assert_eq!(resolve("sk-ant-abc123").unwrap(), "sk-ant-abc123");
+    }
+
+    #[test]
+    fn test_env_resolve() {
+        // SAFETY: test runs sequentially, no other threads access this var
+        unsafe {
+            std::env::set_var("_TEST_SECRET_KEY", "my-secret-value");
+        }
+        assert_eq!(
+            resolve("env://_TEST_SECRET_KEY").unwrap(),
+            "my-secret-value"
+        );
+        unsafe {
+            std::env::remove_var("_TEST_SECRET_KEY");
+        }
+    }
+
+    #[test]
+    fn test_env_resolve_missing() {
+        let result = resolve("env://_NONEXISTENT_VAR_12345");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_file_resolve() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.txt");
+        std::fs::write(&path, "  file-secret-value\n  ").unwrap();
+        let uri = format!("file://{}", path.display());
+        assert_eq!(resolve(&uri).unwrap(), "file-secret-value");
+    }
+
+    #[test]
+    fn test_file_resolve_missing() {
+        let result = resolve("file:///nonexistent/path/secret.txt");
+        assert!(result.is_err());
+    }
+}

--- a/crates/provider/src/routing.rs
+++ b/crates/provider/src/routing.rs
@@ -1,14 +1,24 @@
+use ai_proxy_core::circuit_breaker::{
+    CircuitBreakerConfig, CircuitBreakerPolicy, CircuitState, NoopCircuitBreaker,
+    ThreeStateCircuitBreaker,
+};
 use ai_proxy_core::config::{Config, RoutingStrategy};
 use ai_proxy_core::provider::{AuthRecord, Format, ModelEntry, ModelInfo};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
 
 pub struct CredentialRouter {
     credentials: RwLock<HashMap<Format, Vec<AuthRecord>>>,
     counters: RwLock<HashMap<String, AtomicUsize>>,
     strategy: RwLock<RoutingStrategy>,
+    /// EWMA latency per credential_id (ms).
+    latency_ewma: RwLock<HashMap<String, f64>>,
+    /// EWMA smoothing factor (0.0-1.0).
+    ewma_alpha: RwLock<f64>,
+    /// Circuit breaker config (used when building new records).
+    cb_config: RwLock<CircuitBreakerConfig>,
 }
 
 impl CredentialRouter {
@@ -17,12 +27,21 @@ impl CredentialRouter {
             credentials: RwLock::new(HashMap::new()),
             counters: RwLock::new(HashMap::new()),
             strategy: RwLock::new(strategy),
+            latency_ewma: RwLock::new(HashMap::new()),
+            ewma_alpha: RwLock::new(0.3),
+            cb_config: RwLock::new(CircuitBreakerConfig::default()),
         }
     }
 
     /// Pick the next available credential for the given provider and model.
     /// Skips credentials whose IDs are in `tried`.
-    pub fn pick(&self, provider: Format, model: &str, tried: &[String]) -> Option<AuthRecord> {
+    pub fn pick(
+        &self,
+        provider: Format,
+        model: &str,
+        tried: &[String],
+        client_region: Option<&str>,
+    ) -> Option<AuthRecord> {
         let creds = self.credentials.read().ok()?;
         let entries = creds.get(&provider)?;
 
@@ -42,94 +61,197 @@ impl CredentialRouter {
                 // Always pick the first available credential
                 candidates.first().cloned().cloned()
             }
-            RoutingStrategy::RoundRobin => {
-                let key = format!("{}:{}", provider.as_str(), model);
-                let counters = self.counters.read().ok()?;
-                let idx = if let Some(counter) = counters.get(&key) {
-                    counter.fetch_add(1, Ordering::Relaxed)
-                } else {
-                    drop(counters);
-                    let mut counters = self.counters.write().ok()?;
-                    let counter = counters.entry(key).or_insert_with(|| AtomicUsize::new(0));
-                    counter.fetch_add(1, Ordering::Relaxed)
-                };
-
-                // Weighted round-robin: build expanded index based on weights
-                let total_weight: u32 = candidates.iter().map(|c| c.weight.max(1)).sum();
-                if total_weight == 0 {
-                    return candidates.first().cloned().cloned();
-                }
-                let slot = (idx as u32) % total_weight;
-                let mut cumulative = 0u32;
-                for &c in &candidates {
-                    cumulative += c.weight.max(1);
-                    if slot < cumulative {
-                        return Some(c.clone());
-                    }
-                }
-                // Fallback (shouldn't reach here)
-                Some(candidates[idx % candidates.len()].clone())
-            }
+            RoutingStrategy::RoundRobin => self.pick_round_robin(provider, model, &candidates),
+            RoutingStrategy::LatencyAware => self.pick_latency_aware(&candidates),
+            RoutingStrategy::GeoAware => self.pick_geo_aware(&candidates, client_region),
         }
     }
 
-    /// Mark a credential as unavailable for a duration (cooldown).
-    pub fn mark_unavailable(&self, auth_id: &str, duration: Duration) {
-        if let Ok(mut creds) = self.credentials.write() {
-            let until = Instant::now() + duration;
-            for entries in creds.values_mut() {
-                for auth in entries.iter_mut() {
+    fn pick_round_robin(
+        &self,
+        provider: Format,
+        model: &str,
+        candidates: &[&AuthRecord],
+    ) -> Option<AuthRecord> {
+        let key = format!("{}:{}", provider.as_str(), model);
+        let counters = self.counters.read().ok()?;
+        let idx = if let Some(counter) = counters.get(&key) {
+            counter.fetch_add(1, Ordering::Relaxed)
+        } else {
+            drop(counters);
+            let mut counters = self.counters.write().ok()?;
+            let counter = counters.entry(key).or_insert_with(|| AtomicUsize::new(0));
+            counter.fetch_add(1, Ordering::Relaxed)
+        };
+
+        // Weighted round-robin: build expanded index based on weights
+        let total_weight: u32 = candidates.iter().map(|c| c.weight.max(1)).sum();
+        if total_weight == 0 {
+            return candidates.first().cloned().cloned();
+        }
+        let slot = (idx as u32) % total_weight;
+        let mut cumulative = 0u32;
+        for &c in candidates {
+            cumulative += c.weight.max(1);
+            if slot < cumulative {
+                return Some(c.clone());
+            }
+        }
+        // Fallback (shouldn't reach here)
+        Some(candidates[idx % candidates.len()].clone())
+    }
+
+    fn pick_latency_aware(&self, candidates: &[&AuthRecord]) -> Option<AuthRecord> {
+        if candidates.len() == 1 {
+            return candidates.first().cloned().cloned();
+        }
+
+        let ewma = self.latency_ewma.read().ok()?;
+        let mut best: Option<&AuthRecord> = None;
+        let mut best_latency = f64::MAX;
+
+        for &c in candidates {
+            let latency = ewma.get(&c.id).copied().unwrap_or(0.0);
+            if latency < best_latency {
+                best_latency = latency;
+                best = Some(c);
+            }
+        }
+
+        best.cloned()
+    }
+
+    fn pick_geo_aware(
+        &self,
+        candidates: &[&AuthRecord],
+        client_region: Option<&str>,
+    ) -> Option<AuthRecord> {
+        if let Some(region) = client_region {
+            // Prefer same-region credentials
+            let same_region: Vec<&&AuthRecord> = candidates
+                .iter()
+                .filter(|c| c.region.as_deref() == Some(region))
+                .collect();
+
+            if !same_region.is_empty() {
+                return same_region.first().cloned().cloned().cloned();
+            }
+        }
+
+        // Fallback to first available
+        candidates.first().cloned().cloned()
+    }
+
+    /// Record a credential's request latency for EWMA tracking.
+    pub fn record_latency(&self, credential_id: &str, latency_ms: f64) {
+        let alpha = *self.ewma_alpha.read().unwrap();
+        let mut ewma = self.latency_ewma.write().unwrap();
+        let current = ewma.entry(credential_id.to_string()).or_insert(latency_ms);
+        *current = alpha * latency_ms + (1.0 - alpha) * *current;
+    }
+
+    /// Record a successful request for a credential.
+    pub fn record_success(&self, auth_id: &str) {
+        if let Ok(creds) = self.credentials.read() {
+            for entries in creds.values() {
+                for auth in entries {
                     if auth.id == auth_id {
-                        auth.cooldown_until = Some(until);
+                        auth.circuit_breaker.record_success();
+                        return;
                     }
                 }
             }
         }
     }
 
-    /// Rebuild credentials from config, preserving cooldown state from existing credentials.
+    /// Record a failure for a credential (circuit breaker).
+    pub fn record_failure(&self, auth_id: &str) {
+        if let Ok(creds) = self.credentials.read() {
+            for entries in creds.values() {
+                for auth in entries {
+                    if auth.id == auth_id {
+                        auth.circuit_breaker.record_failure();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get circuit breaker states for all credentials (for Prometheus).
+    pub fn circuit_breaker_states(&self) -> Vec<(String, bool)> {
+        let mut states = Vec::new();
+        if let Ok(creds) = self.credentials.read() {
+            for entries in creds.values() {
+                for auth in entries {
+                    let name = auth
+                        .credential_name
+                        .clone()
+                        .unwrap_or_else(|| auth.id[..8].to_string());
+                    states.push((name, auth.circuit_state() == CircuitState::Open));
+                }
+            }
+        }
+        states
+    }
+
+    /// Rebuild credentials from config, preserving circuit breaker state.
     pub fn update_from_config(&self, config: &Config) {
+        // Update CB config and EWMA alpha
+        if let Ok(mut cb) = self.cb_config.write() {
+            *cb = config.circuit_breaker.clone();
+        }
+        if let Ok(mut alpha) = self.ewma_alpha.write() {
+            *alpha = config.routing.ewma_alpha;
+        }
+
+        let cb_config = config.circuit_breaker.clone();
+
         let mut map: HashMap<Format, Vec<AuthRecord>> = HashMap::new();
 
         // Claude credentials
         for entry in &config.claude_api_key {
-            let auth = build_auth_record(entry, Format::Claude);
+            let auth = build_auth_record(entry, Format::Claude, &cb_config);
             map.entry(Format::Claude).or_default().push(auth);
         }
 
         // OpenAI credentials
         for entry in &config.openai_api_key {
-            let auth = build_auth_record(entry, Format::OpenAI);
+            let auth = build_auth_record(entry, Format::OpenAI, &cb_config);
             map.entry(Format::OpenAI).or_default().push(auth);
         }
 
         // Gemini credentials
         for entry in &config.gemini_api_key {
-            let auth = build_auth_record(entry, Format::Gemini);
+            let auth = build_auth_record(entry, Format::Gemini, &cb_config);
             map.entry(Format::Gemini).or_default().push(auth);
         }
 
         // OpenAI-compatible credentials
         for entry in &config.openai_compatibility {
-            let auth = build_auth_record(entry, Format::OpenAICompat);
+            let auth = build_auth_record(entry, Format::OpenAICompat, &cb_config);
             map.entry(Format::OpenAICompat).or_default().push(auth);
         }
 
         if let Ok(mut creds) = self.credentials.write() {
-            // Preserve cooldown state from existing credentials (matched by api_key + format)
+            // Preserve circuit breaker state from existing credentials
             for (format, new_entries) in map.iter_mut() {
                 if let Some(old_entries) = creds.get(format) {
                     for new_auth in new_entries.iter_mut() {
                         if let Some(old_auth) =
                             old_entries.iter().find(|o| o.api_key == new_auth.api_key)
                         {
-                            new_auth.cooldown_until = old_auth.cooldown_until;
+                            // Preserve CB state by reusing the old Arc
+                            new_auth.circuit_breaker = old_auth.circuit_breaker.clone();
                         }
                     }
                 }
             }
             *creds = map;
         }
+
+        // Preserve latency EWMA data (keyed by credential id changes, so
+        // we can't perfectly preserve — but it's ephemeral data anyway)
 
         // Update strategy
         if let Ok(mut strategy) = self.strategy.write() {
@@ -168,7 +290,6 @@ impl CredentialRouter {
     }
 
     /// Check if the model name matches any credential that has a prefix configured.
-    /// Used by `force_model_prefix` to reject unprefixed model requests.
     pub fn model_has_prefix(&self, model: &str) -> bool {
         if let Ok(creds) = self.credentials.read() {
             for entries in creds.values() {
@@ -204,6 +325,7 @@ impl CredentialRouter {
 fn build_auth_record(
     entry: &ai_proxy_core::config::ProviderKeyEntry,
     format: Format,
+    cb_config: &CircuitBreakerConfig,
 ) -> AuthRecord {
     let models = entry
         .models
@@ -213,6 +335,12 @@ fn build_auth_record(
             alias: m.alias.clone(),
         })
         .collect();
+
+    let circuit_breaker: Arc<dyn CircuitBreakerPolicy> = if cb_config.enabled {
+        Arc::new(ThreeStateCircuitBreaker::new(cb_config.clone()))
+    } else {
+        Arc::new(NoopCircuitBreaker)
+    };
 
     AuthRecord {
         id: uuid::Uuid::new_v4().to_string(),
@@ -225,7 +353,7 @@ fn build_auth_record(
         excluded_models: entry.excluded_models.clone(),
         prefix: entry.prefix.clone(),
         disabled: entry.disabled,
-        cooldown_until: None,
+        circuit_breaker,
         cloak: if matches!(format, Format::Claude) {
             Some(entry.cloak.clone())
         } else {
@@ -234,5 +362,6 @@ fn build_auth_record(
         wire_api: entry.wire_api,
         credential_name: entry.name.clone(),
         weight: entry.weight.max(1),
+        region: entry.region.clone(),
     }
 }

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -1,16 +1,18 @@
 use crate::AppState;
+use ai_proxy_core::auth_key::AuthKeyStore;
+use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
 use axum::{extract::State, http::Request, middleware::Next, response::Response};
 
 pub async fn auth_middleware(
     State(state): State<AppState>,
-    request: Request<axum::body::Body>,
+    mut request: Request<axum::body::Body>,
     next: Next,
 ) -> Result<Response, ProxyError> {
     let config = state.config.load();
 
-    // If no API keys configured, skip auth
-    if config.api_keys.is_empty() {
+    // If no auth keys configured, skip auth
+    if config.auth_keys.is_empty() {
         return Ok(next.run(request).await);
     }
 
@@ -25,10 +27,31 @@ pub async fn auth_middleware(
                 .headers()
                 .get("x-api-key")
                 .and_then(|v| v.to_str().ok())
-        });
+        })
+        .map(|s| s.to_string());
 
-    match token {
-        Some(t) if config.api_keys_set.contains(t) => Ok(next.run(request).await),
-        _ => Err(ProxyError::Auth("Invalid API key".to_string())),
+    let token = match token {
+        Some(t) => t,
+        None => return Err(ProxyError::Auth("Missing API key".to_string())),
+    };
+
+    // Lookup in AuthKeyStore
+    let entry = match config.auth_key_store.lookup(&token) {
+        Some(e) => e,
+        None => return Err(ProxyError::Auth("Invalid API key".to_string())),
+    };
+
+    // Check expiry
+    if AuthKeyStore::is_expired(entry) {
+        return Err(ProxyError::KeyExpired);
     }
+
+    // Inject auth info into RequestContext
+    if let Some(ctx) = request.extensions_mut().get_mut::<RequestContext>() {
+        ctx.api_key_id = Some(AuthKeyStore::mask_key(&token));
+        ctx.tenant_id = entry.tenant_id.clone();
+        ctx.auth_key = Some(entry.clone());
+    }
+
+    Ok(next.run(request).await)
 }

--- a/crates/server/src/dispatch.rs
+++ b/crates/server/src/dispatch.rs
@@ -26,6 +26,10 @@ pub struct DispatchRequest {
     pub user_agent: Option<String>,
     /// Debug mode: return routing details in response headers.
     pub debug: bool,
+    /// API key (for per-key rate limiting post-check).
+    pub api_key: Option<String>,
+    /// Client region (for geo-aware routing).
+    pub client_region: Option<String>,
 }
 
 /// Debug information collected during dispatch for x-debug response headers.
@@ -134,6 +138,45 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
     let start = Instant::now();
     let config = state.config.load();
 
+    // ── Model ACL check ──
+    if let Some(ctx) = req
+        .api_key
+        .as_ref()
+        .and_then(|k| config.auth_key_store.lookup(k))
+        && !ai_proxy_core::auth_key::AuthKeyStore::check_model_access(ctx, &req.model)
+    {
+        return Err(ProxyError::ModelNotAllowed(format!(
+            "model '{}' not allowed for this API key",
+            req.model
+        )));
+    }
+
+    // ── Cache lookup (non-stream, temperature=0) ──
+    if !req.stream
+        && let Some(ref cache) = state.response_cache
+        && let Ok(body_val) = serde_json::from_slice::<serde_json::Value>(&req.body)
+        && let Some(cache_key) = ai_proxy_core::cache::CacheKey::build(&req.model, &body_val)
+    {
+        if let Some(cached) = cache.get(&cache_key).await {
+            state.metrics.record_cache_hit();
+            let mut resp = axum::http::Response::builder()
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .header("x-cache", "HIT")
+                .body(axum::body::Body::from(cached.payload))
+                .map_err(|e| ProxyError::Internal(format!("failed to build response: {e}")))?
+                .into_response();
+            resp.extensions_mut().insert(DispatchMeta {
+                provider: Some(cached.provider),
+                model: Some(cached.model),
+                input_tokens: Some(cached.input_tokens),
+                output_tokens: Some(cached.output_tokens),
+                cost: None,
+            });
+            return Ok(resp);
+        }
+        state.metrics.record_cache_miss();
+    }
+
     // Build the model fallback chain
     let model_chain: Vec<String> = if let Some(ref models) = req.models {
         if models.is_empty() {
@@ -188,7 +231,12 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
 
         for attempt in 0..max_retries {
             for &target_format in &providers {
-                let auth = match state.router.pick(target_format, current_model, &tried) {
+                let auth = match state.router.pick(
+                    target_format,
+                    current_model,
+                    &tried,
+                    req.client_region.as_deref(),
+                ) {
                     Some(a) => a,
                     None => continue,
                 };
@@ -294,7 +342,10 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                     // ── Streaming path with bootstrap retry limit (4D) ──
                     match executor.execute_stream(&auth, provider_request).await {
                         Ok(stream_result) => {
-                            state.metrics.record_latency_ms(start.elapsed().as_millis());
+                            let latency_ms = start.elapsed().as_millis();
+                            state.metrics.record_latency_ms(latency_ms);
+                            state.router.record_success(&auth.id);
+                            state.router.record_latency(&auth.id, latency_ms as f64);
 
                             let need_translate = state
                                 .translators
@@ -412,7 +463,10 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                         result = &mut result_rx => {
                             match result {
                                 Ok(Ok(response)) => {
-                                    state.metrics.record_latency_ms(start.elapsed().as_millis());
+                                    let latency_ms = start.elapsed().as_millis();
+                                    state.metrics.record_latency_ms(latency_ms);
+                                    state.router.record_success(&auth.id);
+                                    state.router.record_latency(&auth.id, latency_ms as f64);
 
                                     let translated = state.translators.translate_non_stream(
                                         req.source_format,
@@ -491,7 +545,10 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                     // ── Non-stream without keepalive (standard path) ──
                     match executor.execute(&auth, provider_request).await {
                         Ok(response) => {
-                            state.metrics.record_latency_ms(start.elapsed().as_millis());
+                            let latency_ms = start.elapsed().as_millis();
+                            state.metrics.record_latency_ms(latency_ms);
+                            state.router.record_success(&auth.id);
+                            state.router.record_latency(&auth.id, latency_ms as f64);
 
                             let translated = state.translators.translate_non_stream(
                                 req.source_format,
@@ -500,6 +557,23 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                                 &body,
                                 &response.payload,
                             )?;
+
+                            // Write to cache for non-stream, temperature=0 requests
+                            if let Some(ref cache) = state.response_cache
+                                && let Ok(body_val) =
+                                    serde_json::from_slice::<serde_json::Value>(&req.body)
+                                && let Some(cache_key) =
+                                    ai_proxy_core::cache::CacheKey::build(&req.model, &body_val)
+                            {
+                                let cached = ai_proxy_core::cache::CachedResponse {
+                                    payload: Bytes::from(translated.clone()),
+                                    provider: target_format.as_str().to_string(),
+                                    model: actual_model.clone(),
+                                    input_tokens: 0,
+                                    output_tokens: 0,
+                                };
+                                cache.insert(cache_key, cached).await;
+                            }
 
                             let mut builder = axum::http::Response::builder()
                                 .header(axum::http::header::CONTENT_TYPE, "application/json");
@@ -537,10 +611,12 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                 }
             }
 
-            // Exponential backoff with full jitter between retry rounds
+            // Exponential backoff with configurable jitter between retry rounds
             if attempt + 1 < max_retries {
                 let cap = std::cmp::min(1u64 << attempt, max_backoff_secs) as f64;
-                let jittered = rand::random::<f64>() * cap;
+                let jitter_factor = retry_cfg.jitter_factor.clamp(0.0, 1.0);
+                let base = cap * (1.0 - jitter_factor);
+                let jittered = base + rand::random::<f64>() * cap * jitter_factor;
                 tokio::time::sleep(Duration::from_secs_f64(jittered)).await;
             }
         }
@@ -712,34 +788,24 @@ fn handle_retry_error(
     state: &AppState,
     auth_id: &str,
     error: &ProxyError,
-    retry_cfg: &RetryConfig,
+    _retry_cfg: &RetryConfig,
 ) {
     state.metrics.record_error();
     match error {
-        ProxyError::Upstream {
-            status,
-            retry_after_secs,
-            ..
-        } => match *status {
+        ProxyError::Upstream { status, .. } => match *status {
             429 => {
-                // Respect upstream Retry-After header if present, otherwise use config default
-                let secs = retry_after_secs.unwrap_or(retry_cfg.cooldown_429_secs);
-                let cooldown = Duration::from_secs(secs);
-                state.router.mark_unavailable(auth_id, cooldown);
-                tracing::warn!("Rate limited (429), cooling down credential for {cooldown:?}");
+                state.router.record_failure(auth_id);
+                tracing::warn!("Rate limited (429), recording circuit breaker failure");
             }
             s if (500..=599).contains(&s) => {
-                let secs = retry_after_secs.unwrap_or(retry_cfg.cooldown_5xx_secs);
-                let cooldown = Duration::from_secs(secs);
-                state.router.mark_unavailable(auth_id, cooldown);
-                tracing::warn!("Upstream error ({s}), cooling down credential for {cooldown:?}");
+                state.router.record_failure(auth_id);
+                tracing::warn!("Upstream error ({s}), recording circuit breaker failure");
             }
             _ => {}
         },
         ProxyError::Network(_) => {
-            let cooldown = Duration::from_secs(retry_cfg.cooldown_network_secs);
-            state.router.mark_unavailable(auth_id, cooldown);
-            tracing::warn!("Network error, cooling down credential for {cooldown:?}");
+            state.router.record_failure(auth_id);
+            tracing::warn!("Network error, recording circuit breaker failure");
         }
         _ => {}
     }

--- a/crates/server/src/handler/admin.rs
+++ b/crates/server/src/handler/admin.rs
@@ -10,7 +10,7 @@ pub async fn admin_config(State(state): State<AppState>) -> impl IntoResponse {
         "host": config.host,
         "port": config.port,
         "tls": { "enable": config.tls.enable },
-        "api_keys_count": config.api_keys.len(),
+        "auth_keys_count": config.auth_keys.len(),
         "routing": config.routing,
         "retry": config.retry,
         "body_limit_mb": config.body_limit_mb,

--- a/crates/server/src/handler/chat_completions.rs
+++ b/crates/server/src/handler/chat_completions.rs
@@ -1,7 +1,9 @@
 use crate::AppState;
 use crate::dispatch::{DispatchRequest, dispatch};
+use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
 use ai_proxy_core::provider::Format;
+use axum::Extension;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::response::IntoResponse;
@@ -9,6 +11,7 @@ use bytes::Bytes;
 
 pub async fn chat_completions(
     State(state): State<AppState>,
+    Extension(ctx): Extension<RequestContext>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, ProxyError> {
@@ -25,6 +28,8 @@ pub async fn chat_completions(
             allowed_formats: None,
             user_agent: parsed.user_agent,
             debug: parsed.debug,
+            api_key: ctx.auth_key.as_ref().map(|e| e.key.clone()),
+            client_region: ctx.client_region,
         },
     )
     .await

--- a/crates/server/src/handler/dashboard/auth_keys.rs
+++ b/crates/server/src/handler/dashboard/auth_keys.rs
@@ -1,4 +1,5 @@
 use crate::AppState;
+use ai_proxy_core::auth_key::{AuthKeyEntry, AuthKeyStore};
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -6,36 +7,60 @@ use axum::response::IntoResponse;
 use serde::Deserialize;
 use serde_json::json;
 
-fn mask_key(key: &str) -> String {
-    if key.len() <= 8 {
-        return "****".to_string();
-    }
-    format!("{}****{}", &key[..4], &key[key.len() - 4..])
-}
-
 #[derive(Debug, Deserialize)]
 pub struct CreateAuthKeyRequest {
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]
-    pub expires_in_days: Option<u32>,
+    pub tenant_id: Option<String>,
+    #[serde(default)]
+    pub allowed_models: Vec<String>,
+    #[serde(default)]
+    pub rate_limit: Option<ai_proxy_core::auth_key::KeyRateLimitConfig>,
+    #[serde(default)]
+    pub budget: Option<ai_proxy_core::auth_key::BudgetConfig>,
+    #[serde(default)]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub metadata: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateAuthKeyRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub tenant_id: Option<Option<String>>,
+    #[serde(default)]
+    pub allowed_models: Option<Vec<String>>,
+    #[serde(default)]
+    pub rate_limit: Option<Option<ai_proxy_core::auth_key::KeyRateLimitConfig>>,
+    #[serde(default)]
+    pub budget: Option<Option<ai_proxy_core::auth_key::BudgetConfig>>,
+    #[serde(default)]
+    pub expires_at: Option<Option<chrono::DateTime<chrono::Utc>>>,
+    #[serde(default)]
+    pub metadata: Option<std::collections::HashMap<String, String>>,
 }
 
 /// GET /api/dashboard/auth-keys
 pub async fn list_auth_keys(State(state): State<AppState>) -> impl IntoResponse {
     let config = state.config.load();
     let keys: Vec<serde_json::Value> = config
-        .api_keys
+        .auth_keys
         .iter()
         .enumerate()
-        .map(|(i, k)| {
+        .map(|(i, entry)| {
             json!({
                 "id": i,
-                "name": format!("Key {}", i + 1),
-                "key_masked": mask_key(k),
-                "created_at": null,
-                "last_used_at": null,
-                "expires_at": null,
+                "key_masked": AuthKeyStore::mask_key(&entry.key),
+                "name": entry.name,
+                "tenant_id": entry.tenant_id,
+                "allowed_models": entry.allowed_models,
+                "rate_limit": entry.rate_limit,
+                "budget": entry.budget,
+                "expires_at": entry.expires_at,
+                "metadata": entry.metadata,
             })
         })
         .collect();
@@ -47,28 +72,26 @@ pub async fn create_auth_key(
     State(state): State<AppState>,
     Json(body): Json<CreateAuthKeyRequest>,
 ) -> impl IntoResponse {
-    // Generate a secure random key with optional name prefix
-    let name = body.name.clone().unwrap_or_default();
     let key = format!(
         "sk-proxy-{}",
         uuid::Uuid::new_v4().to_string().replace('-', "")
     );
 
-    let expires_at = body.expires_in_days.map(|days| {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let expires = now + (days as u64) * 86400;
-        // Format as ISO 8601
-        let dt = chrono::DateTime::from_timestamp(expires as i64, 0);
-        dt.map(|d| d.to_rfc3339()).unwrap_or_default()
-    });
-
     let full_key = key.clone();
+    let entry = AuthKeyEntry {
+        key,
+        name: body.name,
+        tenant_id: body.tenant_id,
+        allowed_models: body.allowed_models,
+        rate_limit: body.rate_limit,
+        budget: body.budget,
+        expires_at: body.expires_at,
+        metadata: body.metadata,
+    };
+
     match super::providers::update_config_file_public(&state, move |config| {
-        config.api_keys.push(key);
-        config.api_keys_set = config.api_keys.iter().cloned().collect();
+        config.auth_keys.push(entry);
+        config.auth_key_store = AuthKeyStore::new(config.auth_keys.clone());
     })
     .await
     {
@@ -76,10 +99,54 @@ pub async fn create_auth_key(
             StatusCode::CREATED,
             Json(json!({
                 "key": full_key,
-                "name": name,
-                "expires_at": expires_at,
                 "message": "API key created. Save this key - it will not be shown again.",
             })),
+        ),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "write_failed", "message": e})),
+        ),
+    }
+}
+
+/// PATCH /api/dashboard/auth-keys/:id
+pub async fn update_auth_key(
+    State(state): State<AppState>,
+    Path(id): Path<usize>,
+    Json(body): Json<UpdateAuthKeyRequest>,
+) -> impl IntoResponse {
+    match super::providers::update_config_file_public(&state, move |config| {
+        if id < config.auth_keys.len() {
+            let entry = &mut config.auth_keys[id];
+            if let Some(name) = body.name {
+                entry.name = Some(name);
+            }
+            if let Some(tenant_id) = body.tenant_id {
+                entry.tenant_id = tenant_id;
+            }
+            if let Some(allowed_models) = body.allowed_models {
+                entry.allowed_models = allowed_models;
+            }
+            if let Some(rate_limit) = body.rate_limit {
+                entry.rate_limit = rate_limit;
+            }
+            if let Some(budget) = body.budget {
+                entry.budget = budget;
+            }
+            if let Some(expires_at) = body.expires_at {
+                entry.expires_at = expires_at;
+            }
+            if let Some(metadata) = body.metadata {
+                entry.metadata = metadata;
+            }
+            config.auth_key_store = AuthKeyStore::new(config.auth_keys.clone());
+        }
+    })
+    .await
+    {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(json!({"message": "Auth key updated successfully"})),
         ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -94,9 +161,9 @@ pub async fn delete_auth_key(
     Path(id): Path<usize>,
 ) -> impl IntoResponse {
     match super::providers::update_config_file_public(&state, move |config| {
-        if id < config.api_keys.len() {
-            config.api_keys.remove(id);
-            config.api_keys_set = config.api_keys.iter().cloned().collect();
+        if id < config.auth_keys.len() {
+            config.auth_keys.remove(id);
+            config.auth_key_store = AuthKeyStore::new(config.auth_keys.clone());
         }
     })
     .await

--- a/crates/server/src/handler/dashboard/config_ops.rs
+++ b/crates/server/src/handler/dashboard/config_ops.rs
@@ -63,7 +63,7 @@ pub async fn get_config(State(state): State<AppState>) -> impl IntoResponse {
         "host": config.host,
         "port": config.port,
         "tls": { "enable": config.tls.enable },
-        "api_keys_count": config.api_keys.len(),
+        "auth_keys_count": config.auth_keys.len(),
         "routing": config.routing,
         "retry": config.retry,
         "body_limit_mb": config.body_limit_mb,

--- a/crates/server/src/handler/dashboard/mod.rs
+++ b/crates/server/src/handler/dashboard/mod.rs
@@ -5,4 +5,5 @@ pub mod logs;
 pub mod providers;
 pub mod routing;
 pub mod system;
+pub mod tenant;
 pub mod websocket;

--- a/crates/server/src/handler/dashboard/providers.rs
+++ b/crates/server/src/handler/dashboard/providers.rs
@@ -189,6 +189,7 @@ pub async fn create_provider(
         cloak: Default::default(),
         wire_api: Default::default(),
         weight: 1,
+        region: None,
     };
 
     match update_config_file(&state, |config| match body.provider_type.as_str() {
@@ -354,7 +355,7 @@ async fn update_config_file(
     mutate(&mut config);
 
     // Rebuild derived fields
-    config.api_keys_set = config.api_keys.iter().cloned().collect();
+    config.auth_key_store = ai_proxy_core::auth_key::AuthKeyStore::new(config.auth_keys.clone());
 
     let yaml =
         serde_yml::to_string(&config).map_err(|e| format!("Failed to serialize config: {e}"))?;

--- a/crates/server/src/handler/dashboard/tenant.rs
+++ b/crates/server/src/handler/dashboard/tenant.rs
@@ -1,0 +1,44 @@
+use crate::AppState;
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::response::IntoResponse;
+use serde_json::json;
+
+/// GET /api/dashboard/tenants — list all tenants with summary metrics.
+pub async fn list_tenants(State(state): State<AppState>) -> impl IntoResponse {
+    let snap = state.metrics.tenant_snapshot();
+    let tenants: Vec<serde_json::Value> = if let Some(obj) = snap.as_object() {
+        obj.iter()
+            .map(|(id, metrics)| {
+                json!({
+                    "id": id,
+                    "requests": metrics["requests"],
+                    "tokens": metrics["tokens"],
+                    "cost_usd": metrics["cost_usd"],
+                })
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+    Json(json!({ "tenants": tenants }))
+}
+
+/// GET /api/dashboard/tenants/:id/metrics — detailed metrics for a tenant.
+pub async fn tenant_metrics(
+    State(state): State<AppState>,
+    Path(tenant_id): Path<String>,
+) -> impl IntoResponse {
+    let snap = state.metrics.tenant_snapshot();
+    if let Some(metrics) = snap.get(&tenant_id) {
+        Json(json!({
+            "tenant_id": tenant_id,
+            "metrics": metrics,
+        }))
+    } else {
+        Json(json!({
+            "tenant_id": tenant_id,
+            "metrics": null,
+        }))
+    }
+}

--- a/crates/server/src/handler/health.rs
+++ b/crates/server/src/handler/health.rs
@@ -13,3 +13,21 @@ pub async fn health() -> impl IntoResponse {
 pub async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
     Json(state.metrics.snapshot())
 }
+
+/// GET /metrics/prometheus — Prometheus text exposition format.
+pub async fn prometheus_metrics(State(state): State<AppState>) -> impl IntoResponse {
+    let cache_stats = state.response_cache.as_ref().map(|c| c.stats());
+
+    let cb_states = state.router.circuit_breaker_states();
+
+    let body =
+        ai_proxy_core::prometheus::render_metrics(&state.metrics, cache_stats.as_ref(), &cb_states);
+
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        body,
+    )
+}

--- a/crates/server/src/handler/messages.rs
+++ b/crates/server/src/handler/messages.rs
@@ -1,7 +1,9 @@
 use crate::AppState;
 use crate::dispatch::{DispatchRequest, dispatch};
+use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
 use ai_proxy_core::provider::Format;
+use axum::Extension;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::response::IntoResponse;
@@ -10,6 +12,7 @@ use bytes::Bytes;
 /// Claude Messages API passthrough (/v1/messages).
 pub async fn messages(
     State(state): State<AppState>,
+    Extension(ctx): Extension<RequestContext>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, ProxyError> {
@@ -26,6 +29,8 @@ pub async fn messages(
             allowed_formats: Some(vec![Format::Claude]),
             user_agent: parsed.user_agent,
             debug: parsed.debug,
+            api_key: ctx.auth_key.as_ref().map(|e| e.key.clone()),
+            client_region: ctx.client_region,
         },
     )
     .await

--- a/crates/server/src/handler/responses.rs
+++ b/crates/server/src/handler/responses.rs
@@ -1,6 +1,8 @@
 use crate::AppState;
+use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
 use ai_proxy_core::provider::Format;
+use axum::Extension;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use bytes::Bytes;
@@ -9,6 +11,7 @@ use bytes::Bytes;
 /// This endpoint forwards directly to upstream since there's no translation layer.
 pub async fn responses(
     State(state): State<AppState>,
+    Extension(ctx): Extension<RequestContext>,
     body: Bytes,
 ) -> Result<impl IntoResponse, ProxyError> {
     let req_value: serde_json::Value =
@@ -33,7 +36,7 @@ pub async fn responses(
 
     let auth = state
         .router
-        .pick(*target_format, &model, &[])
+        .pick(*target_format, &model, &[], ctx.client_region.as_deref())
         .ok_or_else(|| ProxyError::NoCredentials {
             provider: target_format.as_str().into(),
             model: model.clone(),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,10 +4,12 @@ pub mod handler;
 pub mod middleware;
 pub mod streaming;
 
+use ai_proxy_core::audit::AuditBackend;
+use ai_proxy_core::cache::ResponseCacheBackend;
 use ai_proxy_core::config::Config;
 use ai_proxy_core::cost::CostCalculator;
 use ai_proxy_core::metrics::Metrics;
-use ai_proxy_core::rate_limit::RateLimiter;
+use ai_proxy_core::rate_limit::CompositeRateLimiter;
 use ai_proxy_core::request_log::RequestLogStore;
 use ai_proxy_provider::ExecutorRegistry;
 use ai_proxy_provider::routing::CredentialRouter;
@@ -30,8 +32,10 @@ pub struct AppState {
     pub request_logs: Arc<RequestLogStore>,
     pub config_path: Arc<Mutex<String>>,
     pub credential_router: Arc<CredentialRouter>,
-    pub rate_limiter: Arc<RateLimiter>,
+    pub rate_limiter: Arc<CompositeRateLimiter>,
     pub cost_calculator: Arc<CostCalculator>,
+    pub response_cache: Option<Arc<dyn ResponseCacheBackend>>,
+    pub audit: Arc<dyn AuditBackend>,
     pub start_time: Instant,
 }
 
@@ -41,7 +45,11 @@ pub fn build_router(state: AppState) -> Router {
     // Public routes — no auth required
     let public_routes = Router::new()
         .route("/health", axum::routing::get(handler::health::health))
-        .route("/metrics", axum::routing::get(handler::health::metrics));
+        .route("/metrics", axum::routing::get(handler::health::metrics))
+        .route(
+            "/metrics/prometheus",
+            axum::routing::get(handler::health::prometheus_metrics),
+        );
 
     // Admin routes — no auth required (read-only)
     let admin_routes = Router::new()
@@ -118,7 +126,8 @@ pub fn build_router(state: AppState) -> Router {
         )
         .route(
             "/api/dashboard/auth-keys/{id}",
-            axum::routing::delete(handler::dashboard::auth_keys::delete_auth_key),
+            axum::routing::patch(handler::dashboard::auth_keys::update_auth_key)
+                .delete(handler::dashboard::auth_keys::delete_auth_key),
         )
         // Routing
         .route(
@@ -156,6 +165,15 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/api/dashboard/system/logs",
             axum::routing::get(handler::dashboard::system::system_logs),
+        )
+        // Tenants
+        .route(
+            "/api/dashboard/tenants",
+            axum::routing::get(handler::dashboard::tenant::list_tenants),
+        )
+        .route(
+            "/api/dashboard/tenants/{id}/metrics",
+            axum::routing::get(handler::dashboard::tenant::tenant_metrics),
         )
         .layer(axum_mw::from_fn_with_state(
             state.clone(),

--- a/crates/server/src/middleware/rate_limit.rs
+++ b/crates/server/src/middleware/rate_limit.rs
@@ -35,8 +35,8 @@ pub async fn rate_limit_middleware(
         )));
     }
 
-    // Record the request
-    state.rate_limiter.record(api_key.as_deref());
+    // Record the request (RPM dimension)
+    state.rate_limiter.record_request(api_key.as_deref());
 
     let mut response = next.run(request).await;
 

--- a/crates/server/src/middleware/request_context.rs
+++ b/crates/server/src/middleware/request_context.rs
@@ -16,7 +16,17 @@ pub async fn request_context_middleware(mut request: Request, next: Next) -> Res
                 .map(|s| s.to_string())
         });
 
-    let ctx = RequestContext::new(client_ip);
+    // Extract client region from CDN / custom headers
+    let client_region = request
+        .headers()
+        .get("x-client-region")
+        .or_else(|| request.headers().get("cf-ipcountry"))
+        .or_else(|| request.headers().get("x-vercel-ip-country"))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let mut ctx = RequestContext::new(client_ip);
+    ctx.client_region = client_region;
     request.extensions_mut().insert(ctx);
     next.run(request).await
 }

--- a/crates/server/src/middleware/request_logging.rs
+++ b/crates/server/src/middleware/request_logging.rs
@@ -1,12 +1,14 @@
 use crate::AppState;
 use crate::dispatch::DispatchMeta;
+use ai_proxy_core::audit::AuditEntry;
 use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::request_log::RequestLogEntry;
 use axum::extract::State;
 use axum::{extract::Request, middleware::Next, response::Response};
 
 /// Middleware that logs request/response with request context info.
-/// Also captures proxy requests (/v1/*) into the request log ring buffer.
+/// Also captures proxy requests (/v1/*) into the request log ring buffer
+/// and writes audit entries.
 pub async fn request_logging_middleware(
     State(state): State<AppState>,
     request: Request,
@@ -50,8 +52,36 @@ pub async fn request_logging_middleware(
         // Read dispatch metadata from response extensions (set by dispatch)
         let meta = response.extensions().get::<DispatchMeta>().cloned();
 
+        let api_key_id = ctx.as_ref().and_then(|c| c.api_key_id.clone());
+        let tenant_id = ctx.as_ref().and_then(|c| c.tenant_id.clone());
+        let client_ip_log = ctx.as_ref().and_then(|c| c.client_ip.clone());
+
         let entry = RequestLogEntry {
             timestamp: chrono::Utc::now().timestamp_millis(),
+            request_id: request_id.clone(),
+            method: method.to_string(),
+            path: uri.clone(),
+            status,
+            latency_ms: elapsed as u64,
+            provider: meta.as_ref().and_then(|m| m.provider.clone()),
+            model: meta.as_ref().and_then(|m| m.model.clone()),
+            input_tokens: meta.as_ref().and_then(|m| m.input_tokens),
+            output_tokens: meta.as_ref().and_then(|m| m.output_tokens),
+            cost: meta.as_ref().and_then(|m| m.cost),
+            error: if status >= 400 {
+                Some(format!("HTTP {status}"))
+            } else {
+                None
+            },
+            api_key_id: api_key_id.clone(),
+            tenant_id: tenant_id.clone(),
+            client_ip: client_ip_log.clone(),
+        };
+        state.request_logs.push(entry);
+
+        // Write audit entry
+        let audit_entry = AuditEntry {
+            timestamp: chrono::Utc::now(),
             request_id,
             method: method.to_string(),
             path: uri,
@@ -67,8 +97,14 @@ pub async fn request_logging_middleware(
             } else {
                 None
             },
+            api_key_id,
+            tenant_id,
+            client_ip: client_ip_log,
         };
-        state.request_logs.push(entry);
+        let audit = state.audit.clone();
+        tokio::spawn(async move {
+            audit.write(&audit_entry).await;
+        });
     }
 
     response

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -1,7 +1,7 @@
 use ai_proxy_core::config::{Config, DashboardConfig, RoutingStrategy};
 use ai_proxy_core::cost::CostCalculator;
 use ai_proxy_core::metrics::Metrics;
-use ai_proxy_core::rate_limit::RateLimiter;
+use ai_proxy_core::rate_limit::CompositeRateLimiter;
 use ai_proxy_core::request_log::RequestLogStore;
 use ai_proxy_provider::build_registry;
 use ai_proxy_provider::routing::CredentialRouter;
@@ -63,8 +63,10 @@ fn create_test_harness() -> TestHarness {
         request_logs,
         config_path: Arc::new(Mutex::new(config_path.to_str().unwrap().to_string())),
         credential_router,
-        rate_limiter: Arc::new(RateLimiter::new(&config.rate_limit)),
+        rate_limiter: Arc::new(CompositeRateLimiter::new(&config.rate_limit)),
         cost_calculator: Arc::new(CostCalculator::new(&config.model_prices)),
+        response_cache: None,
+        audit: Arc::new(ai_proxy_core::audit::NoopAuditBackend),
         start_time: Instant::now(),
     };
 
@@ -809,6 +811,9 @@ async fn test_log_stats_with_entries() {
             output_tokens: Some(50),
             error: None,
             cost: None,
+            api_key_id: None,
+            tenant_id: None,
+            client_ip: None,
         });
     harness
         .state
@@ -826,6 +831,9 @@ async fn test_log_stats_with_entries() {
             output_tokens: None,
             error: Some("Internal Server Error".to_string()),
             cost: None,
+            api_key_id: None,
+            tenant_id: None,
+            client_ip: None,
         });
 
     let req = authed_get("/api/dashboard/logs/stats", &token);
@@ -863,6 +871,9 @@ async fn test_query_logs_with_entries() {
                     None
                 },
                 cost: None,
+                api_key_id: None,
+                tenant_id: None,
+                client_ip: None,
             });
     }
 

--- a/crates/translator/src/lib.rs
+++ b/crates/translator/src/lib.rs
@@ -176,5 +176,18 @@ pub fn build_registry() -> TranslatorRegistry {
         },
     );
 
+    // OpenAI -> OpenAICompat passthrough (only replace model name, pass responses as-is)
+    reg.register(
+        Format::OpenAI,
+        Format::OpenAICompat,
+        |model, raw_json, _stream| replace_model_in_payload(raw_json, model),
+        ResponseTransform {
+            stream: |_model, _orig_req, _event_type, data, _state| {
+                Ok(vec![String::from_utf8_lossy(data).to_string()])
+            },
+            non_stream: |_model, _orig_req, data| Ok(String::from_utf8_lossy(data).to_string()),
+        },
+    );
+
     reg
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,12 @@
 //! Application struct that encapsulates server assembly and serving logic.
 
 use crate::cli::RunArgs;
+use ai_proxy_core::audit::{AuditBackend, FileAuditBackend, NoopAuditBackend};
+use ai_proxy_core::cache::{MokaCache, ResponseCacheBackend};
 use ai_proxy_core::config::{Config, ConfigWatcher};
 use ai_proxy_core::lifecycle::signal::SignalHandler;
 use ai_proxy_core::lifecycle::{self, Lifecycle};
+use ai_proxy_core::rate_limit::CompositeRateLimiter;
 use ai_proxy_provider::routing::CredentialRouter;
 use arc_swap::ArcSwap;
 use std::sync::{Arc, Mutex};
@@ -14,7 +17,7 @@ pub struct Application {
     app_router: axum::Router,
     config_path: String,
     credential_router: Arc<CredentialRouter>,
-    rate_limiter: Arc<ai_proxy_core::rate_limit::RateLimiter>,
+    rate_limiter: Arc<CompositeRateLimiter>,
     cost_calculator: Arc<ai_proxy_core::cost::CostCalculator>,
     lifecycle: Box<dyn Lifecycle>,
     shutdown_timeout: u64,
@@ -77,12 +80,40 @@ impl Application {
         );
 
         let request_log_capacity = config.dashboard.request_log_capacity;
-        let rate_limiter = Arc::new(ai_proxy_core::rate_limit::RateLimiter::new(
-            &config.rate_limit,
-        ));
+        let rate_limiter = Arc::new(CompositeRateLimiter::new(&config.rate_limit));
         let cost_calculator = Arc::new(ai_proxy_core::cost::CostCalculator::new(
             &config.model_prices,
         ));
+
+        // Initialize response cache (if enabled)
+        let response_cache: Option<Arc<dyn ResponseCacheBackend>> = if config.cache.enabled {
+            tracing::info!(
+                "Response cache enabled (max_entries={}, ttl={}s)",
+                config.cache.max_entries,
+                config.cache.ttl_secs
+            );
+            Some(Arc::new(MokaCache::new(&config.cache)))
+        } else {
+            None
+        };
+
+        // Initialize audit backend
+        let audit: Arc<dyn AuditBackend> = if config.audit.enabled {
+            match FileAuditBackend::new(config.audit.clone()) {
+                Ok(backend) => {
+                    tracing::info!("Audit logging enabled (dir={})", config.audit.dir);
+                    FileAuditBackend::spawn_cleanup_task(config.audit.clone());
+                    Arc::new(backend)
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to initialize audit backend: {e}, audit disabled");
+                    Arc::new(NoopAuditBackend)
+                }
+            }
+        } else {
+            Arc::new(NoopAuditBackend)
+        };
+
         let config = Arc::new(ArcSwap::from_pointee(config));
         let metrics = Arc::new(ai_proxy_core::metrics::Metrics::new());
         let request_logs = Arc::new(ai_proxy_core::request_log::RequestLogStore::new(
@@ -101,6 +132,8 @@ impl Application {
             credential_router: credential_router.clone(),
             rate_limiter: rate_limiter.clone(),
             cost_calculator: cost_calculator.clone(),
+            response_cache,
+            audit,
             start_time: Instant::now(),
         };
         let app_router = ai_proxy_server::build_router(state);

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -37,18 +37,7 @@ export function useWebSocket(): void {
           break;
         }
         case 'request_log': {
-          const raw = message.data as Record<string, unknown>;
-          addLog({
-            ...raw,
-            id: (raw.request_id || raw.id || '') as string,
-            input_tokens: (raw.input_tokens ?? 0) as number,
-            output_tokens: (raw.output_tokens ?? 0) as number,
-            provider: (raw.provider || '-') as string,
-            model: (raw.model || '-') as string,
-            timestamp: typeof raw.timestamp === 'number'
-              ? new Date(raw.timestamp as number).toISOString()
-              : raw.timestamp as string,
-          } as RequestLog);
+          addLog(message.data as RequestLog);
           break;
         }
       }

--- a/web/src/pages/AuthKeys.tsx
+++ b/web/src/pages/AuthKeys.tsx
@@ -42,7 +42,7 @@ export default function AuthKeys() {
     try {
       const response = await authKeysApi.create({
         name: newKeyName,
-        expires_in_days: newKeyExpiry ? parseInt(newKeyExpiry, 10) : undefined,
+        expires_at: newKeyExpiry ? new Date(Date.now() + parseInt(newKeyExpiry, 10) * 86400000).toISOString() : undefined,
       });
 
       setCreatedKey(response.data.key);
@@ -58,7 +58,7 @@ export default function AuthKeys() {
     }
   };
 
-  const handleDelete = async (id: string, name: string) => {
+  const handleDelete = async (id: number, name: string) => {
     if (!window.confirm(`Delete API key "${name}"? This cannot be undone.`)) {
       return;
     }
@@ -111,9 +111,9 @@ export default function AuthKeys() {
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Key Prefix</th>
-                <th>Created</th>
-                <th>Last Used</th>
+                <th>Key</th>
+                <th>Tenant</th>
+                <th>Models</th>
                 <th>Expires</th>
                 <th>Actions</th>
               </tr>
@@ -139,15 +139,13 @@ export default function AuthKeys() {
               ) : (
                 keys.map((key) => (
                   <tr key={key.id}>
-                    <td className="text-bold">{key.name || '-'}</td>
-                    <td className="text-mono">{key.key_prefix || '-'}</td>
-                    <td className="text-nowrap">
-                      {key.created_at ? new Date(key.created_at).toLocaleDateString() : '-'}
-                    </td>
-                    <td className="text-nowrap">
-                      {key.last_used_at
-                        ? new Date(key.last_used_at).toLocaleDateString()
-                        : 'Never'}
+                    <td className="text-bold">{key.name ?? '-'}</td>
+                    <td className="text-mono">{key.key_masked || '-'}</td>
+                    <td>{key.tenant_id ?? '-'}</td>
+                    <td>
+                      {key.allowed_models.length > 0
+                        ? key.allowed_models.join(', ')
+                        : 'All'}
                     </td>
                     <td className="text-nowrap">
                       {key.expires_at
@@ -157,7 +155,7 @@ export default function AuthKeys() {
                     <td>
                       <button
                         className="btn btn-ghost btn-sm btn-danger-ghost"
-                        onClick={() => handleDelete(key.id, key.name)}
+                        onClick={() => handleDelete(key.id, key.name ?? 'Unnamed')}
                         title="Delete"
                       >
                         <Trash2 size={14} />

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -70,9 +70,9 @@ export default function Providers() {
   const openEdit = (provider: Provider) => {
     setEditId(provider.id);
     setForm({
-      name: provider.name,
+      name: provider.name ?? '',
       provider_type: provider.provider_type,
-      base_url: provider.base_url,
+      base_url: provider.base_url ?? '',
       api_key: '',
       enabled: provider.enabled,
       models: provider.models.join(', '),
@@ -210,7 +210,7 @@ export default function Providers() {
                         {PROVIDER_TYPES.find((t) => t.value === provider.provider_type)?.label ?? provider.provider_type}
                       </span>
                     </td>
-                    <td className="text-mono text-ellipsis" title={provider.base_url}>
+                    <td className="text-mono text-ellipsis" title={provider.base_url ?? undefined}>
                       {provider.base_url}
                     </td>
                     <td>
@@ -247,7 +247,7 @@ export default function Providers() {
                         </button>
                         <button
                           className="btn btn-ghost btn-sm btn-danger-ghost"
-                          onClick={() => handleDelete(provider.id, provider.name)}
+                          onClick={() => handleDelete(provider.id, provider.name ?? 'Unnamed')}
                           title="Delete"
                         >
                           <Trash2 size={14} />

--- a/web/src/pages/RequestLogs.tsx
+++ b/web/src/pages/RequestLogs.tsx
@@ -148,7 +148,7 @@ export default function RequestLogs() {
                 </tr>
               ) : (
                 logs.map((log) => (
-                  <tr key={log.id}>
+                  <tr key={log.request_id}>
                     <td className="text-nowrap">
                       {new Date(log.timestamp).toLocaleString()}
                     </td>
@@ -167,7 +167,7 @@ export default function RequestLogs() {
                     </td>
                     <td className="text-nowrap">{log.latency_ms}ms</td>
                     <td className="text-nowrap">
-                      {log.input_tokens + log.output_tokens}
+                      {(log.input_tokens ?? 0) + (log.output_tokens ?? 0)}
                     </td>
                   </tr>
                 ))

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -39,7 +39,9 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    // Skip token refresh for login/refresh endpoints — let the caller handle the error
+    const isAuthEndpoint = originalRequest.url?.includes('/auth/login') || originalRequest.url?.includes('/auth/refresh');
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthEndpoint) {
       originalRequest._retry = true;
 
       try {
@@ -109,9 +111,7 @@ export const providersApi = {
     data: {
       ...res.data,
       provider_type: providerTypeToFrontend(res.data.provider_type),
-      enabled: (res.data as Record<string, unknown>).disabled !== undefined
-        ? !(res.data as Record<string, unknown>).disabled
-        : true,
+      enabled: res.data.disabled !== undefined ? !res.data.disabled : true,
     },
   })),
 
@@ -140,12 +140,15 @@ export const authKeysApi = {
       const raw = res.data.auth_keys || res.data;
       const data = Array.isArray(raw)
         ? raw.map((item: Record<string, unknown>) => ({
-            id: String(item.id ?? ''),
-            name: (item.name as string) || '',
-            key_prefix: (item.key_prefix as string) || (item.key_masked as string) || '',
-            created_at: (item.created_at as string) || '',
-            last_used_at: (item.last_used_at as string) || null,
-            expires_at: (item.expires_at as string) || null,
+            id: Number(item.id ?? 0),
+            key_masked: (item.key_masked as string) || '',
+            name: (item.name as string | null) ?? null,
+            tenant_id: (item.tenant_id as string | null) ?? null,
+            allowed_models: (item.allowed_models as string[]) || [],
+            rate_limit: (item.rate_limit as AuthKey['rate_limit']) ?? null,
+            budget: (item.budget as AuthKey['budget']) ?? null,
+            expires_at: (item.expires_at as string | null) ?? null,
+            metadata: (item.metadata as Record<string, string>) || {},
           }))
         : [];
       return { ...res, data };
@@ -154,7 +157,7 @@ export const authKeysApi = {
   create: (data: AuthKeyCreateRequest) =>
     api.post<AuthKeyCreateResponse>('/auth-keys', data),
 
-  delete: (id: string) => api.delete(`/auth-keys/${id}`),
+  delete: (id: number | string) => api.delete(`/auth-keys/${id}`),
 };
 
 // ── Routing ──

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -22,14 +22,17 @@ export interface AuthState {
 
 export interface Provider {
   id: string;
-  name: string;
+  name: string | null;
   provider_type: ProviderType;
-  base_url: string;
+  base_url: string | null;
+  api_key_masked: string;
   api_key?: string;
   enabled: boolean;
+  disabled: boolean;
   models: string[];
-  created_at: string;
-  updated_at: string;
+  models_count: number;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export type ProviderType = 'openai' | 'claude' | 'gemini' | 'openai_compat';
@@ -54,24 +57,38 @@ export interface ProviderUpdateRequest {
 // ── Auth Keys ──
 
 export interface AuthKey {
-  id: string;
-  name: string;
-  key_prefix: string;
-  created_at: string;
-  last_used_at: string | null;
+  id: number;
+  key_masked: string;
+  name: string | null;
+  tenant_id: string | null;
+  allowed_models: string[];
+  rate_limit: KeyRateLimitConfig | null;
+  budget: BudgetConfig | null;
   expires_at: string | null;
+  metadata: Record<string, string>;
+}
+
+export interface KeyRateLimitConfig {
+  rpm?: number;
+  tpm?: number;
+  cost_per_day_usd?: number;
+}
+
+export interface BudgetConfig {
+  total_usd: number;
+  period: 'daily' | 'monthly';
 }
 
 export interface AuthKeyCreateRequest {
-  name: string;
-  expires_in_days?: number;
+  name?: string;
+  tenant_id?: string;
+  allowed_models?: string[];
+  expires_at?: string;
 }
 
 export interface AuthKeyCreateResponse {
-  id: string;
-  name: string;
   key: string;
-  expires_at: string | null;
+  message: string;
 }
 
 // ── Routing ──
@@ -103,6 +120,7 @@ export interface MetricsSnapshot {
   avg_latency_ms: number;
   error_rate: number;
   uptime_seconds: number;
+  [key: string]: unknown;
 }
 
 export interface MetricsTimeSeries {
@@ -139,17 +157,22 @@ export interface MetricsState {
 // ── Request Logs ──
 
 export interface RequestLog {
-  id: string;
-  timestamp: string;
+  request_id: string;
+  timestamp: number;
   method: string;
   path: string;
-  provider: string;
-  model: string;
+  provider: string | null;
+  model: string | null;
   status: number;
   latency_ms: number;
-  input_tokens: number;
-  output_tokens: number;
-  error?: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cost: number | null;
+  error?: string | null;
+  api_key_id: string | null;
+  tenant_id: string | null;
+  client_ip: string | null;
+  [key: string]: unknown;
 }
 
 export interface RequestLogFilter {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
         target: 'http://localhost:8317',
         changeOrigin: true,
       },
+      '/metrics': {
+        target: 'http://localhost:8317',
+        changeOrigin: true,
+      },
       '/ws': {
         target: 'ws://localhost:8317',
         ws: true,


### PR DESCRIPTION
## Summary
- Add 6 new core modules: structured auth keys with multi-tenant support, three-state circuit breaker, response cache (Moka LRU), JSONL audit logging, Prometheus metrics endpoint, and secret resolution (env:///file://)
- Rewrite rate limiting with trait-based multi-dimensional system (RPM + TPM + Cost), enhance routing with EWMA latency-aware and geo-aware strategies
- Fix frontend login error display, add OpenAI→OpenAICompat translator, and implement cache write-through in dispatch

## Changes

### `crates/core/` — New modules
- `auth_key.rs`: `AuthKeyEntry` with tenant_id, allowed_models (glob), rate_limit, budget, expiry; `AuthKeyStore` for O(1) lookup
- `circuit_breaker.rs`: `CircuitBreakerPolicy` trait + `ThreeStateCircuitBreaker` (Closed/Open/HalfOpen) + `NoopCircuitBreaker`
- `cache.rs`: `ResponseCacheBackend` trait + `MokaCache` (LRU + TTL), `CacheKey` (SHA-256)
- `audit.rs`: `AuditBackend` trait + `FileAuditBackend` (JSONL, daily rotation) + `NoopAuditBackend`
- `prometheus.rs`: Hand-rolled Prometheus text format — requests, errors, tokens, cost, duration histogram, cache, CB state
- `secret.rs`: `resolve()` for `env://` and `file://` secret references

### `crates/core/` — Enhanced modules
- `config.rs`: `auth-keys` replaces `api-keys`; new config sections for circuit-breaker, cache, audit; `RoutingStrategy` gains `LatencyAware` + `GeoAware`; `RetryConfig` gains `jitter_factor`
- `rate_limit.rs`: Rewritten with `RateLimitDimension` trait; `SlidingWindowLimiter` (RPM + TPM), `CostLimiter`, `CompositeRateLimiter`
- `metrics.rs`: TTFT histogram, per-tenant counters, cache hit/miss, prometheus accessors
- `error.rs`: `ModelNotAllowed` (403), `KeyExpired` (401)

### `crates/provider/` — Routing
- `routing.rs`: EWMA latency tracking, `LatencyAware` + `GeoAware` strategies, circuit breaker integration

### `crates/server/` — Server
- `auth.rs`: `AuthKeyStore` lookup, expiry check, model ACL
- `dispatch.rs`: Cache lookup/write, TTFT tracking, latency recording, CB success/failure
- `handler/health.rs`: `/metrics/prometheus` endpoint
- `handler/dashboard/tenant.rs`: Tenant dashboard endpoints
- `handler/dashboard/auth_keys.rs`: Rewritten for structured `AuthKeyEntry` CRUD

### `crates/translator/`
- `lib.rs`: Register `OpenAI→OpenAICompat` passthrough translator (fixes model prefix stripping)

### `web/` — Frontend
- `services/api.ts`: Fix 401 interceptor to skip auth endpoints (login error was swallowed)
- `vite.config.ts`: Add `/metrics` proxy rule

## Spec & Reference Doc Impact
- Related to planned SPECs 015-020 (auth keys, circuit breaker, cache, audit, prometheus, rate limiting)
- `config.example.yaml` updated with all new config sections

## Test Plan
- [x] `make lint` passes (clippy + fmt)
- [x] `make test` passes (131 tests: 88 core + 5 provider + 38 dashboard integration)
- [x] `npx tsc --noEmit` passes (frontend type check)
- [x] 33/33 Playwright E2E dashboard tests pass
- [x] Manual E2E testing with real Bailian API key (non-stream, stream, cache hit, model ACL, auth expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)