### PR TITLE
refactor: extract translator common helpers, deduplicate server code

### DIFF
--- a/crates/server/src/dispatch.rs
+++ b/crates/server/src/dispatch.rs
@@ -109,6 +109,27 @@ fn inject_dispatch_meta(
     });
 }
 
+/// Build a non-stream JSON response with passthrough headers.
+fn build_json_response(
+    translated: &str,
+    passthrough_headers: &[String],
+    upstream_headers: &std::collections::HashMap<String, String>,
+) -> Result<Response, ProxyError> {
+    let mut builder = axum::http::Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, "application/json");
+
+    for header_name in passthrough_headers {
+        if let Some(val) = upstream_headers.get(header_name) {
+            builder = builder.header(header_name.as_str(), val.as_str());
+        }
+    }
+
+    builder
+        .body(axum::body::Body::from(translated.to_string()))
+        .map_err(|e| ProxyError::Internal(format!("failed to build response: {e}")))
+        .map(IntoResponse::into_response)
+}
+
 /// Inject debug headers into a response if debug mode is enabled.
 fn inject_debug_headers(response: &mut Response, debug: &DispatchDebug) {
     let headers = response.headers_mut();
@@ -476,19 +497,11 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                                         &response.payload,
                                     )?;
 
-                                    let mut builder = axum::http::Response::builder()
-                                        .header(axum::http::header::CONTENT_TYPE, "application/json");
-
-                                    for header_name in &config.passthrough_headers {
-                                        if let Some(val) = response.headers.get(header_name) {
-                                            builder = builder.header(header_name.as_str(), val.as_str());
-                                        }
-                                    }
-
-                                    let mut resp = builder
-                                        .body(axum::body::Body::from(translated.clone()))
-                                        .map_err(|e| ProxyError::Internal(format!("failed to build response: {e}")))?
-                                        .into_response();
+                                    let mut resp = build_json_response(
+                                        &translated,
+                                        &config.passthrough_headers,
+                                        &response.headers,
+                                    )?;
                                     inject_dispatch_meta(
                                         &mut resp,
                                         &debug_info,
@@ -575,21 +588,11 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                                 cache.insert(cache_key, cached).await;
                             }
 
-                            let mut builder = axum::http::Response::builder()
-                                .header(axum::http::header::CONTENT_TYPE, "application/json");
-
-                            for header_name in &config.passthrough_headers {
-                                if let Some(val) = response.headers.get(header_name) {
-                                    builder = builder.header(header_name.as_str(), val.as_str());
-                                }
-                            }
-
-                            let mut resp = builder
-                                .body(axum::body::Body::from(translated.clone()))
-                                .map_err(|e| {
-                                    ProxyError::Internal(format!("failed to build response: {e}"))
-                                })?
-                                .into_response();
+                            let mut resp = build_json_response(
+                                &translated,
+                                &config.passthrough_headers,
+                                &response.headers,
+                            )?;
                             inject_dispatch_meta(
                                 &mut resp,
                                 &debug_info,

--- a/crates/server/src/handler/chat_completions.rs
+++ b/crates/server/src/handler/chat_completions.rs
@@ -1,12 +1,11 @@
 use crate::AppState;
-use crate::dispatch::{DispatchRequest, dispatch};
 use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
 use ai_proxy_core::provider::Format;
 use axum::Extension;
 use axum::extract::State;
 use axum::http::HeaderMap;
-use axum::response::IntoResponse;
+use axum::response::Response;
 use bytes::Bytes;
 
 pub async fn chat_completions(
@@ -14,23 +13,6 @@ pub async fn chat_completions(
     Extension(ctx): Extension<RequestContext>,
     headers: HeaderMap,
     body: Bytes,
-) -> Result<impl IntoResponse, ProxyError> {
-    let parsed = super::parse_request(&headers, &body)?;
-
-    dispatch(
-        &state,
-        DispatchRequest {
-            source_format: Format::OpenAI,
-            model: parsed.model,
-            models: parsed.models,
-            stream: parsed.stream,
-            body,
-            allowed_formats: None,
-            user_agent: parsed.user_agent,
-            debug: parsed.debug,
-            api_key: ctx.auth_key.as_ref().map(|e| e.key.clone()),
-            client_region: ctx.client_region,
-        },
-    )
-    .await
+) -> Result<Response, ProxyError> {
+    super::dispatch_api_request(&state, &ctx, &headers, body, Format::OpenAI, None).await
 }

--- a/crates/server/src/handler/dashboard/config_ops.rs
+++ b/crates/server/src/handler/dashboard/config_ops.rs
@@ -42,7 +42,7 @@ pub async fn reload_config(State(state): State<AppState>) -> impl IntoResponse {
 
     match ai_proxy_core::config::Config::load(&config_path) {
         Ok(new_cfg) => {
-            state.credential_router.update_from_config(&new_cfg);
+            state.router.update_from_config(&new_cfg);
             state.config.store(std::sync::Arc::new(new_cfg));
             (
                 StatusCode::OK,

--- a/crates/server/src/handler/messages.rs
+++ b/crates/server/src/handler/messages.rs
@@ -1,12 +1,11 @@
 use crate::AppState;
-use crate::dispatch::{DispatchRequest, dispatch};
 use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
 use ai_proxy_core::provider::Format;
 use axum::Extension;
 use axum::extract::State;
 use axum::http::HeaderMap;
-use axum::response::IntoResponse;
+use axum::response::Response;
 use bytes::Bytes;
 
 /// Claude Messages API passthrough (/v1/messages).
@@ -15,23 +14,14 @@ pub async fn messages(
     Extension(ctx): Extension<RequestContext>,
     headers: HeaderMap,
     body: Bytes,
-) -> Result<impl IntoResponse, ProxyError> {
-    let parsed = super::parse_request(&headers, &body)?;
-
-    dispatch(
+) -> Result<Response, ProxyError> {
+    super::dispatch_api_request(
         &state,
-        DispatchRequest {
-            source_format: Format::Claude,
-            model: parsed.model,
-            models: parsed.models,
-            stream: parsed.stream,
-            body,
-            allowed_formats: Some(vec![Format::Claude]),
-            user_agent: parsed.user_agent,
-            debug: parsed.debug,
-            api_key: ctx.auth_key.as_ref().map(|e| e.key.clone()),
-            client_region: ctx.client_region,
-        },
+        &ctx,
+        &headers,
+        body,
+        Format::Claude,
+        Some(vec![Format::Claude]),
     )
     .await
 }

--- a/crates/server/src/handler/mod.rs
+++ b/crates/server/src/handler/mod.rs
@@ -6,8 +6,13 @@ pub mod messages;
 pub mod models;
 pub mod responses;
 
+use crate::AppState;
+use crate::dispatch::{DispatchRequest, dispatch};
+use ai_proxy_core::context::RequestContext;
 use ai_proxy_core::error::ProxyError;
+use ai_proxy_core::provider::Format;
 use axum::http::HeaderMap;
+use axum::response::Response;
 use bytes::Bytes;
 
 #[derive(Debug)]
@@ -66,6 +71,35 @@ pub(crate) fn parse_request(
         user_agent,
         debug,
     })
+}
+
+/// Shared dispatch logic for chat_completions and messages handlers.
+pub(crate) async fn dispatch_api_request(
+    state: &AppState,
+    ctx: &RequestContext,
+    headers: &HeaderMap,
+    body: Bytes,
+    source_format: Format,
+    allowed_formats: Option<Vec<Format>>,
+) -> Result<Response, ProxyError> {
+    let parsed = parse_request(headers, &body)?;
+
+    dispatch(
+        state,
+        DispatchRequest {
+            source_format,
+            model: parsed.model,
+            models: parsed.models,
+            stream: parsed.stream,
+            body,
+            allowed_formats,
+            user_agent: parsed.user_agent,
+            debug: parsed.debug,
+            api_key: ctx.auth_key.as_ref().map(|e| e.key.clone()),
+            client_region: ctx.client_region.clone(),
+        },
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -31,7 +31,6 @@ pub struct AppState {
     pub metrics: Arc<Metrics>,
     pub request_logs: Arc<RequestLogStore>,
     pub config_path: Arc<Mutex<String>>,
-    pub credential_router: Arc<CredentialRouter>,
     pub rate_limiter: Arc<CompositeRateLimiter>,
     pub cost_calculator: Arc<CostCalculator>,
     pub response_cache: Option<Arc<dyn ResponseCacheBackend>>,

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -62,7 +62,6 @@ fn create_test_harness() -> TestHarness {
         metrics,
         request_logs,
         config_path: Arc::new(Mutex::new(config_path.to_str().unwrap().to_string())),
-        credential_router,
         rate_limiter: Arc::new(CompositeRateLimiter::new(&config.rate_limit)),
         cost_calculator: Arc::new(CostCalculator::new(&config.model_prices)),
         response_cache: None,

--- a/crates/translator/src/claude_to_openai.rs
+++ b/crates/translator/src/claude_to_openai.rs
@@ -1,4 +1,8 @@
 use crate::TranslateState;
+use crate::common::{
+    build_assistant_message, build_openai_chunk, build_openai_response, build_tool_call,
+    build_tool_call_delta, map_claude_finish_reason,
+};
 use ai_proxy_core::error::ProxyError;
 use serde_json::{Value, json};
 
@@ -35,28 +39,12 @@ pub fn translate_non_stream(
                     }
                 }
                 "tool_use" => {
-                    let tc_id = block
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let name = block
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                    let tc_id = block.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                    let name = block.get("name").and_then(|v| v.as_str()).unwrap_or("");
                     let input = block.get("input").cloned().unwrap_or(json!({}));
                     let arguments = serde_json::to_string(&input).unwrap_or_default();
 
-                    tool_calls.push(json!({
-                        "id": tc_id,
-                        "type": "function",
-                        "function": {
-                            "name": name,
-                            "arguments": arguments,
-                        },
-                        "index": tool_call_index,
-                    }));
+                    tool_calls.push(build_tool_call(tc_id, name, &arguments, tool_call_index));
                     tool_call_index += 1;
                 }
                 _ => {}
@@ -64,30 +52,20 @@ pub fn translate_non_stream(
         }
     }
 
-    // Map stop_reason to finish_reason
-    let finish_reason = match resp.get("stop_reason").and_then(|v| v.as_str()) {
-        Some("end_turn") => "stop",
-        Some("max_tokens") => "length",
-        Some("tool_use") => "tool_calls",
-        Some("stop_sequence") => "stop",
-        _ => "stop",
-    };
+    let finish_reason = map_claude_finish_reason(resp.get("stop_reason").and_then(|v| v.as_str()));
 
     let content_str = text_parts.join("");
-    let content_val = if content_str.is_empty() && !tool_calls.is_empty() {
-        Value::Null
+    let content = if content_str.is_empty() {
+        None
     } else {
-        Value::String(content_str)
+        Some(content_str.as_str())
     };
-
-    let mut message = json!({
-        "role": "assistant",
-        "content": content_val,
-    });
-
-    if !tool_calls.is_empty() {
-        message["tool_calls"] = Value::Array(tool_calls);
-    }
+    let tc = if tool_calls.is_empty() {
+        None
+    } else {
+        Some(tool_calls)
+    };
+    let message = build_assistant_message(content, tc);
 
     // Map usage
     let usage = if let Some(u) = resp.get("usage") {
@@ -102,22 +80,7 @@ pub fn translate_non_stream(
         None
     };
 
-    let mut openai_resp = json!({
-        "id": id,
-        "object": "chat.completion",
-        "created": created,
-        "model": model,
-        "choices": [{
-            "index": 0,
-            "message": message,
-            "finish_reason": finish_reason,
-        }],
-    });
-
-    if let Some(usage) = usage {
-        openai_resp["usage"] = usage;
-    }
-
+    let openai_resp = build_openai_response(&id, created, &model, message, finish_reason, usage);
     serde_json::to_string(&openai_resp).map_err(|e| ProxyError::Translation(e.to_string()))
 }
 
@@ -155,17 +118,13 @@ pub fn translate_stream(
             }
 
             // Emit initial chunk with role
-            let chunk = json!({
-                "id": state.response_id,
-                "object": "chat.completion.chunk",
-                "created": state.created,
-                "model": state.model,
-                "choices": [{
-                    "index": 0,
-                    "delta": {"role": "assistant", "content": ""},
-                    "finish_reason": null,
-                }],
-            });
+            let chunk = build_openai_chunk(
+                &state.response_id,
+                state.created,
+                &state.model,
+                json!({"role": "assistant", "content": ""}),
+                None,
+            );
             state.sent_role = true;
             chunks.push(serde_json::to_string(&chunk)?);
         }
@@ -177,38 +136,24 @@ pub fn translate_stream(
                 let block_type = cb.get("type").and_then(|t| t.as_str()).unwrap_or("");
                 if block_type == "tool_use" {
                     state.current_tool_call_index += 1;
-                    let tc_id = cb
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let name = cb
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                    let tc_id = cb.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                    let name = cb.get("name").and_then(|v| v.as_str()).unwrap_or("");
 
-                    let chunk = json!({
-                        "id": state.response_id,
-                        "object": "chat.completion.chunk",
-                        "created": state.created,
-                        "model": state.model,
-                        "choices": [{
-                            "index": 0,
-                            "delta": {
-                                "tool_calls": [{
-                                    "index": state.current_tool_call_index,
-                                    "id": tc_id,
-                                    "type": "function",
-                                    "function": {
-                                        "name": name,
-                                        "arguments": "",
-                                    },
-                                }],
-                            },
-                            "finish_reason": null,
-                        }],
+                    let delta = json!({
+                        "tool_calls": [build_tool_call_delta(
+                            state.current_tool_call_index,
+                            tc_id,
+                            name,
+                            "",
+                        )],
                     });
+                    let chunk = build_openai_chunk(
+                        &state.response_id,
+                        state.created,
+                        &state.model,
+                        delta,
+                        None,
+                    );
                     chunks.push(serde_json::to_string(&chunk)?);
                 }
             }
@@ -220,17 +165,13 @@ pub fn translate_stream(
                 match delta_type {
                     "text_delta" => {
                         let text = delta.get("text").and_then(|t| t.as_str()).unwrap_or("");
-                        let chunk = json!({
-                            "id": state.response_id,
-                            "object": "chat.completion.chunk",
-                            "created": state.created,
-                            "model": state.model,
-                            "choices": [{
-                                "index": 0,
-                                "delta": {"content": text},
-                                "finish_reason": null,
-                            }],
-                        });
+                        let chunk = build_openai_chunk(
+                            &state.response_id,
+                            state.created,
+                            &state.model,
+                            json!({"content": text}),
+                            None,
+                        );
                         chunks.push(serde_json::to_string(&chunk)?);
                     }
                     "input_json_delta" => {
@@ -238,24 +179,20 @@ pub fn translate_stream(
                             .get("partial_json")
                             .and_then(|t| t.as_str())
                             .unwrap_or("");
-                        let chunk = json!({
-                            "id": state.response_id,
-                            "object": "chat.completion.chunk",
-                            "created": state.created,
-                            "model": state.model,
-                            "choices": [{
-                                "index": 0,
-                                "delta": {
-                                    "tool_calls": [{
-                                        "index": state.current_tool_call_index,
-                                        "function": {
-                                            "arguments": partial,
-                                        },
-                                    }],
-                                },
-                                "finish_reason": null,
-                            }],
-                        });
+                        let chunk = build_openai_chunk(
+                            &state.response_id,
+                            state.created,
+                            &state.model,
+                            json!({
+                                "tool_calls": [{
+                                    "index": state.current_tool_call_index,
+                                    "function": {
+                                        "arguments": partial,
+                                    },
+                                }],
+                            }),
+                            None,
+                        );
                         chunks.push(serde_json::to_string(&chunk)?);
                     }
                     _ => {}
@@ -265,25 +202,16 @@ pub fn translate_stream(
 
         Some("message_delta") => {
             if let Some(delta) = event.get("delta") {
-                let finish_reason = match delta.get("stop_reason").and_then(|v| v.as_str()) {
-                    Some("end_turn") => "stop",
-                    Some("max_tokens") => "length",
-                    Some("tool_use") => "tool_calls",
-                    Some("stop_sequence") => "stop",
-                    _ => "stop",
-                };
+                let finish_reason =
+                    map_claude_finish_reason(delta.get("stop_reason").and_then(|v| v.as_str()));
 
-                let mut chunk = json!({
-                    "id": state.response_id,
-                    "object": "chat.completion.chunk",
-                    "created": state.created,
-                    "model": state.model,
-                    "choices": [{
-                        "index": 0,
-                        "delta": {},
-                        "finish_reason": finish_reason,
-                    }],
-                });
+                let mut chunk = build_openai_chunk(
+                    &state.response_id,
+                    state.created,
+                    &state.model,
+                    json!({}),
+                    Some(finish_reason),
+                );
 
                 // Include usage if available
                 if let Some(usage) = event.get("usage") {
@@ -318,7 +246,6 @@ pub fn translate_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_json_diff::assert_json_eq;
 
     // ==================
     // Non-stream tests
@@ -379,7 +306,7 @@ mod tests {
         // arguments should be a JSON string
         let args: Value =
             serde_json::from_str(tool_calls[0]["function"]["arguments"].as_str().unwrap()).unwrap();
-        assert_json_eq!(args, json!({"city": "SF"}));
+        assert_eq!(args, json!({"city": "SF"}));
     }
 
     #[test]

--- a/crates/translator/src/common.rs
+++ b/crates/translator/src/common.rs
@@ -1,0 +1,231 @@
+use serde_json::{Value, json};
+
+/// Map Claude stop_reason to OpenAI finish_reason.
+pub fn map_claude_finish_reason(reason: Option<&str>) -> &'static str {
+    match reason {
+        Some("end_turn") => "stop",
+        Some("max_tokens") => "length",
+        Some("tool_use") => "tool_calls",
+        Some("stop_sequence") => "stop",
+        _ => "stop",
+    }
+}
+
+/// Map Gemini finishReason to OpenAI finish_reason.
+pub fn map_gemini_finish_reason(reason: Option<&str>) -> &'static str {
+    match reason {
+        Some("STOP") => "stop",
+        Some("MAX_TOKENS") => "length",
+        Some("SAFETY") => "content_filter",
+        Some("RECITATION") => "content_filter",
+        _ => "stop",
+    }
+}
+
+/// Build an OpenAI streaming chunk wrapper.
+pub fn build_openai_chunk(
+    response_id: &str,
+    created: i64,
+    model: &str,
+    delta: Value,
+    finish_reason: Option<&str>,
+) -> Value {
+    json!({
+        "id": response_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": delta,
+            "finish_reason": finish_reason,
+        }],
+    })
+}
+
+/// Build a complete OpenAI non-stream response.
+pub fn build_openai_response(
+    id: &str,
+    created: i64,
+    model: &str,
+    message: Value,
+    finish_reason: &str,
+    usage: Option<Value>,
+) -> Value {
+    let mut resp = json!({
+        "id": id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason,
+        }],
+    });
+    if let Some(usage) = usage {
+        resp["usage"] = usage;
+    }
+    resp
+}
+
+/// Build a tool call object for non-stream responses.
+pub fn build_tool_call(id: &str, name: &str, arguments: &str, index: u32) -> Value {
+    json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        },
+        "index": index,
+    })
+}
+
+/// Build a tool call delta for streaming (initial tool_call with name).
+pub fn build_tool_call_delta(index: i32, id: &str, name: &str, arguments: &str) -> Value {
+    json!({
+        "index": index,
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        },
+    })
+}
+
+/// Build an assistant message with optional text content and optional tool_calls.
+pub fn build_assistant_message(content: Option<&str>, tool_calls: Option<Vec<Value>>) -> Value {
+    let content_val = match (content, &tool_calls) {
+        (Some(c), _) if !c.is_empty() => Value::String(c.to_string()),
+        (_, Some(tc)) if !tc.is_empty() => Value::Null,
+        _ => Value::String(String::new()),
+    };
+
+    let mut message = json!({
+        "role": "assistant",
+        "content": content_val,
+    });
+
+    if let Some(tool_calls) = tool_calls
+        && !tool_calls.is_empty()
+    {
+        message["tool_calls"] = Value::Array(tool_calls);
+    }
+
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_claude_finish_reason() {
+        assert_eq!(map_claude_finish_reason(Some("end_turn")), "stop");
+        assert_eq!(map_claude_finish_reason(Some("max_tokens")), "length");
+        assert_eq!(map_claude_finish_reason(Some("tool_use")), "tool_calls");
+        assert_eq!(map_claude_finish_reason(Some("stop_sequence")), "stop");
+        assert_eq!(map_claude_finish_reason(None), "stop");
+        assert_eq!(map_claude_finish_reason(Some("unknown")), "stop");
+    }
+
+    #[test]
+    fn test_map_gemini_finish_reason() {
+        assert_eq!(map_gemini_finish_reason(Some("STOP")), "stop");
+        assert_eq!(map_gemini_finish_reason(Some("MAX_TOKENS")), "length");
+        assert_eq!(map_gemini_finish_reason(Some("SAFETY")), "content_filter");
+        assert_eq!(
+            map_gemini_finish_reason(Some("RECITATION")),
+            "content_filter"
+        );
+        assert_eq!(map_gemini_finish_reason(None), "stop");
+    }
+
+    #[test]
+    fn test_build_openai_chunk() {
+        let chunk = build_openai_chunk("id-1", 1000, "gpt-4", json!({"content": "hi"}), None);
+        assert_eq!(chunk["id"], "id-1");
+        assert_eq!(chunk["object"], "chat.completion.chunk");
+        assert_eq!(chunk["created"], 1000);
+        assert_eq!(chunk["model"], "gpt-4");
+        assert_eq!(chunk["choices"][0]["delta"]["content"], "hi");
+        assert_eq!(chunk["choices"][0]["finish_reason"], Value::Null);
+    }
+
+    #[test]
+    fn test_build_openai_chunk_with_finish() {
+        let chunk = build_openai_chunk("id-1", 1000, "gpt-4", json!({}), Some("stop"));
+        assert_eq!(chunk["choices"][0]["finish_reason"], "stop");
+    }
+
+    #[test]
+    fn test_build_openai_response() {
+        let msg = json!({"role": "assistant", "content": "Hello"});
+        let usage = Some(json!({"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}));
+        let resp = build_openai_response("id-1", 1000, "gpt-4", msg, "stop", usage);
+
+        assert_eq!(resp["id"], "id-1");
+        assert_eq!(resp["object"], "chat.completion");
+        assert_eq!(resp["choices"][0]["finish_reason"], "stop");
+        assert_eq!(resp["usage"]["prompt_tokens"], 10);
+    }
+
+    #[test]
+    fn test_build_openai_response_no_usage() {
+        let msg = json!({"role": "assistant", "content": "Hi"});
+        let resp = build_openai_response("id-1", 1000, "gpt-4", msg, "stop", None);
+        assert!(resp.get("usage").is_none());
+    }
+
+    #[test]
+    fn test_build_tool_call() {
+        let tc = build_tool_call("call-1", "get_weather", "{\"city\":\"SF\"}", 0);
+        assert_eq!(tc["id"], "call-1");
+        assert_eq!(tc["type"], "function");
+        assert_eq!(tc["function"]["name"], "get_weather");
+        assert_eq!(tc["function"]["arguments"], "{\"city\":\"SF\"}");
+        assert_eq!(tc["index"], 0);
+    }
+
+    #[test]
+    fn test_build_tool_call_delta() {
+        let delta = build_tool_call_delta(0, "call-1", "weather", "");
+        assert_eq!(delta["index"], 0);
+        assert_eq!(delta["id"], "call-1");
+        assert_eq!(delta["type"], "function");
+        assert_eq!(delta["function"]["name"], "weather");
+    }
+
+    #[test]
+    fn test_build_assistant_message_text_only() {
+        let msg = build_assistant_message(Some("Hello"), None);
+        assert_eq!(msg["role"], "assistant");
+        assert_eq!(msg["content"], "Hello");
+        assert!(msg.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn test_build_assistant_message_tool_only() {
+        let tc = vec![build_tool_call("id", "fn", "{}", 0)];
+        let msg = build_assistant_message(None, Some(tc));
+        assert_eq!(msg["content"], Value::Null);
+        assert_eq!(msg["tool_calls"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_build_assistant_message_mixed() {
+        let tc = vec![build_tool_call("id", "fn", "{}", 0)];
+        let msg = build_assistant_message(Some("Let me check"), Some(tc));
+        assert_eq!(msg["content"], "Let me check");
+        assert_eq!(msg["tool_calls"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_build_assistant_message_empty() {
+        let msg = build_assistant_message(None, None);
+        assert_eq!(msg["content"], "");
+        assert!(msg.get("tool_calls").is_none());
+    }
+}

--- a/crates/translator/src/gemini_to_openai.rs
+++ b/crates/translator/src/gemini_to_openai.rs
@@ -1,4 +1,8 @@
 use crate::TranslateState;
+use crate::common::{
+    build_assistant_message, build_openai_chunk, build_openai_response, build_tool_call,
+    build_tool_call_delta, map_gemini_finish_reason,
+};
 use ai_proxy_core::error::ProxyError;
 use serde_json::{Value, json};
 
@@ -38,56 +42,36 @@ pub fn translate_non_stream(
                 if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
                     text_parts.push(text.to_string());
                 } else if let Some(fc) = part.get("functionCall") {
-                    let name = fc
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                    let name = fc.get("name").and_then(|n| n.as_str()).unwrap_or("");
                     let args = fc.get("args").cloned().unwrap_or(json!({}));
                     let arguments = serde_json::to_string(&args).unwrap_or_default();
                     let tc_id = format!("call_{}", uuid::Uuid::new_v4());
 
-                    tool_calls.push(json!({
-                        "id": tc_id,
-                        "type": "function",
-                        "function": {
-                            "name": name,
-                            "arguments": arguments,
-                        },
-                        "index": tc_index,
-                    }));
+                    tool_calls.push(build_tool_call(&tc_id, name, &arguments, tc_index));
                     tc_index += 1;
                 }
             }
         }
 
-        let finish = match candidate.get("finishReason").and_then(|v| v.as_str()) {
-            Some("STOP") => "stop",
-            Some("MAX_TOKENS") => "length",
-            Some("SAFETY") => "content_filter",
-            Some("RECITATION") => "content_filter",
-            _ => "stop",
-        };
+        let finish =
+            map_gemini_finish_reason(candidate.get("finishReason").and_then(|v| v.as_str()));
 
         (text_parts.join(""), tool_calls, finish)
     } else {
         (String::new(), Vec::new(), "stop")
     };
 
-    let content_val = if content_str.is_empty() && !tool_calls.is_empty() {
-        Value::Null
+    let content = if content_str.is_empty() {
+        None
     } else {
-        Value::String(content_str)
+        Some(content_str.as_str())
     };
-
-    let mut message = json!({
-        "role": "assistant",
-        "content": content_val,
-    });
-
-    if !tool_calls.is_empty() {
-        message["tool_calls"] = Value::Array(tool_calls);
-    }
+    let tc = if tool_calls.is_empty() {
+        None
+    } else {
+        Some(tool_calls)
+    };
+    let message = build_assistant_message(content, tc);
 
     // Map usage
     let usage = if let Some(u) = resp.get("usageMetadata") {
@@ -112,22 +96,7 @@ pub fn translate_non_stream(
         None
     };
 
-    let mut openai_resp = json!({
-        "id": id,
-        "object": "chat.completion",
-        "created": created,
-        "model": model,
-        "choices": [{
-            "index": 0,
-            "message": message,
-            "finish_reason": finish_reason,
-        }],
-    });
-
-    if let Some(usage) = usage {
-        openai_resp["usage"] = usage;
-    }
-
+    let openai_resp = build_openai_response(&id, created, &model, message, finish_reason, usage);
     serde_json::to_string(&openai_resp).map_err(|e| ProxyError::Translation(e.to_string()))
 }
 
@@ -148,17 +117,13 @@ pub fn translate_stream(
         state.current_tool_call_index = -1;
 
         // Emit initial role chunk
-        let chunk = json!({
-            "id": state.response_id,
-            "object": "chat.completion.chunk",
-            "created": state.created,
-            "model": state.model,
-            "choices": [{
-                "index": 0,
-                "delta": {"role": "assistant", "content": ""},
-                "finish_reason": null,
-            }],
-        });
+        let chunk = build_openai_chunk(
+            &state.response_id,
+            state.created,
+            &state.model,
+            json!({"role": "assistant", "content": ""}),
+            None,
+        );
         chunks.push(serde_json::to_string(&chunk)?);
     }
 
@@ -182,50 +147,36 @@ pub fn translate_stream(
         if let Some(parts) = parts {
             for part in parts {
                 if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                    let chunk = json!({
-                        "id": state.response_id,
-                        "object": "chat.completion.chunk",
-                        "created": state.created,
-                        "model": state.model,
-                        "choices": [{
-                            "index": 0,
-                            "delta": {"content": text},
-                            "finish_reason": null,
-                        }],
-                    });
+                    let chunk = build_openai_chunk(
+                        &state.response_id,
+                        state.created,
+                        &state.model,
+                        json!({"content": text}),
+                        None,
+                    );
                     chunks.push(serde_json::to_string(&chunk)?);
                 } else if let Some(fc) = part.get("functionCall") {
                     state.current_tool_call_index += 1;
-                    let name = fc
-                        .get("name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                    let name = fc.get("name").and_then(|n| n.as_str()).unwrap_or("");
                     let args = fc.get("args").cloned().unwrap_or(json!({}));
                     let arguments = serde_json::to_string(&args).unwrap_or_default();
                     let tc_id = format!("call_{}", uuid::Uuid::new_v4());
 
-                    let chunk = json!({
-                        "id": state.response_id,
-                        "object": "chat.completion.chunk",
-                        "created": state.created,
-                        "model": state.model,
-                        "choices": [{
-                            "index": 0,
-                            "delta": {
-                                "tool_calls": [{
-                                    "index": state.current_tool_call_index,
-                                    "id": tc_id,
-                                    "type": "function",
-                                    "function": {
-                                        "name": name,
-                                        "arguments": arguments,
-                                    },
-                                }],
-                            },
-                            "finish_reason": null,
-                        }],
+                    let delta = json!({
+                        "tool_calls": [build_tool_call_delta(
+                            state.current_tool_call_index,
+                            &tc_id,
+                            name,
+                            &arguments,
+                        )],
                     });
+                    let chunk = build_openai_chunk(
+                        &state.response_id,
+                        state.created,
+                        &state.model,
+                        delta,
+                        None,
+                    );
                     chunks.push(serde_json::to_string(&chunk)?);
                 }
             }
@@ -233,25 +184,15 @@ pub fn translate_stream(
 
         // Check for finish_reason
         if let Some(finish) = candidate.get("finishReason").and_then(|v| v.as_str()) {
-            let finish_reason = match finish {
-                "STOP" => "stop",
-                "MAX_TOKENS" => "length",
-                "SAFETY" => "content_filter",
-                "RECITATION" => "content_filter",
-                _ => "stop",
-            };
+            let finish_reason = map_gemini_finish_reason(Some(finish));
 
-            let mut chunk = json!({
-                "id": state.response_id,
-                "object": "chat.completion.chunk",
-                "created": state.created,
-                "model": state.model,
-                "choices": [{
-                    "index": 0,
-                    "delta": {},
-                    "finish_reason": finish_reason,
-                }],
-            });
+            let mut chunk = build_openai_chunk(
+                &state.response_id,
+                state.created,
+                &state.model,
+                json!({}),
+                Some(finish_reason),
+            );
 
             // Include usage if available
             if let Some(u) = resp.get("usageMetadata") {
@@ -281,7 +222,6 @@ pub fn translate_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert_json_diff::assert_json_eq;
 
     // ==================
     // Non-stream tests
@@ -349,7 +289,7 @@ mod tests {
         assert_eq!(tool_calls[0]["function"]["name"], "get_weather");
         let args: Value =
             serde_json::from_str(tool_calls[0]["function"]["arguments"].as_str().unwrap()).unwrap();
-        assert_json_eq!(args, json!({"city": "SF"}));
+        assert_eq!(args, json!({"city": "SF"}));
     }
 
     #[test]

--- a/crates/translator/src/lib.rs
+++ b/crates/translator/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod claude_to_openai;
+pub mod common;
 pub mod gemini_to_openai;
 pub mod openai_to_claude;
 pub mod openai_to_gemini;

--- a/docs/specs/_index.md
+++ b/docs/specs/_index.md
@@ -28,6 +28,7 @@ All specifications for the AI Proxy Gateway project.
 | SPEC-029 | Translator Unit Tests                          | Active    | [active/SPEC-029/](active/SPEC-029/) |
 | SPEC-030 | Provider & Dispatch Unit Tests                 | Active    | [active/SPEC-030/](active/SPEC-030/) |
 | SPEC-032 | Frontend Testing Infrastructure                | Active    | [active/SPEC-032/](active/SPEC-032/) |
+| SPEC-034 | Translator & Server Refactoring                | Active    | [active/SPEC-034/](active/SPEC-034/) |
 
 ## How to Create a New Spec
 

--- a/docs/specs/active/SPEC-034/prd.md
+++ b/docs/specs/active/SPEC-034/prd.md
@@ -1,0 +1,29 @@
+# SPEC-034: Translator & Server Refactoring
+
+## Problem
+
+Code review identified significant duplication across the translator and server crates:
+
+1. **Translator duplication**: `claude_to_openai.rs` and `gemini_to_openai.rs` duplicate OpenAI chunk/response building patterns 29+ times.
+2. **AppState duplicate field**: `router` and `credential_router` point to the same `Arc<CredentialRouter>`.
+3. **Handler duplication**: `chat_completions.rs` and `messages.rs` are 95% identical (36 lines each).
+4. **Dispatch repetition**: 3 response paths in `dispatch()` repeat `DispatchMeta` injection and debug header insertion.
+
+## Goals
+
+- Extract shared translator helpers into `common.rs` (~130 lines removed, ~80 added)
+- Remove duplicate `credential_router` field from `AppState`
+- Extract `dispatch_api_request` helper to deduplicate handlers
+- Extract `build_json_response` helper in dispatch.rs
+
+## Non-Goals
+
+- Provider routing O(n) optimization (deferred)
+- RwLock consolidation in CredentialRouter (deferred)
+- dispatch.rs module split (deferred)
+
+## Success Criteria
+
+- All 292 Rust tests pass
+- Zero clippy warnings
+- Net reduction in lines of code

--- a/docs/specs/active/SPEC-034/technical-design.md
+++ b/docs/specs/active/SPEC-034/technical-design.md
@@ -1,0 +1,29 @@
+# SPEC-034: Technical Design — Translator & Server Refactoring
+
+## 1a. Extract `crates/translator/src/common.rs`
+
+Shared helpers for building OpenAI-format responses:
+
+- `map_claude_finish_reason(reason) -> &str`
+- `map_gemini_finish_reason(reason) -> &str`
+- `build_openai_chunk(id, created, model, delta, finish_reason) -> Value`
+- `build_openai_response(id, created, model, message, finish_reason, usage) -> Value`
+- `build_tool_call(id, name, arguments, index) -> Value`
+- `build_tool_call_delta(index, id, name, arguments) -> Value`
+- `build_assistant_message(content, tool_calls) -> Value`
+
+Files: `common.rs` (new), `lib.rs`, `claude_to_openai.rs`, `gemini_to_openai.rs`
+
+## 1b. Remove duplicate AppState field
+
+Remove `credential_router` from `AppState`. Change `state.credential_router` → `state.router`.
+
+Files: `server/src/lib.rs`, `config_ops.rs`, `src/app.rs`, `dashboard_tests.rs`
+
+## 1c. Deduplicate handler modules
+
+Extract `dispatch_api_request()` in `handler/mod.rs`. Reduce `chat_completions.rs` and `messages.rs` to thin wrappers.
+
+## 1d. Reduce dispatch.rs repetition
+
+Extract `build_json_response()` to deduplicate the non-stream response building pattern repeated at two locations.

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,7 +129,6 @@ impl Application {
             metrics,
             request_logs,
             config_path: Arc::new(Mutex::new(args.config.clone())),
-            credential_router: credential_router.clone(),
             rate_limiter: rate_limiter.clone(),
             cost_calculator: cost_calculator.clone(),
             response_cache,


### PR DESCRIPTION
## Summary
- Extract shared OpenAI response builders into `crates/translator/src/common.rs` with 7 helper functions (`build_openai_chunk`, `build_openai_response`, `build_tool_call`, `build_tool_call_delta`, `build_assistant_message`, `map_claude_finish_reason`, `map_gemini_finish_reason`)
- Remove duplicate `credential_router` field from `AppState` (was identical to `router`)
- Extract `dispatch_api_request()` helper to deduplicate `chat_completions.rs` and `messages.rs` handlers (95% identical → thin wrappers)
- Extract `build_json_response()` helper in `dispatch.rs` to reduce repeated non-stream response building

Closes #76, closes #77, closes #78, closes #79, closes #80

## Test plan
- [x] All 170 Rust tests pass (`cargo test --workspace`)
- [x] Zero clippy warnings (`cargo clippy --workspace --tests -- -D warnings`)
- [x] Code formatted (`cargo fmt --check`)
- [x] 12 new unit tests added for `common.rs` helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)