### PR TITLE
refactor: deduplicate frontend types and utilities

### DIFF
--- a/docs/specs/_index.md
+++ b/docs/specs/_index.md
@@ -29,6 +29,7 @@ All specifications for the AI Proxy Gateway project.
 | SPEC-030 | Provider & Dispatch Unit Tests                 | Active    | [active/SPEC-030/](active/SPEC-030/) |
 | SPEC-032 | Frontend Testing Infrastructure                | Active    | [active/SPEC-032/](active/SPEC-032/) |
 | SPEC-034 | Translator & Server Refactoring                | Active    | [active/SPEC-034/](active/SPEC-034/) |
+| SPEC-035 | Frontend Code Cleanup                          | Active    | [active/SPEC-035/](active/SPEC-035/) |
 
 ## How to Create a New Spec
 

--- a/docs/specs/active/SPEC-035/prd.md
+++ b/docs/specs/active/SPEC-035/prd.md
@@ -1,0 +1,18 @@
+# SPEC-035: Frontend Code Cleanup
+
+## Problem
+
+1. **Type duplication**: `MetricsState`, `AuthState`, `LogsState` interfaces are defined in both store files and `types/index.ts`.
+2. **Utility duplication**: `formatUptime()` has two different implementations in `System.tsx` and `Overview.tsx`.
+
+## Goals
+
+- Remove duplicate store-local types from `types/index.ts`
+- Unify `formatUptime()` into a single utility function
+- Extract `formatNumber()` utility
+
+## Success Criteria
+
+- All 48 frontend tests pass
+- No TypeScript errors (`npx tsc --noEmit`)
+- No duplicate type definitions

--- a/docs/specs/active/SPEC-035/technical-design.md
+++ b/docs/specs/active/SPEC-035/technical-design.md
@@ -1,0 +1,10 @@
+# SPEC-035: Technical Design — Frontend Code Cleanup
+
+## 2a. Remove type duplication
+
+Remove `MetricsState`, `AuthState`, `LogsState` from `web/src/types/index.ts` — stores are the SSOT.
+
+## 2b. Extract shared utility functions
+
+Create `web/src/utils/format.ts` with unified `formatUptime()` and `formatNumber()`.
+Update `System.tsx` and `Overview.tsx` to import from utils.

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useMetricsStore } from '../stores/metricsStore';
 import MetricCard from '../components/MetricCard';
+import { formatUptime, formatNumber } from '../utils/format';
 import {
   Activity,
   AlertTriangle,
@@ -27,21 +28,6 @@ export default function Overview() {
   useEffect(() => {
     fetchStats();
   }, [fetchStats]);
-
-  const formatNumber = (n: number): string => {
-    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-    return String(n);
-  };
-
-  const formatUptime = (seconds: number): string => {
-    const days = Math.floor(seconds / 86400);
-    const hours = Math.floor((seconds % 86400) / 3600);
-    const mins = Math.floor((seconds % 3600) / 60);
-    if (days > 0) return `${days}d ${hours}h`;
-    if (hours > 0) return `${hours}h ${mins}m`;
-    return `${mins}m`;
-  };
 
   return (
     <div className="page">

--- a/web/src/pages/System.tsx
+++ b/web/src/pages/System.tsx
@@ -3,6 +3,7 @@ import { systemApi, configApi } from '../services/api';
 import type { SystemHealth } from '../types';
 import StatusBadge from '../components/StatusBadge';
 import MetricCard from '../components/MetricCard';
+import { formatUptime } from '../utils/format';
 import {
   Activity,
   RefreshCw,
@@ -35,20 +36,6 @@ export default function System() {
     const interval = setInterval(fetchHealth, 15000);
     return () => clearInterval(interval);
   }, [fetchHealth]);
-
-  const formatUptime = (seconds: number): string => {
-    const days = Math.floor(seconds / 86400);
-    const hours = Math.floor((seconds % 86400) / 3600);
-    const mins = Math.floor((seconds % 3600) / 60);
-    const secs = Math.floor(seconds % 60);
-
-    const parts: string[] = [];
-    if (days > 0) parts.push(`${days}d`);
-    if (hours > 0) parts.push(`${hours}h`);
-    if (mins > 0) parts.push(`${mins}m`);
-    if (parts.length === 0) parts.push(`${secs}s`);
-    return parts.join(' ');
-  };
 
   const handleReload = async () => {
     if (!window.confirm('Reload the gateway configuration? Active connections will not be affected.')) {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -10,14 +10,6 @@ export interface LoginResponse {
   expires_in: number;
 }
 
-export interface AuthState {
-  token: string | null;
-  isAuthenticated: boolean;
-  login: (username: string, password: string) => Promise<void>;
-  logout: () => void;
-  refreshToken: () => Promise<void>;
-}
-
 // ── Provider ──
 
 export interface Provider {
@@ -142,18 +134,6 @@ export interface LatencyBucket {
   count: number;
 }
 
-export interface MetricsState {
-  snapshot: MetricsSnapshot | null;
-  timeSeries: MetricsTimeSeries[];
-  providerDistribution: ProviderDistribution[];
-  latencyBuckets: LatencyBucket[];
-  setSnapshot: (snapshot: MetricsSnapshot) => void;
-  addTimeSeriesPoint: (point: MetricsTimeSeries) => void;
-  setProviderDistribution: (data: ProviderDistribution[]) => void;
-  setLatencyBuckets: (data: LatencyBucket[]) => void;
-  fetchStats: () => Promise<void>;
-}
-
 // ── Request Logs ──
 
 export interface RequestLog {
@@ -189,19 +169,6 @@ export interface PaginatedResponse<T> {
   page_size: number;
   total: number;
   total_pages: number;
-}
-
-export interface LogsState {
-  logs: RequestLog[];
-  page: number;
-  pageSize: number;
-  total: number;
-  totalPages: number;
-  filters: RequestLogFilter;
-  setFilters: (filters: RequestLogFilter) => void;
-  setPage: (page: number) => void;
-  fetchLogs: () => Promise<void>;
-  addLog: (log: RequestLog) => void;
 }
 
 // ── System ──

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,0 +1,28 @@
+/**
+ * Format a duration in seconds to a human-readable uptime string.
+ * Examples: "3d 2h 45m", "2h 15m", "45m", "30s"
+ */
+export function formatUptime(seconds: number): string {
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (mins > 0) parts.push(`${mins}m`);
+  if (parts.length === 0) parts.push(`${secs}s`);
+
+  return parts.join(' ');
+}
+
+/**
+ * Format a number with K/M suffixes for compact display.
+ * Examples: 1500 → "1.5K", 2300000 → "2.3M", 42 → "42"
+ */
+export function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}


### PR DESCRIPTION
## Summary
- Remove duplicate `MetricsState`, `AuthState`, `LogsState` interfaces from `types/index.ts` (stores are the SSOT)
- Extract `formatUptime()` and `formatNumber()` into `web/src/utils/format.ts`
- Unify two different `formatUptime` implementations into a single robust version

Closes #82, closes #83, closes #84

## Test plan
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] No duplicate type definitions remain
- [x] Single `formatUptime()` implementation used across Overview and System pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)