### PR TITLE
docs: sync reference type docs with current codebase

### DIFF
--- a/docs/reference/types/config.md
+++ b/docs/reference/types/config.md
@@ -2,7 +2,7 @@
 
 All configuration types used for YAML config parsing and runtime settings.
 
-**Source:** `crates/core/src/config.rs`, `crates/core/src/payload.rs`, `crates/core/src/cloak.rs`
+**Source:** `crates/core/src/config.rs`, `crates/core/src/payload.rs`, `crates/core/src/cloak.rs`, `crates/core/src/auth_key.rs`, `crates/core/src/cache.rs`, `crates/core/src/audit.rs`, `crates/core/src/circuit_breaker.rs`, `crates/core/src/cost.rs`
 
 ---
 
@@ -12,29 +12,71 @@ The root configuration struct. Loaded from YAML via `Config::load()`. Uses `#[se
 
 ```rust
 pub struct Config {
+    // Server
     pub host: String,
     pub port: u16,
     pub tls: TlsConfig,
-    pub api_keys: Vec<String>,
+
+    // Client auth
+    pub auth_keys: Vec<AuthKeyEntry>,
     #[serde(skip)]
-    pub api_keys_set: HashSet<String>,    // built from api_keys during sanitize()
+    pub auth_key_store: AuthKeyStore,    // built from auth_keys during sanitize()
+
+    // Global proxy
     pub proxy_url: Option<String>,
+
+    // Debug & logging
     pub debug: bool,
     pub logging_to_file: bool,
     pub log_dir: Option<String>,
+
+    // Routing
     pub routing: RoutingConfig,
     pub request_retry: u32,
     pub max_retry_interval: u64,
+
+    // Timeouts
     pub connect_timeout: u64,
     pub request_timeout: u64,
+
+    // Streaming
     pub streaming: StreamingConfig,
     pub body_limit_mb: usize,
+
+    // Retry
     pub retry: RetryConfig,
+
+    // Payload manipulation
     pub payload: PayloadConfig,
+
+    // Headers
     pub passthrough_headers: Vec<String>,
     pub claude_header_defaults: HashMap<String, String>,
     pub force_model_prefix: bool,
     pub non_stream_keepalive_secs: u64,
+
+    // Cost tracking
+    pub model_prices: HashMap<String, ModelPrice>,
+
+    // Rate limiting
+    pub rate_limit: RateLimitConfig,
+
+    // Circuit breaker
+    pub circuit_breaker: CircuitBreakerConfig,
+
+    // Response cache
+    pub cache: CacheConfig,
+
+    // Audit logging
+    pub audit: AuditConfig,
+
+    // Dashboard
+    pub dashboard: DashboardConfig,
+
+    // Daemon
+    pub daemon: DaemonConfig,
+
+    // Provider credentials
     pub claude_api_key: Vec<ProviderKeyEntry>,
     pub openai_api_key: Vec<ProviderKeyEntry>,
     pub gemini_api_key: Vec<ProviderKeyEntry>,
@@ -49,7 +91,7 @@ pub struct Config {
 | `host` | `String` | `"0.0.0.0"` | `host` |
 | `port` | `u16` | `8317` | `port` |
 | `tls` | `TlsConfig` | disabled | `tls` |
-| `api_keys` | `Vec<String>` | `[]` | `api-keys` |
+| `auth_keys` | `Vec<AuthKeyEntry>` | `[]` | `auth-keys` |
 | `proxy_url` | `Option<String>` | `None` | `proxy-url` |
 | `debug` | `bool` | `false` | `debug` |
 | `logging_to_file` | `bool` | `false` | `logging-to-file` |
@@ -67,6 +109,13 @@ pub struct Config {
 | `claude_header_defaults` | `HashMap<String, String>` | `{}` | `claude-header-defaults` |
 | `force_model_prefix` | `bool` | `false` | `force-model-prefix` |
 | `non_stream_keepalive_secs` | `u64` | `0` (disabled) | `non-stream-keepalive-secs` |
+| `model_prices` | `HashMap<String, ModelPrice>` | `{}` | `model-prices` |
+| `rate_limit` | `RateLimitConfig` | disabled | `rate-limit` |
+| `circuit_breaker` | `CircuitBreakerConfig` | enabled | `circuit-breaker` |
+| `cache` | `CacheConfig` | disabled | `cache` |
+| `audit` | `AuditConfig` | disabled | `audit` |
+| `dashboard` | `DashboardConfig` | disabled | `dashboard` |
+| `daemon` | `DaemonConfig` | see below | `daemon` |
 | `claude_api_key` | `Vec<ProviderKeyEntry>` | `[]` | `claude-api-key` |
 | `openai_api_key` | `Vec<ProviderKeyEntry>` | `[]` | `openai-api-key` |
 | `gemini_api_key` | `Vec<ProviderKeyEntry>` | `[]` | `gemini-api-key` |
@@ -85,7 +134,111 @@ pub struct Config {
 - Duplicate entries (by `api_key`) are deduplicated.
 - Trailing slashes are stripped from `base_url`.
 - Header keys are normalized to lowercase.
-- `api_keys_set` is built from `api_keys` for O(1) lookups.
+- `auth_key_store` is built from `auth_keys` for O(1) lookups.
+
+---
+
+## AuthKeyEntry
+
+**Source:** `crates/core/src/auth_key.rs`
+
+Per-client API key with access control, rate limits, budgets, and expiry.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct AuthKeyEntry {
+    pub key: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    #[serde(default)]
+    pub allowed_models: Vec<String>,
+    #[serde(default)]
+    pub rate_limit: Option<KeyRateLimitConfig>,
+    #[serde(default)]
+    pub budget: Option<BudgetConfig>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `key` | `String` | required | `key` | Client API key string (e.g., `"sk-proxy-abc123"`). |
+| `name` | `Option<String>` | `None` | `name` | Human-readable label for this key. |
+| `tenant_id` | `Option<String>` | `None` | `tenant-id` | Tenant identifier for multi-tenant tracking. |
+| `allowed_models` | `Vec<String>` | `[]` | `allowed-models` | Glob patterns restricting model access. Empty = all models allowed. |
+| `rate_limit` | `Option<KeyRateLimitConfig>` | `None` | `rate-limit` | Per-key rate limit overrides. |
+| `budget` | `Option<BudgetConfig>` | `None` | `budget` | Cost budget configuration. |
+| `expires_at` | `Option<DateTime<Utc>>` | `None` | `expires-at` | Key expiry time (ISO 8601). Requests after this time get `KeyExpired` error. |
+| `metadata` | `HashMap<String, String>` | `{}` | `metadata` | Arbitrary key-value metadata. |
+
+### YAML example
+
+```yaml
+auth-keys:
+  - key: "sk-proxy-team-alpha"
+    name: "Team Alpha"
+    tenant-id: "alpha"
+    allowed-models: ["claude-*", "gpt-4o*"]
+    rate-limit:
+      rpm: 100
+      tpm: 500000
+    budget:
+      total-usd: 500.0
+      period: monthly
+    expires-at: "2026-12-31T23:59:59Z"
+```
+
+---
+
+## KeyRateLimitConfig
+
+**Source:** `crates/core/src/auth_key.rs`
+
+Per-key rate limit overrides (all fields optional).
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct KeyRateLimitConfig {
+    pub rpm: Option<u32>,
+    pub tpm: Option<u64>,
+    pub cost_per_day_usd: Option<f64>,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `rpm` | `Option<u32>` | `None` | `rpm` | Requests per minute limit for this key. |
+| `tpm` | `Option<u64>` | `None` | `tpm` | Tokens per minute limit for this key. |
+| `cost_per_day_usd` | `Option<f64>` | `None` | `cost-per-day-usd` | Daily cost limit in USD for this key. |
+
+---
+
+## BudgetConfig
+
+**Source:** `crates/core/src/auth_key.rs`
+
+Cost budget configuration for a key.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BudgetConfig {
+    pub total_usd: f64,
+    pub period: BudgetPeriod,
+}
+```
+
+| Field | Type | YAML key | Description |
+|-------|------|----------|-------------|
+| `total_usd` | `f64` | `total-usd` | Maximum spend in USD for the budget period. |
+| `period` | `BudgetPeriod` | `period` | Reset period: `"daily"` or `"monthly"`. |
 
 ---
 
@@ -127,18 +280,27 @@ tls:
 #[serde(rename_all = "kebab-case", default)]
 pub struct RoutingConfig {
     pub strategy: RoutingStrategy,
+    pub fallback_enabled: bool,
+    pub ewma_alpha: f64,
+    pub default_region: Option<String>,
 }
 ```
 
-| Field | Type | Default | YAML key |
-|-------|------|---------|----------|
-| `strategy` | `RoutingStrategy` | `RoundRobin` | `strategy` |
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `strategy` | `RoutingStrategy` | `RoundRobin` | `strategy` | Credential selection strategy. |
+| `fallback_enabled` | `bool` | `true` | `fallback-enabled` | Allow fallback to other providers on failure. |
+| `ewma_alpha` | `f64` | `0.3` | `ewma-alpha` | EWMA smoothing factor for latency-aware routing (0.0-1.0). |
+| `default_region` | `Option<String>` | `None` | `default-region` | Default region for geo-aware routing when client region is unknown. |
 
 ### YAML example
 
 ```yaml
 routing:
-  strategy: round-robin
+  strategy: latency-aware
+  fallback-enabled: true
+  ewma-alpha: 0.3
+  default-region: us-east
 ```
 
 ---
@@ -180,6 +342,7 @@ pub struct RetryConfig {
     pub cooldown_429_secs: u64,
     pub cooldown_5xx_secs: u64,
     pub cooldown_network_secs: u64,
+    pub jitter_factor: f64,
 }
 ```
 
@@ -190,6 +353,7 @@ pub struct RetryConfig {
 | `cooldown_429_secs` | `u64` | `60` | `cooldown-429-secs` | Cooldown duration for rate-limited (429) credentials. Overridden by `Retry-After` header when present. |
 | `cooldown_5xx_secs` | `u64` | `15` | `cooldown-5xx-secs` | Cooldown duration for 5xx errors. Overridden by `Retry-After` header when present. |
 | `cooldown_network_secs` | `u64` | `10` | `cooldown-network-secs` | Cooldown duration for network errors (timeout, connection failure). |
+| `jitter_factor` | `f64` | `1.0` | `jitter-factor` | Jitter factor for retry backoff (0.0 = no jitter, 1.0 = full jitter). |
 
 ### YAML example
 
@@ -200,6 +364,260 @@ retry:
   cooldown-429-secs: 60
   cooldown-5xx-secs: 15
   cooldown-network-secs: 10
+  jitter-factor: 1.0
+```
+
+---
+
+## RateLimitConfig
+
+**Source:** `crates/core/src/config.rs`
+
+Global rate limiting configuration. All limits are enforced in-memory.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct RateLimitConfig {
+    pub enabled: bool,
+    pub global_rpm: u32,
+    pub per_key_rpm: u32,
+    pub global_tpm: u64,
+    pub per_key_tpm: u64,
+    pub per_key_cost_per_day_usd: f64,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `enabled` | `bool` | `false` | `enabled` | Enable rate limiting. |
+| `global_rpm` | `u32` | `0` | `global-rpm` | Global requests per minute limit (0 = unlimited). |
+| `per_key_rpm` | `u32` | `0` | `per-key-rpm` | Per-API-key requests per minute limit (0 = unlimited). |
+| `global_tpm` | `u64` | `0` | `global-tpm` | Global tokens per minute limit (0 = unlimited). |
+| `per_key_tpm` | `u64` | `0` | `per-key-tpm` | Per-API-key tokens per minute limit (0 = unlimited). |
+| `per_key_cost_per_day_usd` | `f64` | `0.0` | `per-key-cost-per-day-usd` | Per-API-key cost per day in USD (0.0 = unlimited). |
+
+### YAML example
+
+```yaml
+rate-limit:
+  enabled: true
+  global-rpm: 1000
+  per-key-rpm: 60
+  per-key-cost-per-day-usd: 50.0
+```
+
+---
+
+## CircuitBreakerConfig
+
+**Source:** `crates/core/src/circuit_breaker.rs`
+
+Per-credential circuit breaker configuration. Uses a three-state model (Closed -> Open -> HalfOpen -> Closed).
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CircuitBreakerConfig {
+    pub enabled: bool,
+    pub failure_threshold: u32,
+    pub cooldown_secs: u64,
+    pub half_open_max_probes: u32,
+    pub rolling_window_secs: u64,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `enabled` | `bool` | `true` | `enabled` | Enable circuit breaker. When disabled, `NoopCircuitBreaker` is used. |
+| `failure_threshold` | `u32` | `5` | `failure-threshold` | Consecutive failures within the rolling window to trip the circuit. |
+| `cooldown_secs` | `u64` | `30` | `cooldown-secs` | How long the circuit stays open before transitioning to half-open. |
+| `half_open_max_probes` | `u32` | `1` | `half-open-max-probes` | Number of probe requests allowed in half-open state. |
+| `rolling_window_secs` | `u64` | `60` | `rolling-window-secs` | Rolling window for failure counting. Failures older than this are reset. |
+
+### YAML example
+
+```yaml
+circuit-breaker:
+  enabled: true
+  failure-threshold: 5
+  cooldown-secs: 30
+  half-open-max-probes: 1
+  rolling-window-secs: 60
+```
+
+---
+
+## CacheConfig
+
+**Source:** `crates/core/src/cache.rs`
+
+Response cache configuration. Only caches non-streaming requests with temperature=0.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CacheConfig {
+    pub enabled: bool,
+    pub max_entries: u64,
+    pub ttl_secs: u64,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `enabled` | `bool` | `false` | `enabled` | Enable response caching. |
+| `max_entries` | `u64` | `10_000` | `max-entries` | Maximum number of cached entries. |
+| `ttl_secs` | `u64` | `3600` | `ttl-secs` | Time-to-live for cached entries in seconds. |
+
+### YAML example
+
+```yaml
+cache:
+  enabled: true
+  max-entries: 10000
+  ttl-secs: 3600
+```
+
+---
+
+## AuditConfig
+
+**Source:** `crates/core/src/audit.rs`
+
+Audit logging configuration. Logs are written as JSONL with daily rotation.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct AuditConfig {
+    pub enabled: bool,
+    pub dir: String,
+    pub retention_days: u32,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `enabled` | `bool` | `false` | `enabled` | Enable audit logging. |
+| `dir` | `String` | `"./logs/audit"` | `dir` | Directory for audit log files. |
+| `retention_days` | `u32` | `30` | `retention-days` | Number of days to retain audit logs before cleanup. |
+
+### YAML example
+
+```yaml
+audit:
+  enabled: true
+  dir: ./logs/audit
+  retention-days: 30
+```
+
+---
+
+## DashboardConfig
+
+**Source:** `crates/core/src/config.rs`
+
+Dashboard admin API configuration.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct DashboardConfig {
+    pub enabled: bool,
+    pub username: String,
+    pub password_hash: String,
+    pub jwt_secret: Option<String>,
+    pub jwt_ttl_secs: u64,
+    pub request_log_capacity: usize,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `enabled` | `bool` | `false` | `enabled` | Enable the dashboard admin API. |
+| `username` | `String` | `"admin"` | `username` | Admin login username. |
+| `password_hash` | `String` | `""` | `password-hash` | bcrypt-hashed admin password (e.g., `"$2b$12$..."`). |
+| `jwt_secret` | `Option<String>` | `None` | `jwt-secret` | JWT signing secret. Falls back to env `DASHBOARD_JWT_SECRET`. |
+| `jwt_ttl_secs` | `u64` | `3600` | `jwt-ttl-secs` | JWT token TTL in seconds. |
+| `request_log_capacity` | `usize` | `10_000` | `request-log-capacity` | Request log ring buffer capacity. |
+
+### Key methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `resolve_jwt_secret` | `fn resolve_jwt_secret(&self) -> Option<String>` | Returns `jwt_secret` if set, otherwise reads `DASHBOARD_JWT_SECRET` env var. |
+
+### YAML example
+
+```yaml
+dashboard:
+  enabled: true
+  username: admin
+  password-hash: "$2b$12$..."
+  jwt-ttl-secs: 3600
+  request-log-capacity: 10000
+```
+
+---
+
+## DaemonConfig
+
+**Source:** `crates/core/src/config.rs`
+
+Daemon mode configuration.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct DaemonConfig {
+    pub pid_file: String,
+    pub shutdown_timeout: u64,
+}
+```
+
+| Field | Type | Default | YAML key | Description |
+|-------|------|---------|----------|-------------|
+| `pid_file` | `String` | `"./ai-proxy.pid"` | `pid-file` | Path to the PID file. |
+| `shutdown_timeout` | `u64` | `30` | `shutdown-timeout` | Graceful shutdown timeout in seconds. |
+
+### YAML example
+
+```yaml
+daemon:
+  pid-file: ./ai-proxy.pid
+  shutdown-timeout: 30
+```
+
+---
+
+## ModelPrice
+
+**Source:** `crates/core/src/cost.rs`
+
+Custom price override for a model (USD per 1M tokens).
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ModelPrice {
+    pub input: f64,
+    pub output: f64,
+}
+```
+
+| Field | Type | YAML key | Description |
+|-------|------|----------|-------------|
+| `input` | `f64` | `input` | Cost per 1M input tokens in USD. |
+| `output` | `f64` | `output` | Cost per 1M output tokens in USD. |
+
+### YAML example
+
+```yaml
+model-prices:
+  custom-model:
+    input: 3.0
+    output: 15.0
 ```
 
 ---
@@ -332,6 +750,10 @@ pub struct ProviderKeyEntry {
     pub cloak: CloakConfig,
     #[serde(default)]
     pub wire_api: WireApi,
+    #[serde(default = "default_weight")]
+    pub weight: u32,
+    #[serde(default)]
+    pub region: Option<String>,
 }
 ```
 
@@ -348,6 +770,8 @@ pub struct ProviderKeyEntry {
 | `name` | `Option<String>` | `None` | `name` | Human-readable name for logging/identification. |
 | `cloak` | `CloakConfig` | `CloakMode::Never` | `cloak` | Claude cloaking configuration. Only used for Claude provider entries. |
 | `wire_api` | `WireApi` | `Chat` | `wire-api` | Wire API format for OpenAI-compatible providers. |
+| `weight` | `u32` | `1` | `weight` | Weight for weighted round-robin routing (range 1-100). |
+| `region` | `Option<String>` | `None` | `region` | Region identifier for geo-aware routing. |
 
 ### YAML example
 
@@ -357,6 +781,8 @@ claude-api-key:
     base-url: "https://api.anthropic.com"
     prefix: "claude/"
     name: "primary-claude"
+    weight: 2
+    region: us-east
     models:
       - id: "claude-sonnet-4-20250514"
         alias: "sonnet"

--- a/docs/reference/types/enums.md
+++ b/docs/reference/types/enums.md
@@ -89,6 +89,8 @@ Controls how credentials are selected when multiple credentials can serve a requ
 pub enum RoutingStrategy {
     RoundRobin,
     FillFirst,
+    LatencyAware,
+    GeoAware,
 }
 ```
 
@@ -98,12 +100,17 @@ pub enum RoutingStrategy {
 |---------|-----------------|----------|
 | `RoundRobin` | `"round-robin"` | Distributes requests across credentials using `AtomicUsize` counters per `"provider:model"` key. Default strategy. |
 | `FillFirst` | `"fill-first"` | Always picks the first available credential in the list. |
+| `LatencyAware` | `"latency-aware"` | Picks the credential with the lowest EWMA latency. Uses `ewma_alpha` smoothing factor from `RoutingConfig`. |
+| `GeoAware` | `"geo-aware"` | Prefers credentials whose `region` matches the client's region. Falls back to `default_region` in `RoutingConfig`. |
 
 ### YAML example
 
 ```yaml
 routing:
-  strategy: round-robin   # or fill-first
+  strategy: round-robin   # or fill-first, latency-aware, geo-aware
+  fallback-enabled: true
+  ewma-alpha: 0.3          # for latency-aware
+  default-region: us-east   # for geo-aware
 ```
 
 ### Usage context
@@ -154,3 +161,58 @@ claude-api-key:
 - `CloakConfig.mode` -- per-credential cloak config
 - `should_cloak()` function evaluates this against `User-Agent`
 - `apply_cloak()` injects system prompt, `metadata.user_id`, and obfuscates sensitive words
+
+---
+
+## CircuitState
+
+**Source:** `crates/core/src/circuit_breaker.rs`
+
+The state of a credential's circuit breaker.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+```
+
+| Variant | Serialized value | Meaning |
+|---------|-----------------|---------|
+| `Closed` | `"closed"` | Healthy -- requests flow normally. |
+| `Open` | `"open"` | Tripped -- requests blocked until cooldown expires. |
+| `HalfOpen` | `"half-open"` | Probing -- limited requests allowed to test recovery. |
+
+### Usage context
+
+- `CircuitBreakerPolicy.state()` -- current state of a credential's circuit breaker
+- `AuthRecord.circuit_state()` -- convenience accessor
+
+---
+
+## BudgetPeriod
+
+**Source:** `crates/core/src/auth_key.rs`
+
+Budget reset period for per-key cost budgets.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BudgetPeriod {
+    Daily,
+    Monthly,
+}
+```
+
+| Variant | Serialized value |
+|---------|-----------------|
+| `Daily` | `"daily"` |
+| `Monthly` | `"monthly"` |
+
+### Usage context
+
+- `BudgetConfig.period` -- in `AuthKeyEntry` budget configuration

--- a/docs/reference/types/errors.md
+++ b/docs/reference/types/errors.md
@@ -42,6 +42,15 @@ pub enum ProxyError {
     #[error("model not found: {0}")]
     ModelNotFound(String),
 
+    #[error("rate limit exceeded: {0}")]
+    RateLimited(String),
+
+    #[error("model access denied: {0}")]
+    ModelNotAllowed(String),
+
+    #[error("API key expired")]
+    KeyExpired,
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -55,13 +64,16 @@ pub enum ProxyError {
 |---------|--------|-------------|
 | `Config` | `String` | Configuration validation or loading error. |
 | `Auth` | `String` | Client authentication failure (invalid or missing API key). |
-| `NoCredentials` | `provider: String, model: String` | No available credentials for the given provider and model. All credentials may be disabled, in cooldown, or not configured. |
+| `NoCredentials` | `provider: String, model: String` | No available credentials for the given provider and model. All credentials may be disabled, circuit-broken, or not configured. |
 | `ModelCooldown` | `model: String, seconds: u64` | The requested model's credentials are all in cooldown. |
 | `Upstream` | `status: u16, body: String, retry_after_secs: Option<u64>` | Error response from upstream provider. `retry_after_secs` is parsed from the upstream `Retry-After` header if present. |
 | `Network` | `String` | Network-level failure (timeout, connection refused, DNS failure). |
 | `Translation` | `String` | Error during request/response format translation (JSON parse errors, missing fields). |
 | `BadRequest` | `String` | Malformed client request (missing model field, invalid JSON, etc.). |
 | `ModelNotFound` | `String` | No provider has a credential that supports the requested model. |
+| `RateLimited` | `String` | Global or per-key rate limit exceeded (RPM, TPM, or daily cost). |
+| `ModelNotAllowed` | `String` | The auth key does not have access to the requested model (restricted by `allowed_models`). |
+| `KeyExpired` | (none) | The client's API key has passed its `expires_at` date. |
 | `Internal` | `String` | Unexpected internal error (response build failure, task panic, etc.). |
 
 ---
@@ -75,9 +87,10 @@ impl ProxyError {
     pub fn status_code(&self) -> StatusCode {
         match self {
             Self::Config(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,  // 500
-            Self::Auth(_) => StatusCode::UNAUTHORIZED,                                  // 401
+            Self::Auth(_) | Self::KeyExpired => StatusCode::UNAUTHORIZED,               // 401
+            Self::ModelNotAllowed(_) => StatusCode::FORBIDDEN,                          // 403
             Self::NoCredentials { .. } => StatusCode::SERVICE_UNAVAILABLE,              // 503
-            Self::ModelCooldown { .. } => StatusCode::TOO_MANY_REQUESTS,               // 429
+            Self::ModelCooldown { .. } | Self::RateLimited(_) => StatusCode::TOO_MANY_REQUESTS, // 429
             Self::Upstream { status, .. } => {
                 StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_GATEWAY)       // pass-through or 502
             }
@@ -96,8 +109,11 @@ impl ProxyError {
 |---------|-------------|------|
 | `Config` | 500 Internal Server Error | |
 | `Auth` | 401 Unauthorized | |
+| `KeyExpired` | 401 Unauthorized | |
+| `ModelNotAllowed` | 403 Forbidden | |
 | `NoCredentials` | 503 Service Unavailable | |
 | `ModelCooldown` | 429 Too Many Requests | |
+| `RateLimited` | 429 Too Many Requests | |
 | `Upstream` | pass-through (e.g., 429, 500) or 502 | |
 | `Network` | 502 Bad Gateway | |
 | `Translation` | 500 Internal Server Error | |
@@ -115,9 +131,10 @@ The `error_type()` and `error_code()` are **private** helper methods (not part o
 
 | Variant | error_type |
 |---------|------------|
-| `Auth` | `"authentication_error"` |
+| `Auth`, `KeyExpired` | `"authentication_error"` |
+| `ModelNotAllowed` | `"permission_error"` |
 | `NoCredentials` | `"insufficient_quota"` |
-| `ModelCooldown` | `"rate_limit_error"` |
+| `ModelCooldown`, `RateLimited` | `"rate_limit_error"` |
 | `BadRequest` | `"invalid_request_error"` |
 | `ModelNotFound` | `"invalid_request_error"` |
 | `Upstream` | `"upstream_error"` |
@@ -127,9 +144,10 @@ The `error_type()` and `error_code()` are **private** helper methods (not part o
 
 | Variant | error_code |
 |---------|------------|
-| `Auth` | `"invalid_api_key"` |
+| `Auth`, `KeyExpired` | `"invalid_api_key"` |
+| `ModelNotAllowed` | `"model_not_allowed"` |
 | `NoCredentials` | `"insufficient_quota"` |
-| `ModelCooldown` | `"rate_limit_exceeded"` |
+| `ModelCooldown`, `RateLimited` | `"rate_limit_exceeded"` |
 | `ModelNotFound` | `"model_not_found"` |
 | `BadRequest` | `"invalid_request"` |
 | all others | `"internal_error"` |
@@ -159,6 +177,10 @@ For all variants except `Upstream` (with valid JSON body):
 For `Upstream` errors where the body is valid JSON, the original upstream error body is passed through verbatim with the upstream's HTTP status code. This preserves provider-specific error details.
 
 If the upstream body is not valid JSON, the standard error format is used instead.
+
+### Retry-After header
+
+For `RateLimited` and `ModelCooldown` responses, the `Retry-After` header is automatically set to `"60"` seconds.
 
 ---
 

--- a/docs/reference/types/provider.md
+++ b/docs/reference/types/provider.md
@@ -11,7 +11,7 @@ Runtime types for provider execution, credential routing, and format translation
 Runtime credential representation built from `ProviderKeyEntry` during config loading. Carries all data needed to authenticate and route a request to a specific upstream provider.
 
 ```rust
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AuthRecord {
     pub id: String,
     pub provider: Format,
@@ -23,9 +23,12 @@ pub struct AuthRecord {
     pub excluded_models: Vec<String>,
     pub prefix: Option<String>,
     pub disabled: bool,
-    pub cooldown_until: Option<std::time::Instant>,
+    pub circuit_breaker: Arc<dyn CircuitBreakerPolicy>,
     pub cloak: Option<CloakConfig>,
     pub wire_api: WireApi,
+    pub credential_name: Option<String>,
+    pub weight: u32,
+    pub region: Option<String>,
 }
 ```
 
@@ -41,9 +44,12 @@ pub struct AuthRecord {
 | `excluded_models` | `Vec<String>` | Glob patterns for excluded models. |
 | `prefix` | `Option<String>` | Model name prefix for namespace isolation. |
 | `disabled` | `bool` | Whether this credential is disabled. |
-| `cooldown_until` | `Option<Instant>` | Cooldown expiry time. Set by `CredentialRouter.mark_unavailable()`. |
+| `circuit_breaker` | `Arc<dyn CircuitBreakerPolicy>` | Circuit breaker instance managing availability state. |
 | `cloak` | `Option<CloakConfig>` | Cloak config. Only `Some` for Claude credentials. |
 | `wire_api` | `WireApi` | Wire API format (Chat or Responses). |
+| `credential_name` | `Option<String>` | Human-readable name from `ProviderKeyEntry.name`. |
+| `weight` | `u32` | Weight for weighted round-robin routing (default 1). |
+| `region` | `Option<String>` | Region identifier for geo-aware routing. |
 
 ### Key methods
 
@@ -56,7 +62,9 @@ pub struct AuthRecord {
 | `strip_prefix` | `fn strip_prefix<'a>(&self, model: &'a str) -> &'a str` | Removes prefix from model name. Returns original if no prefix match. |
 | `prefixed_model_id` | `fn prefixed_model_id(&self, model_id: &str) -> String` | Prepends the configured prefix to a model ID. |
 | `is_model_excluded` | `fn is_model_excluded(&self, model: &str) -> bool` | Checks exclusion list using glob matching. |
-| `is_available` | `fn is_available(&self) -> bool` | Returns `false` if disabled or currently in cooldown. |
+| `name` | `fn name(&self) -> Option<&str>` | Returns the credential's human-readable name. |
+| `is_available` | `fn is_available(&self) -> bool` | Returns `false` if disabled or circuit breaker denies execution (`circuit_breaker.can_execute()` returns false). |
+| `circuit_state` | `fn circuit_state(&self) -> CircuitState` | Returns the current circuit breaker state (`Closed`, `Open`, or `HalfOpen`). |
 
 ---
 
@@ -244,13 +252,16 @@ pub trait ProviderExecutor: Send + Sync {
 
 **Source:** `crates/provider/src/routing.rs`
 
-Thread-safe credential store that selects the appropriate credential for each request based on provider, model, routing strategy, and cooldown state.
+Thread-safe credential store that selects the appropriate credential for each request based on provider, model, routing strategy, and circuit breaker state.
 
 ```rust
 pub struct CredentialRouter {
     credentials: RwLock<HashMap<Format, Vec<AuthRecord>>>,
     counters: RwLock<HashMap<String, AtomicUsize>>,
     strategy: RwLock<RoutingStrategy>,
+    latency_ewma: RwLock<HashMap<String, f64>>,
+    ewma_alpha: RwLock<f64>,
+    cb_config: RwLock<CircuitBreakerConfig>,
 }
 ```
 
@@ -259,10 +270,13 @@ pub struct CredentialRouter {
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `new` | `fn new(strategy: RoutingStrategy) -> Self` | Create a new router with the given strategy. |
-| `pick` | `fn pick(&self, provider: Format, model: &str, tried: &[String]) -> Option<AuthRecord>` | Pick the next available credential. Filters by availability, model support, and exclusion of already-tried IDs. Uses round-robin (with `AtomicUsize` counter per `"provider:model"` key) or fill-first based on strategy. |
-| `mark_unavailable` | `fn mark_unavailable(&self, auth_id: &str, duration: Duration)` | Set cooldown on a credential. Sets `cooldown_until` to `Instant::now() + duration`. |
-| `update_from_config` | `fn update_from_config(&self, config: &Config)` | Rebuild all credentials from config. Preserves cooldown state from existing credentials (matched by `api_key` + format). Also updates routing strategy. |
-| `all_models` | `fn all_models(&self) -> Vec<ModelInfo>` | List all unique models across all available (non-disabled, non-cooled-down) credentials. Prefers alias over raw ID. Deduplicates by model ID. |
+| `pick` | `fn pick(&self, provider: Format, model: &str, tried: &[String], client_region: Option<&str>) -> Option<AuthRecord>` | Pick the next available credential. Filters by availability (circuit breaker), model support, and exclusion of already-tried IDs. Strategy-specific selection: round-robin, fill-first, latency-aware (lowest EWMA), or geo-aware (region match). |
+| `record_latency` | `fn record_latency(&self, credential_id: &str, latency_ms: f64)` | Record request latency for EWMA calculation (used by latency-aware routing). |
+| `record_success` | `fn record_success(&self, auth_id: &str)` | Report a successful request to the credential's circuit breaker. |
+| `record_failure` | `fn record_failure(&self, auth_id: &str)` | Report a failed request to the credential's circuit breaker. May trip the circuit open. |
+| `circuit_breaker_states` | `fn circuit_breaker_states(&self) -> Vec<(String, bool)>` | Get circuit breaker availability state for all credentials. Returns `(credential_id, can_execute)`. |
+| `update_from_config` | `fn update_from_config(&self, config: &Config)` | Rebuild all credentials from config. Also updates routing strategy and circuit breaker config. |
+| `all_models` | `fn all_models(&self) -> Vec<ModelInfo>` | List all unique models across all available (non-disabled, circuit-closed) credentials. Prefers alias over raw ID. Deduplicates by model ID. |
 | `model_has_prefix` | `fn model_has_prefix(&self, model: &str) -> bool` | Check if any available credential with a prefix supports this model. Used for `force_model_prefix` enforcement. |
 | `resolve_providers` | `fn resolve_providers(&self, model: &str) -> Vec<Format>` | Return all provider formats that have at least one available credential supporting the model. |
 
@@ -370,7 +384,7 @@ pub struct ExecutorRegistry {
 |--------|-----------|-------------|
 | `get` | `fn get(&self, name: &str) -> Option<Arc<dyn ProviderExecutor>>` | Look up executor by name. |
 | `get_by_format` | `fn get_by_format(&self, format: Format) -> Option<Arc<dyn ProviderExecutor>>` | Look up executor by native format. |
-| `all` | `fn all(&self) -> impl Iterator<...>` | Iterate all registered executors. |
+| `all` | `fn all(&self) -> impl Iterator<Item = (&String, &Arc<dyn ProviderExecutor>)>` | Iterate all registered executors. |
 
 ---
 
@@ -386,6 +400,10 @@ pub struct RequestContext {
     pub request_id: String,
     pub start_time: Instant,
     pub client_ip: Option<String>,
+    pub api_key_id: Option<String>,
+    pub tenant_id: Option<String>,
+    pub auth_key: Option<AuthKeyEntry>,
+    pub client_region: Option<String>,
 }
 ```
 
@@ -394,6 +412,10 @@ pub struct RequestContext {
 | `request_id` | `String` | UUID v4 generated per request. |
 | `start_time` | `Instant` | When the request was received. |
 | `client_ip` | `Option<String>` | Extracted from `X-Forwarded-For` or `X-Real-IP` headers. |
+| `api_key_id` | `Option<String>` | Masked API key ID (set by auth middleware after key validation). |
+| `tenant_id` | `Option<String>` | Tenant ID from the matching `AuthKeyEntry`. |
+| `auth_key` | `Option<AuthKeyEntry>` | Full auth key entry (for per-key rate limits and model access checks). |
+| `client_region` | `Option<String>` | Client region for geo-aware routing (extracted from headers or config). |
 
 ### Methods
 


### PR DESCRIPTION
## Summary

- Sync all 4 reference type documents (`docs/reference/types/`) with actual Rust source code
- Fix 48 ERROR-level and 5 STALE-level discrepancies found by `/doc-audit quick`

## Changes

### `enums.md`
- Add `LatencyAware` and `GeoAware` routing strategies
- Add `CircuitState` enum (Closed/Open/HalfOpen)
- Add `BudgetPeriod` enum (Daily/Monthly)

### `config.md`
- Replace outdated `api_keys: Vec<String>` with `auth_keys: Vec<AuthKeyEntry>`
- Add 7 missing config sections: `RateLimitConfig`, `CircuitBreakerConfig`, `CacheConfig`, `AuditConfig`, `DashboardConfig`, `DaemonConfig`, `ModelPrice`
- Add missing fields: `RoutingConfig` (fallback_enabled, ewma_alpha, default_region), `RetryConfig` (jitter_factor), `ProviderKeyEntry` (weight, region)

### `provider.md`
- Replace removed `cooldown_until` field with `circuit_breaker: Arc<dyn CircuitBreakerPolicy>`
- Add `credential_name`, `weight`, `region` fields to `AuthRecord`
- Add `name()`, `circuit_state()` methods to `AuthRecord`
- Update `CredentialRouter.pick()` signature (added `client_region` param)
- Replace removed `mark_unavailable()` with `record_latency/success/failure()` and `circuit_breaker_states()`
- Add 4 new `RequestContext` fields: `api_key_id`, `tenant_id`, `auth_key`, `client_region`

### `errors.md`
- Add 3 missing error variants: `RateLimited` (429), `ModelNotAllowed` (403), `KeyExpired` (401)
- Document `Retry-After` header behavior for rate-limited responses

## Spec & Reference Doc Impact
None — this PR **is** the doc sync.

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (304 tests)
- Docs-only change — no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)