### PR TITLE
feat: add test level filtering and coding agent CLI tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,8 @@ jobs:
     timeout-minutes: 30
     env:
       E2E_BAILIAN_API_KEY: ${{ secrets.E2E_BAILIAN_API_KEY }}
+      # quick on push, full on manual/schedule
+      TEST_LEVEL: ${{ github.event_name == 'push' && 'quick' || 'full' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -23,6 +23,7 @@ services:
     environment:
       - GATEWAY_URL=http://gateway:8317
       - TEST_FILTER
+      - TEST_LEVEL
     entrypoint: ["bash", "/tests/entrypoint.sh"]
 
 volumes:

--- a/tests/e2e-docker/cases/aider/test.sh
+++ b/tests/e2e-docker/cases/aider/test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# @level: full
+set -euo pipefail
+
+source /tests/lib/helpers.sh
+
+CASE_NAME="aider"
+MODEL="qwen3-coder-plus"
+
+log_info "Aider E2E test — OpenAI-compatible mode"
+
+# 1. Verify model is available
+check_model_available "$MODEL"
+
+# 2. Install Python + Aider (node:20-bookworm-slim has apt)
+log_info "Installing Python and Aider..."
+apt-get install -y --no-install-recommends -qq python3 python3-pip python3-venv > /dev/null 2>&1
+python3 -m pip install --break-system-packages -q aider-chat 2>&1 | tail -1
+log_info "Aider installed"
+
+# 3. Configure: Aider uses env vars for OpenAI-compatible
+export OPENAI_API_KEY="sk-proxy-e2e-dummy"
+export OPENAI_API_BASE="http://gateway:8317/v1"
+
+# 4. Set up git workspace
+WORKDIR=$(mktemp -d)
+cd "$WORKDIR"
+git init -q
+git config user.email "e2e@test.local"
+git config user.name "E2E Test"
+git commit --allow-empty -m "init" -q
+
+# 5. Run non-interactive with --message flag
+log_info "Testing model: $MODEL"
+timer_start
+
+OUTPUT=$(aider --model "openai/$MODEL" --no-auto-commits --message "Respond with exactly: PONG" 2>&1) || {
+    elapsed=$(timer_elapsed)
+    log_fail "$MODEL — aider exited with code $? ($(format_duration "$elapsed"))"
+    echo "$OUTPUT"
+    report_row "$CASE_NAME" "fail" "$MODEL" "$elapsed" "$OUTPUT"
+    rm -rf "$WORKDIR"
+    exit 1
+}
+
+elapsed=$(timer_elapsed)
+
+if [[ -z "$OUTPUT" ]]; then
+    log_fail "$MODEL — empty output ($(format_duration "$elapsed"))"
+    report_row "$CASE_NAME" "fail" "$MODEL" "$elapsed" "(empty output)"
+    rm -rf "$WORKDIR"
+    exit 1
+fi
+
+log_info "Response: $OUTPUT"
+log_pass "$MODEL ($(format_duration "$elapsed"))"
+report_row "$CASE_NAME" "pass" "$MODEL" "$elapsed" "$OUTPUT"
+
+# 6. Cleanup
+rm -rf "$WORKDIR"
+
+log_header "Aider test passed"

--- a/tests/e2e-docker/cases/cline/test.sh
+++ b/tests/e2e-docker/cases/cline/test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# @level: full
+set -euo pipefail
+
+source /tests/lib/helpers.sh
+
+CASE_NAME="cline"
+MODEL="qwen3-coder-plus"
+
+log_info "Cline E2E test — OpenAI-compatible mode"
+
+# 1. Verify model is available
+check_model_available "$MODEL"
+
+# 2. Install Cline CLI
+log_info "Installing Cline CLI..."
+npm install -g cline 2>&1 | tail -1
+log_info "Cline installed"
+
+# 3. Configure: Cline uses env vars for OpenAI-compatible
+export OPENAI_API_KEY="sk-proxy-e2e-dummy"
+export OPENAI_BASE_URL="http://gateway:8317/v1"
+
+# 4. Set up git workspace
+WORKDIR=$(mktemp -d)
+cd "$WORKDIR"
+git init -q
+git config user.email "e2e@test.local"
+git config user.name "E2E Test"
+git commit --allow-empty -m "init" -q
+
+# 5. Run non-interactive
+log_info "Testing model: $MODEL"
+timer_start
+
+OUTPUT=$(cline -m "$MODEL" -y "Respond with exactly: PONG" 2>&1) || {
+    elapsed=$(timer_elapsed)
+    log_fail "$MODEL — cline exited with code $? ($(format_duration "$elapsed"))"
+    echo "$OUTPUT"
+    report_row "$CASE_NAME" "fail" "$MODEL" "$elapsed" "$OUTPUT"
+    rm -rf "$WORKDIR"
+    exit 1
+}
+
+elapsed=$(timer_elapsed)
+
+if [[ -z "$OUTPUT" ]]; then
+    log_fail "$MODEL — empty output ($(format_duration "$elapsed"))"
+    report_row "$CASE_NAME" "fail" "$MODEL" "$elapsed" "(empty output)"
+    rm -rf "$WORKDIR"
+    exit 1
+fi
+
+log_info "Response: $OUTPUT"
+log_pass "$MODEL ($(format_duration "$elapsed"))"
+report_row "$CASE_NAME" "pass" "$MODEL" "$elapsed" "$OUTPUT"
+
+# 6. Cleanup
+rm -rf "$WORKDIR"
+
+log_header "Cline test passed"

--- a/tests/e2e-docker/cases/opencode-full/test.sh
+++ b/tests/e2e-docker/cases/opencode-full/test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# @level: full
+set -euo pipefail
+
+source /tests/lib/helpers.sh
+
+CASE_NAME="opencode-full"
+
+log_info "opencode E2E test — all Bailian models (full)"
+
+MODELS=(
+    "qwen3.5-plus"
+    "qwen3-coder-next"
+    "qwen3-coder-plus"
+    "glm-5"
+    "glm-4.7"
+    "kimi-k2.5"
+    "MiniMax-M2.5"
+)
+
+# 1. Verify all models are available
+for model in "${MODELS[@]}"; do
+    check_model_available "$model"
+done
+
+# 2. Install opencode + jq for JSON processing
+log_info "Installing opencode and jq..."
+npm install -g opencode-ai 2>&1 | tail -1
+apt-get install -y --no-install-recommends -qq jq > /dev/null 2>&1
+log_info "opencode installed"
+
+# 3. Set up workspace (opencode requires a git repo)
+WORKDIR=$(mktemp -d)
+cd "$WORKDIR"
+git init -q
+git config user.email "e2e@test.local"
+git config user.name "E2E Test"
+git commit --allow-empty -m "init" -q
+
+# 4. Configure opencode
+cp /tests/cases/opencode/opencode.json "$WORKDIR/opencode.json"
+
+# 5. Sanitize sensitive data from session JSON
+# Removes: apiKey, api-key, authorization headers, tokens
+sanitize_json() {
+    sed -E \
+        -e 's/"(apiKey|api-key|api_key|token|authorization|secret)"\s*:\s*"[^"]*"/"\1": "***"/gi' \
+        -e 's/sk-[a-zA-Z0-9_-]+/sk-***/g'
+}
+
+# 6. Test each model
+MODEL_PASSED=0
+MODEL_FAILED=0
+
+for model in "${MODELS[@]}"; do
+    log_info "Testing model: $model"
+    timer_start
+
+    # Run once with --format json to capture structured event stream
+    # This includes: text events, tool_use, reasoning, step_start/finish, errors
+    # We extract text content from JSON events for display + include full JSON for details
+    RAW_OUTPUT=$(opencode run --format json -m "proxy/$model" "Respond with exactly: PONG" 2>&1) || {
+        elapsed=$(timer_elapsed)
+        log_fail "$model — opencode exited with code $? ($(format_duration "$elapsed"))"
+        echo "$RAW_OUTPUT"
+
+        SANITIZED=$(echo "$RAW_OUTPUT" | sanitize_json)
+        report_row "$CASE_NAME" "fail" "$model" "$elapsed" "$SANITIZED"
+        ((MODEL_FAILED++)) || true
+        continue
+    }
+
+    elapsed=$(timer_elapsed)
+
+    if [[ -z "$RAW_OUTPUT" ]]; then
+        log_fail "$model — empty output ($(format_duration "$elapsed"))"
+        report_row "$CASE_NAME" "fail" "$model" "$elapsed" "(empty output)"
+        ((MODEL_FAILED++)) || true
+        continue
+    fi
+
+    # Extract text content from JSON events for quick summary
+    # Filter to JSON lines only (skip non-JSON like sqlite-migration logs on first run)
+    TEXT_CONTENT=$(echo "$RAW_OUTPUT" | grep '^{' | jq -r 'select(.type == "text") | .part.text // empty' 2>/dev/null | tr -d '\n' || echo "")
+    if [[ -z "$TEXT_CONTENT" ]]; then
+        TEXT_CONTENT="(no text extracted from JSON events)"
+    fi
+
+    log_info "Response: $TEXT_CONTENT"
+
+    # Sanitize and build report with full JSON event stream
+    SANITIZED=$(echo "$RAW_OUTPUT" | sanitize_json)
+    COMBINED="[opencode output]
+${TEXT_CONTENT}
+
+[Session Messages (sanitized)]
+${SANITIZED}"
+
+    log_pass "$model ($(format_duration "$elapsed"))"
+    report_row "$CASE_NAME" "pass" "$model" "$elapsed" "$COMBINED"
+    ((MODEL_PASSED++)) || true
+done
+
+# 7. Cleanup
+rm -rf "$WORKDIR"
+
+# 8. Summary
+log_header "opencode results: $MODEL_PASSED/$((MODEL_PASSED + MODEL_FAILED)) models passed"
+
+if [[ $MODEL_FAILED -gt 0 ]]; then
+    log_fail "$MODEL_FAILED model(s) failed"
+    exit 1
+fi

--- a/tests/e2e-docker/cases/opencode/test.sh
+++ b/tests/e2e-docker/cases/opencode/test.sh
@@ -1,26 +1,17 @@
 #!/usr/bin/env bash
+# @level: quick
 set -euo pipefail
 
 source /tests/lib/helpers.sh
 
 CASE_NAME="opencode"
 
-log_info "opencode E2E test — all Bailian models"
+log_info "opencode E2E smoke test — single model (quick)"
 
-MODELS=(
-    "qwen3.5-plus"
-    "qwen3-coder-next"
-    "qwen3-coder-plus"
-    "glm-5"
-    "glm-4.7"
-    "kimi-k2.5"
-    "MiniMax-M2.5"
-)
+MODEL="qwen3-coder-plus"
 
-# 1. Verify all models are available
-for model in "${MODELS[@]}"; do
-    check_model_available "$model"
-done
+# 1. Verify model is available
+check_model_available "$MODEL"
 
 # 2. Install opencode + jq for JSON processing
 log_info "Installing opencode and jq..."
@@ -40,73 +31,55 @@ git commit --allow-empty -m "init" -q
 cp /tests/cases/opencode/opencode.json "$WORKDIR/opencode.json"
 
 # 5. Sanitize sensitive data from session JSON
-# Removes: apiKey, api-key, authorization headers, tokens
 sanitize_json() {
     sed -E \
         -e 's/"(apiKey|api-key|api_key|token|authorization|secret)"\s*:\s*"[^"]*"/"\1": "***"/gi' \
         -e 's/sk-[a-zA-Z0-9_-]+/sk-***/g'
 }
 
-# 6. Test each model
-MODEL_PASSED=0
-MODEL_FAILED=0
+# 6. Test single model
+log_info "Testing model: $MODEL"
+timer_start
 
-for model in "${MODELS[@]}"; do
-    log_info "Testing model: $model"
-    timer_start
-
-    # Run once with --format json to capture structured event stream
-    # This includes: text events, tool_use, reasoning, step_start/finish, errors
-    # We extract text content from JSON events for display + include full JSON for details
-    RAW_OUTPUT=$(opencode run --format json -m "proxy/$model" "Respond with exactly: PONG" 2>&1) || {
-        elapsed=$(timer_elapsed)
-        log_fail "$model — opencode exited with code $? ($(format_duration "$elapsed"))"
-        echo "$RAW_OUTPUT"
-
-        SANITIZED=$(echo "$RAW_OUTPUT" | sanitize_json)
-        report_row "$CASE_NAME" "fail" "$model" "$elapsed" "$SANITIZED"
-        ((MODEL_FAILED++)) || true
-        continue
-    }
-
+RAW_OUTPUT=$(opencode run --format json -m "proxy/$MODEL" "Respond with exactly: PONG" 2>&1) || {
     elapsed=$(timer_elapsed)
+    log_fail "$MODEL — opencode exited with code $? ($(format_duration "$elapsed"))"
+    echo "$RAW_OUTPUT"
 
-    if [[ -z "$RAW_OUTPUT" ]]; then
-        log_fail "$model — empty output ($(format_duration "$elapsed"))"
-        report_row "$CASE_NAME" "fail" "$model" "$elapsed" "(empty output)"
-        ((MODEL_FAILED++)) || true
-        continue
-    fi
-
-    # Extract text content from JSON events for quick summary
-    # Filter to JSON lines only (skip non-JSON like sqlite-migration logs on first run)
-    TEXT_CONTENT=$(echo "$RAW_OUTPUT" | grep '^{' | jq -r 'select(.type == "text") | .part.text // empty' 2>/dev/null | tr -d '\n' || echo "")
-    if [[ -z "$TEXT_CONTENT" ]]; then
-        TEXT_CONTENT="(no text extracted from JSON events)"
-    fi
-
-    log_info "Response: $TEXT_CONTENT"
-
-    # Sanitize and build report with full JSON event stream
     SANITIZED=$(echo "$RAW_OUTPUT" | sanitize_json)
-    COMBINED="[opencode output]
+    report_row "$CASE_NAME" "fail" "$MODEL" "$elapsed" "$SANITIZED"
+    rm -rf "$WORKDIR"
+    exit 1
+}
+
+elapsed=$(timer_elapsed)
+
+if [[ -z "$RAW_OUTPUT" ]]; then
+    log_fail "$MODEL — empty output ($(format_duration "$elapsed"))"
+    report_row "$CASE_NAME" "fail" "$MODEL" "$elapsed" "(empty output)"
+    rm -rf "$WORKDIR"
+    exit 1
+fi
+
+# Extract text content from JSON events
+TEXT_CONTENT=$(echo "$RAW_OUTPUT" | grep '^{' | jq -r 'select(.type == "text") | .part.text // empty' 2>/dev/null | tr -d '\n' || echo "")
+if [[ -z "$TEXT_CONTENT" ]]; then
+    TEXT_CONTENT="(no text extracted from JSON events)"
+fi
+
+log_info "Response: $TEXT_CONTENT"
+
+SANITIZED=$(echo "$RAW_OUTPUT" | sanitize_json)
+COMBINED="[opencode output]
 ${TEXT_CONTENT}
 
 [Session Messages (sanitized)]
 ${SANITIZED}"
 
-    log_pass "$model ($(format_duration "$elapsed"))"
-    report_row "$CASE_NAME" "pass" "$model" "$elapsed" "$COMBINED"
-    ((MODEL_PASSED++)) || true
-done
+log_pass "$MODEL ($(format_duration "$elapsed"))"
+report_row "$CASE_NAME" "pass" "$MODEL" "$elapsed" "$COMBINED"
 
 # 7. Cleanup
 rm -rf "$WORKDIR"
 
-# 8. Summary
-log_header "opencode results: $MODEL_PASSED/$((MODEL_PASSED + MODEL_FAILED)) models passed"
-
-if [[ $MODEL_FAILED -gt 0 ]]; then
-    log_fail "$MODEL_FAILED model(s) failed"
-    exit 1
-fi
+log_header "opencode smoke test passed"

--- a/tests/e2e-docker/entrypoint.sh
+++ b/tests/e2e-docker/entrypoint.sh
@@ -18,9 +18,12 @@ wait_for_health "$GATEWAY_URL/health" 30
 
 # 4. Discover & run test cases
 FILTER="${TEST_FILTER:-}"
+LEVEL="${TEST_LEVEL:-quick}"
 PASSED=0
 FAILED=0
 SKIPPED=0
+
+log_info "Test level: $LEVEL"
 
 timer_start
 SUITE_START=$_TIMER_START
@@ -38,6 +41,17 @@ for test_dir in /tests/cases/*/; do
     # Skip directories without test.sh
     if [[ ! -f "$test_dir/test.sh" ]]; then
         log_warn "Skipping: $name (no test.sh)"
+        ((SKIPPED++)) || true
+        continue
+    fi
+
+    # Read @level metadata from test.sh (default: quick)
+    case_level=$(grep -m1 '^# @level:' "$test_dir/test.sh" | sed 's/^# @level:[[:space:]]*//' || echo "quick")
+    case_level="${case_level:-quick}"
+
+    # Skip if test level exceeds requested level
+    if [[ "$LEVEL" == "quick" && "$case_level" == "full" ]]; then
+        log_info "Skipping: $name (level: full, running: quick)"
         ((SKIPPED++)) || true
         continue
     fi


### PR DESCRIPTION
## Summary

- Add `TEST_LEVEL` system (`quick`/`full`) to E2E Docker test framework
- Each `test.sh` declares its level via `# @level:` metadata on line 2
- `entrypoint.sh` reads `TEST_LEVEL` env var and skips tests above the requested level
- Split opencode into quick smoke test (1 model) and full multi-model test (7 models)
- Add Cline CLI test (`npm install -g cline`, OpenAI-compatible via `OPENAI_BASE_URL`)
- Add Aider test (`pip install aider-chat`, OpenAI-compatible via `OPENAI_API_BASE`)

### Trigger Matrix

| Trigger | `TEST_LEVEL` | What runs |
|---------|-------------|-----------|
| Push to main | `quick` | opencode (1 model) |
| `workflow_dispatch` | `full` | opencode + opencode-full + cline + aider |
| Weekly schedule | `full` | opencode + opencode-full + cline + aider |

## Test plan

- [ ] CI `e2e-docker` job passes on this PR (push → quick mode, only opencode runs)
- [ ] Manual `workflow_dispatch` triggers full suite with all 4 test cases
- [ ] `TEST_FILTER=cline TEST_LEVEL=full` runs only cline test

🤖 Generated with [Claude Code](https://claude.com/claude-code)