### PR TITLE
chore: retro improvements — ship PR detection, rename playbook

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: "End-to-end commit pipeline: lint, test, commit, push, create PR, wait for CI."
+description: "End-to-end commit pipeline: lint, test, commit, push, create PR, wait for CI. Detects existing PRs."
 ---
 
 # Ship Pipeline
@@ -18,28 +18,32 @@ Usage: `ship [--no-pr] [--merge] [commit message]`
 Steps:
 
 1. **Parse arguments**: Extract `--no-pr`, `--merge` flags and commit message
-2. **Format + Check**: Run `make fmt` + `make lint` — fix clippy issues and re-check until passing
-3. **Test**: Run `make test` — fix failures and re-test until passing
-4. **Doc sync check**: Check if changes affect files that require doc updates:
+2. **Existing PR detection**: Check if current branch already has an open PR via `gh pr list --head <branch>`
+   - If open PR exists + `--merge` mode: skip to CI wait + merge step
+   - If open PR exists + no `--merge`: report PR URL, suggest using `--merge`
+   - If no open PR: continue normal flow
+3. **Format + Check**: Run `make fmt` + `make lint` — fix clippy issues and re-check until passing
+4. **Test**: Run `make test` — fix failures and re-test until passing
+5. **Doc sync check**: Check if changes affect files that require doc updates:
    - `crates/core/src/provider.rs` or `config.rs` → check `docs/reference/types/`
    - `crates/server/src/handler/` or `lib.rs` routes → check `docs/reference/api-surface.md`
    - `crates/provider/src/` new executor → check `docs/playbooks/add-provider.md`
    - `crates/translator/src/` new translator → check `docs/playbooks/add-translator.md`
-5. **Spec association check**: Read `docs/specs/_index.md`, if related Active Spec:
+6. **Spec association check**: Read `docs/specs/_index.md`, if related Active Spec:
    - Check if changes complete the Spec fully
    - If complete: advance Spec (Active → Completed), move directory, update `_index.md`
    - Include Spec changes in this commit
-6. **Branch management**:
+7. **Branch management**:
    - If on `main` with uncommitted changes: derive branch name from commit message, create and switch
    - If on `main` with committed changes ahead of origin: create branch, reset main to origin, switch
-7. **Stage**: `git add` changed files (exclude `config.yaml` / `.env` / secrets)
-8. **Commit**: Use provided or derived commit message (conventional commit format)
-9. **Push**: `git push -u origin HEAD`
-10. **Create PR** (unless `--no-pr`):
+8. **Stage**: `git add` changed files (exclude `config.yaml` / `.env` / secrets)
+9. **Commit**: Use provided or derived commit message (conventional commit format)
+10. **Push**: `git push -u origin HEAD`
+11. **Create PR** (unless `--no-pr`):
     a. Derive PR title from branch name and commits
     b. Generate PR body with Summary, Changes, Spec & Doc Impact, Test Plan
     c. `gh pr create --title "..." --body "..."`
     d. `gh pr checks --watch` — wait for CI
     e. If `--merge` and CI passes: merge PR, handle stacked PRs if any
-11. **Local cleanup** (merge mode only): checkout main, pull, delete local branch
-12. **Report**: commit SHA, push result, PR URL, CI/merge status
+12. **Local cleanup** (merge mode only): checkout main, pull, delete local branch
+13. **Report**: commit SHA, push result, PR URL, CI/merge status

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -11,18 +11,22 @@
 Steps:
 
 1. **解析参数**: 从 `$ARGUMENTS` 中提取 `--no-pr`、`--merge` 标志和 commit message（如有）
-2. **格式化 + 检查**: Run `make fmt` + `make lint` — 发现 clippy 问题则修复代码并重新检查，直到通过
-3. **测试**: Run `make test` — 发现失败则修复并重新测试，直到通过
-4. **文档同步检查**: 检查改动是否涉及以下文件，如有则提醒同步文档:
+2. **已有 PR 检测**: 用 `gh pr list --head <current-branch> --state open --json number,url` 检查当前分支是否已有 open PR
+   - 如果有 open PR 且是 `--merge` 模式: 跳过步骤 3-10，直接跳到步骤 11d（等待 CI + merge）
+   - 如果有 open PR 且非 `--merge` 模式: 报告 PR URL，提示用 `--merge` 来合并
+   - 如果没有 open PR: 继续正常流程
+3. **格式化 + 检查**: Run `make fmt` + `make lint` — 发现 clippy 问题则修复代码并重新检查，直到通过
+4. **测试**: Run `make test` — 发现失败则修复并重新测试，直到通过
+5. **文档同步检查**: 检查改动是否涉及以下文件，如有则提醒同步文档:
    - `crates/core/src/provider.rs` 或 `config.rs` 变更 → 检查 `docs/reference/types/` 是否需要更新
    - `crates/server/src/handler/` 或 `lib.rs` 路由变更 → 检查 `docs/reference/api-surface.md`
    - `crates/provider/src/` 新增 executor → 检查 `docs/playbooks/add-provider.md`
    - `crates/translator/src/` 新增翻译器 → 检查 `docs/playbooks/add-translator.md`
-5. **Spec 关联检查**: 读取 `docs/specs/_index.md`，如果有关联的 Active Spec:
+6. **Spec 关联检查**: 读取 `docs/specs/_index.md`，如果有关联的 Active Spec:
    - 检查改动是否完成了 Spec 的全部内容
    - 如果已完成：自动执行 `/spec advance SPEC-NNN`（Active → Completed），将目录从 `active/` 移动到 `completed/`，更新 `_index.md`
    - 将 Spec 变更一并加入本次提交
-6. **分支管理**:
+7. **分支管理**:
    - 如果当前在 `main` 分支且有**未暂存/未提交**的改动:
      - 从 commit message 推导分支名（如 `feat: add daemon support` → `feature/daemon-support`）
      - 分支名规则: `feat:` → `feature/`, `fix:` → `fix/`, `docs:` → `docs/`, `refactor:` → `refactor/`, `test:` → `test/`, `chore:` → `chore/`
@@ -33,10 +37,10 @@ Steps:
      - `git reset --hard origin/main` — 将 main 回退到 origin/main
      - `git checkout <branch-name>` — 切换到新分支
      - 这样 main 保持与 origin/main 同步，新提交在 feature 分支上
-7. **暂存**: `git add` 改动文件（排除 `config.yaml` / `.env` 等敏感文件）
-8. **提交**: 如果参数中指定了 commit message，使用该 message；否则从分支名 + 改动推导（conventional commit 格式: `feat:`/`fix:`/`docs:`/`refactor:`/`test:`/`chore:`）。执行 `git commit`
-9. **推送**: `git push -u origin HEAD`
-10. **创建 PR**（除非 `--no-pr`）:
+8. **暂存**: `git add` 改动文件（排除 `config.yaml` / `.env` 等敏感文件）
+9. **提交**: 如果参数中指定了 commit message，使用该 message；否则从分支名 + 改动推导（conventional commit 格式: `feat:`/`fix:`/`docs:`/`refactor:`/`test:`/`chore:`）。执行 `git commit`
+10. **推送**: `git push -u origin HEAD`
+11. **创建 PR**（除非 `--no-pr`）:
    a. 从分支名和 commit 历史推导 PR 标题（conventional commit 格式，70 字符内）
    b. 生成 PR body:
       ```
@@ -63,7 +67,7 @@ Steps:
         2. 然后 `gh pr merge --merge --delete-branch`
       - 如果没有依赖 PR: `gh pr merge --merge --delete-branch`
    f. 报告 PR URL 和 CI 结果（及 merge 状态）
-11. **本地清理** (仅 `--merge` 且合并成功后):
+12. **本地清理** (仅 `--merge` 且合并成功后):
     - `git checkout main && git pull origin main`
     - `git branch -d <branch-name>` — 删除本地已合并的分支
-12. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）、merge 状态（如适用）
+13. **结果报告**: 报告 commit SHA、push 结果、PR URL（如适用）、merge 状态（如适用）

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: "End-to-end commit pipeline: lint, test, commit, push, create PR"
+description: "End-to-end commit pipeline: lint, test, commit, push, create PR. Detects existing PRs."
 ---
 
 End-to-end commit pipeline. Arguments: $1 $2 $3 (flags and commit message).
@@ -14,19 +14,23 @@ Usage:
 Steps:
 
 1. **Parse arguments**: Extract `--no-pr`, `--merge` flags and commit message
-2. **Format + Check**: `make fmt` + `make lint` — fix issues until passing
-3. **Test**: `make test` — fix failures until passing
-4. **Doc sync check**: If changes touch core types/server routes/providers, check if docs need updating
-5. **Spec check**: Read `docs/specs/_index.md`, if related Active Spec is fully completed, advance it
-6. **Branch management**:
+2. **Existing PR detection**: Check if current branch already has an open PR
+   - If open PR + `--merge`: skip to CI wait + merge
+   - If open PR + no `--merge`: report PR URL, suggest `--merge`
+   - If no open PR: continue normal flow
+3. **Format + Check**: `make fmt` + `make lint` — fix issues until passing
+4. **Test**: `make test` — fix failures until passing
+5. **Doc sync check**: If changes touch core types/server routes/providers, check if docs need updating
+6. **Spec check**: Read `docs/specs/_index.md`, if related Active Spec is fully completed, advance it
+7. **Branch management**:
    - On `main` with uncommitted changes: derive branch name from commit message, create and switch
    - On `main` with committed changes ahead: create branch, reset main to origin, switch
-7. **Stage**: `git add` changed files (exclude config.yaml/.env/secrets)
-8. **Commit**: Use provided or derived conventional commit message
-9. **Push**: `git push -u origin HEAD`
-10. **Create PR** (unless `--no-pr`):
+8. **Stage**: `git add` changed files (exclude config.yaml/.env/secrets)
+9. **Commit**: Use provided or derived conventional commit message
+10. **Push**: `git push -u origin HEAD`
+11. **Create PR** (unless `--no-pr`):
     - Derive title, generate body with Summary/Changes/Doc Impact/Test Plan
     - `gh pr create`, `gh pr checks --watch`
     - If `--merge` + CI passes: handle stacked PRs, then merge
-11. **Cleanup** (merge only): checkout main, pull, delete local branch
-12. **Report**: commit SHA, push result, PR URL, CI/merge status
+12. **Cleanup** (merge only): checkout main, pull, delete local branch
+13. **Report**: commit SHA, push result, PR URL, CI/merge status

--- a/docs/playbooks/rename-project.md
+++ b/docs/playbooks/rename-project.md
@@ -1,0 +1,96 @@
+# Playbook: Rename Project
+
+Step-by-step guide for renaming the project (crate names, binary, env vars, Docker, docs).
+
+## Prerequisites
+
+- All tests passing on current main
+- No open PRs that would conflict
+
+## Steps
+
+### 1. Cargo.toml files (5 files)
+
+Update package names and dependency references:
+- `Cargo.toml` (root) — package name, all workspace dep names
+- `crates/core/Cargo.toml` — package name
+- `crates/provider/Cargo.toml` — package name + deps
+- `crates/translator/Cargo.toml` — package name + deps
+- `crates/server/Cargo.toml` — package name + deps
+
+### 2. Rust source code (~40 files)
+
+Bulk find-replace across all `.rs` files:
+- `old_core` → `new_core` (use statements)
+- `old_provider` → `new_provider`
+- `old_translator` → `new_translator`
+- `old_server` → `new_server`
+
+Also update:
+- `crates/core/src/prometheus.rs` — metric name prefix strings
+- `crates/core/src/proxy.rs` — user-agent string
+- `crates/core/src/config.rs` — PID file default, test assertions
+- `crates/core/src/lifecycle/logging.rs` — log filename
+- `src/main.rs` — status print messages
+
+### 3. CLI & env vars
+
+- `src/cli.rs` — `#[command(name = "...")]`, env var prefixes, PID file default
+
+### 4. Docker & deployment
+
+- `Dockerfile` — binary name, user/group, config paths
+- `docker-compose.yml` — service name, image tag, volume paths
+- `docker-compose.e2e.yml` — volume paths
+- `Makefile` — docker image/container name, volume paths
+- `dist/*.service` — rename file, update all internal references
+
+### 5. Config files
+
+- `config.example.yaml` — header comment, pid-file path
+- `config.test.yaml` — pid-file path
+- `.env.example` — header comment, env var names, RUST_LOG filter
+
+### 6. CI/CD workflows
+
+- `.github/workflows/security.yml` — docker image tag
+
+### 7. Web frontend
+
+- `web/package.json` — name field
+- Regenerate `web/package-lock.json` via `cd web && npm install`
+
+### 8. Documentation
+
+- `AGENTS.md` (= `CLAUDE.md`) — project name, crate names, command examples, env vars
+- `README.md` — project name, binary name, all examples
+- `LICENSE` — copyright holder
+- `docs/reference/architecture.md` — crate names, binary name
+- `docs/reference/types/*.md` — source file citations
+- `docs/playbooks/*.md` — project name, import examples
+- `docs/specs/completed/*/technical-design.md` — project references
+
+### 9. Agent/command config files
+
+- `.claude/`, `.agents/`, `.opencode/` files that reference old name
+
+### 10. Cargo.lock regeneration
+
+```sh
+rm Cargo.lock
+cargo generate-lockfile
+```
+
+## Verification Checklist
+
+1. `cargo build --workspace` — compile succeeds
+2. `make lint` — fmt + clippy pass
+3. `make test` — all tests pass
+4. `grep -r "old_name" --include="*.rs" --include="*.toml" --include="*.yml" --include="*.yaml" --include="*.md" --include="*.json" .` — zero results (excluding .git, target, node_modules)
+5. Docker build: `docker build -t new_name:local .` — succeeds
+
+## Post-merge
+
+- GitHub repo rename: Settings → General → Repository name
+- Update local remote: `git remote set-url origin <new-url>`
+- `gh repo rename <new-name> --yes` can also be used from CLI


### PR DESCRIPTION
## Summary
- Add existing PR detection to `/ship` command so `--merge` can directly merge without re-running full pipeline
- Add `docs/playbooks/rename-project.md` with step-by-step rename guide

## Changes
- `.claude/commands/ship.md` — new step 2: existing PR detection
- `.agents/skills/ship/SKILL.md` — synced
- `.opencode/commands/ship.md` — synced
- `docs/playbooks/rename-project.md` — new playbook

## Spec & Reference Doc Impact
None

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)