### PR TITLE
chore: retro improvements — audit command, lint --tests, path fixes

### DIFF
--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: audit
+description: "Full codebase review and batch fix. Supports scopes: all/security/stability/performance/refactor. Use --fix to auto-fix."
+---
+
+# Codebase Audit
+
+Full codebase review with optional batch fix. The user specifies an optional scope (default: all) and --fix flag.
+
+Steps:
+
+1. **Parse arguments**: Extract `--fix` flag and scope filter (all/security/stability/performance/refactor)
+
+2. **Parallel review**: Dispatch review tasks by crate:
+   - `prism-core` — config, error handling, type safety, panic sites
+   - `prism-provider` — executors, SSE parsing, credential routing, network safety
+   - `prism-translator` — format conversion, streaming state, JSON parsing
+   - `prism-server` — middleware, dispatch, handlers, auth
+   - Cross-crate — architectural consistency, interface contracts, dependency direction
+
+   Each review checks:
+   - **Security**: unwrap/panic, buffer overflow, injection, auth bypass, info leaks
+   - **Stability**: swallowed errors, lock poisoning, TOCTOU, resource leaks
+   - **Performance**: O(n^2) lookups, unnecessary allocations, hot path optimization
+   - **Refactoring**: code duplication, oversized functions, type safety improvements
+
+3. **Classify findings**: Organize by priority (P0 Critical, P1 High, P2 Medium)
+
+4. **If --fix**: Batch fix all findings, verify with `make lint` + `make test`
+
+5. **If no --fix**: Optionally create GitHub Issues for tracking
+
+6. **Report**: Total findings, fixes applied, remaining items

--- a/.agents/skills/diagnose/SKILL.md
+++ b/.agents/skills/diagnose/SKILL.md
@@ -15,7 +15,7 @@ Steps:
    - Config/hot-reload → crates/core/src/config.rs (ConfigWatcher)
    - Auth issues → crates/server/src/auth.rs
    - Cloaking/Payload → crates/core/src/cloak.rs, crates/core/src/payload.rs
-   - Request dispatch/retry → crates/server/src/dispatch.rs
+   - Request dispatch/retry → crates/server/src/dispatch/ (mod.rs, helpers.rs, streaming.rs, retry.rs)
    - Provider execution → crates/provider/src/ (corresponding executor)
 2. Examine related code paths:
    - Read potentially involved source files

--- a/.agents/skills/lint/SKILL.md
+++ b/.agents/skills/lint/SKILL.md
@@ -14,14 +14,14 @@ Modes:
 ## check mode
 
 1. `cargo fmt --check` — Check formatting
-2. `cargo clippy --workspace -- -D warnings` — Check lint rules
+2. `cargo clippy --workspace --tests -- -D warnings` — Check lint rules
 3. Summarize: format issue count + clippy warning count
 4. If issues found, list each with file location and fix suggestion
 
 ## fix mode
 
 1. `cargo fmt` — Auto-format
-2. `cargo clippy --workspace -- -D warnings` — Check lint rules
+2. `cargo clippy --workspace --tests -- -D warnings` — Check lint rules
 3. If clippy warnings found, try `cargo clippy --fix --allow-dirty --workspace`
-4. Re-run `cargo clippy --workspace -- -D warnings` to confirm all pass
+4. Re-run `cargo clippy --workspace --tests -- -D warnings` to confirm all pass
 5. Summarize: auto-fixed count + remaining manual-fix count

--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,53 @@
+全量代码审查+批量修复。Argument $ARGUMENTS: `[--fix] [scope]`（scope: all/security/stability/performance/refactor，default: all）。
+
+用法:
+- `/audit` — 审查全部代码，输出问题报告
+- `/audit security` — 仅审查安全相关问题
+- `/audit --fix` — 审查并自动修复所有问题
+- `/audit --fix stability` — 仅修复稳定性问题
+
+Steps:
+
+1. **解析参数**: 提取 `--fix` 标志和 scope 过滤器
+
+2. **并行审查**: 按 crate 分派审查任务（可并行）:
+   - `prism-core` — 配置、错误处理、类型安全、panic sites
+   - `prism-provider` — 执行器、SSE 解析、凭证路由、网络安全
+   - `prism-translator` — 格式转换、流式状态、JSON 解析
+   - `prism-server` — 中间件、dispatch、handler、认证
+   - 跨 crate — 架构一致性、接口契约、依赖方向
+
+   每个审查关注:
+   - **安全**: unwrap/panic、缓冲区溢出、注入、认证绕过、敏感信息泄漏
+   - **稳定性**: 错误吞没、锁 poison、TOCTOU、资源泄漏
+   - **性能**: O(n²) 查找、不必要分配、热路径优化
+   - **重构**: 代码重复、过长函数、类型安全改进
+
+3. **汇总分类**: 按优先级整理发现:
+
+   ## 审查报告
+
+   ### P0 — Critical (安全)
+   | # | 文件:行号 | 问题 | 修复建议 |
+
+   ### P1 — High (稳定性)
+   | # | 文件:行号 | 问题 | 修复建议 |
+
+   ### P2 — Medium (性能/重构)
+   | # | 文件:行号 | 问题 | 修复建议 |
+
+4. **如果 `--fix`**: 批量修复
+   a. 按优先级从高到低修复每个问题
+   b. 每修完一批（同 crate 的改动）运行 `cargo check`
+   c. 全部修完后运行 `make lint` + `make test`
+   d. 如需创建 Spec（重构类改动），自动创建并关联
+
+5. **创建 GitHub Issues**（可选，仅无 `--fix` 时）:
+   - 询问用户是否要创建 issues
+   - 按问题逐个 `gh issue create`，附标签和优先级
+
+6. **结果报告**:
+   - 发现问题总数（按优先级）
+   - 修复数（如 `--fix`）
+   - 剩余需手动处理的问题
+   - 下一步建议（如 `/ship` 提交修复）

--- a/.claude/commands/diagnose.md
+++ b/.claude/commands/diagnose.md
@@ -8,7 +8,7 @@ Steps:
    - 配置/热重载 → crates/core/src/config.rs (ConfigWatcher)
    - 认证问题 → crates/server/src/auth.rs
    - Cloaking/Payload → crates/core/src/cloak.rs, crates/core/src/payload.rs
-   - 请求分发/重试 → crates/server/src/dispatch.rs
+   - 请求分发/重试 → crates/server/src/dispatch/ (mod.rs, helpers.rs, streaming.rs, retry.rs)
    - Provider 执行 → crates/provider/src/ (对应的 executor)
 2. 检查相关代码路径:
    - 读取可能涉及的源文件

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -8,13 +8,13 @@ Steps:
 
 **check 模式:**
 1. `cargo fmt --check` — 检查格式
-2. `cargo clippy --workspace -- -D warnings` — 检查 lint 规则
+2. `cargo clippy --workspace --tests -- -D warnings` — 检查 lint 规则
 3. 汇总: 格式问题数 + clippy 警告数
 4. 如有问题，列出每个问题的文件位置和修复建议
 
 **fix 模式:**
 1. `cargo fmt` — 自动格式化
-2. `cargo clippy --workspace -- -D warnings` — 检查 lint 规则
+2. `cargo clippy --workspace --tests -- -D warnings` — 检查 lint 规则
 3. 如有 clippy 警告，尝试应用 `cargo clippy --fix --allow-dirty --workspace`
-4. 再次运行 `cargo clippy --workspace -- -D warnings` 确认全部通过
+4. 再次运行 `cargo clippy --workspace --tests -- -D warnings` 确认全部通过
 5. 汇总: 自动修复数 + 剩余需手动修复数

--- a/.opencode/commands/audit.md
+++ b/.opencode/commands/audit.md
@@ -1,0 +1,19 @@
+---
+description: "Full codebase review and batch fix"
+---
+
+Full codebase audit. Args: $1 (scope: all/security/stability/performance/refactor, default: all). Add --fix to auto-fix.
+
+Steps:
+1. Parse arguments: extract --fix flag and scope filter
+2. Review each crate in parallel:
+   - prism-core: config, errors, type safety, panic sites
+   - prism-provider: executors, SSE, credential routing, network safety
+   - prism-translator: format conversion, streaming state, JSON parsing
+   - prism-server: middleware, dispatch, handlers, auth
+   - Cross-crate: architecture, interface contracts
+3. Check for: security (unwrap/panic, injection, auth bypass), stability (swallowed errors, lock poison, TOCTOU), performance (O(n^2), allocations), refactoring (duplication, type safety)
+4. Classify findings by priority (P0/P1/P2)
+5. If --fix: batch fix, then `make lint` + `make test`
+6. If no --fix: optionally create GitHub Issues
+7. Report: total findings, fixes applied, remaining items

--- a/.opencode/commands/diagnose.md
+++ b/.opencode/commands/diagnose.md
@@ -12,7 +12,7 @@ Steps:
    - Config/hot-reload → crates/core/src/config.rs
    - Auth → crates/server/src/auth.rs
    - Cloaking/Payload → crates/core/src/cloak.rs, crates/core/src/payload.rs
-   - Dispatch/retry → crates/server/src/dispatch.rs
+   - Dispatch/retry → crates/server/src/dispatch/ (mod.rs, helpers.rs, streaming.rs, retry.rs)
    - Provider execution → crates/provider/src/
 2. Examine related code paths, error handling (ProxyError), config.example.yaml
 3. Attempt to reproduce: check existing tests, construct minimal test case if needed

--- a/.opencode/commands/lint.md
+++ b/.opencode/commands/lint.md
@@ -6,13 +6,13 @@ Run code linting. Mode: $1 (default: check).
 
 **check mode:**
 1. `cargo fmt --check` — check formatting
-2. `cargo clippy --workspace -- -D warnings` — check lint rules
+2. `cargo clippy --workspace --tests -- -D warnings` — check lint rules
 3. Summarize: format issues + clippy warnings
 4. List each issue with file location and fix suggestion
 
 **fix mode:**
 1. `cargo fmt` — auto-format
-2. `cargo clippy --workspace -- -D warnings` — check lint rules
+2. `cargo clippy --workspace --tests -- -D warnings` — check lint rules
 3. If warnings: `cargo clippy --fix --allow-dirty --workspace`
 4. Re-run clippy to confirm all pass
 5. Summarize: auto-fixed count + remaining manual-fix count

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,27 @@ make docker-compose-down   # Stop docker compose services
 make audit   # cargo audit — check for known vulnerabilities
 ```
 
+## Slash Commands
+
+Agent commands defined in `.claude/commands/`. Portable to OpenCode (`.opencode/commands/`) and Codex (`.agents/skills/`) via `/sync-commands`.
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/ship` | End-to-end commit pipeline (lint, test, commit, push, PR, CI) | `/ship --merge "feat: xxx"` |
+| `/audit` | Full codebase review + batch fix | `/audit --fix security` |
+| `/lint` | Run formatting + clippy checks | `/lint fix` |
+| `/test` | Run tests (unit, e2e, docker) | `/test unit` |
+| `/spec` | Manage spec lifecycle (create/list/advance/td) | `/spec create "Title"` |
+| `/implement` | Implement a spec end-to-end | `/implement SPEC-008` |
+| `/issues` | Generate GitHub issues from spec | `/issues SPEC-009` |
+| `/review` | Review a pull request | `/review 114` |
+| `/diagnose` | Diagnose and fix a project problem | `/diagnose "SSE timeout"` |
+| `/deps` | Dependency management (merge/fix/update) | `/deps merge` |
+| `/merge` | Batch merge multiple PRs | `/merge 81 85` |
+| `/doc-audit` | Audit docs vs code consistency | `/doc-audit full --fix` |
+| `/retro` | Retrospective: improve commands/workflow | `/retro 3` |
+| `/sync-commands` | Sync command definitions across agent tools | `/sync-commands` |
+
 ## Rules
 
 - **Lint before commit**: Run `make lint` and fix all warnings before committing.


### PR DESCRIPTION
## Summary
- Add new `/audit` command for full codebase review + batch fix workflow
- Fix clippy `--tests` flag missing from lint command across all agent formats
- Update stale `dispatch.rs` path references after module split
- Add Slash Commands reference table to CLAUDE.md

## Changes
- `.claude/commands/audit.md` — New audit command (SSOT)
- `.agents/skills/audit/SKILL.md` — Portable skill version
- `.opencode/commands/audit.md` — OpenCode version
- `.claude/commands/lint.md` + portable copies — Add `--tests` to clippy
- `.claude/commands/diagnose.md` + portable copies — Fix dispatch path
- `CLAUDE.md` (via AGENTS.md symlink) — Add Slash Commands table

## Spec & Reference Doc Impact
None — tooling and documentation only

## Test Plan
- [x] No code changes — tooling only
- [x] All 3 agent formats (claude/skills/opencode) are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)