### PR TITLE
docs: fix 8 doc-code inconsistencies found by full audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ HTTP server and request dispatch:
 - Handlers: `chat_completions`, `messages`, `responses`, `models`, `admin`, `health`
 - Auth: `auth.rs` -- Bearer token / x-api-key validation (top-level module)
 - Middleware: `request_logging`, `request_context`, `dashboard_auth` (JWT), `rate_limit` (in `middleware/` directory)
-- `dispatch` -- Core routing logic with retry, credential rotation, translation, cloaking, payload rules, model fallback (`models` array), debug mode (`x-debug` header), cost calculation, and token usage extraction
-- `streaming` -- SSE response builder with keepalive
+- `dispatch/` -- Core routing logic (split into `mod.rs`, `helpers.rs`, `streaming.rs`, `retry.rs`): credential rotation, translation, cloaking, payload rules, model fallback (`models` array), debug mode (`x-debug` header), cost calculation, token usage extraction, and keepalive body builder
+- `streaming` -- SSE response builder
 - `handler/dashboard/` -- Dashboard API handlers:
   - `auth` -- Login (bcrypt verify + JWT), token refresh
   - `providers` -- Provider CRUD with API key masking and atomic config write-back

--- a/docs/reference/types/errors.md
+++ b/docs/reference/types/errors.md
@@ -42,8 +42,11 @@ pub enum ProxyError {
     #[error("model not found: {0}")]
     ModelNotFound(String),
 
-    #[error("rate limit exceeded: {0}")]
-    RateLimited(String),
+    #[error("rate limit exceeded: {message}")]
+    RateLimited {
+        message: String,
+        retry_after_secs: u64,
+    },
 
     #[error("model access denied: {0}")]
     ModelNotAllowed(String),
@@ -71,7 +74,7 @@ pub enum ProxyError {
 | `Translation` | `String` | Error during request/response format translation (JSON parse errors, missing fields). |
 | `BadRequest` | `String` | Malformed client request (missing model field, invalid JSON, etc.). |
 | `ModelNotFound` | `String` | No provider has a credential that supports the requested model. |
-| `RateLimited` | `String` | Global or per-key rate limit exceeded (RPM, TPM, or daily cost). |
+| `RateLimited` | `message: String, retry_after_secs: u64` | Global or per-key rate limit exceeded (RPM, TPM, or daily cost). `retry_after_secs` is used in the `Retry-After` response header. |
 | `ModelNotAllowed` | `String` | The auth key does not have access to the requested model (restricted by `allowed_models`). |
 | `KeyExpired` | (none) | The client's API key has passed its `expires_at` date. |
 | `Internal` | `String` | Unexpected internal error (response build failure, task panic, etc.). |

--- a/docs/reference/types/provider.md
+++ b/docs/reference/types/provider.md
@@ -257,6 +257,7 @@ Thread-safe credential store that selects the appropriate credential for each re
 ```rust
 pub struct CredentialRouter {
     credentials: RwLock<HashMap<Format, Vec<AuthRecord>>>,
+    credential_index: RwLock<HashMap<String, (Format, usize)>>,
     counters: RwLock<HashMap<String, AtomicUsize>>,
     strategy: RwLock<RoutingStrategy>,
     latency_ewma: RwLock<HashMap<String, f64>>,
@@ -348,8 +349,8 @@ pub struct TranslateState {
     pub response_id: String,
     pub model: String,
     pub created: i64,
-    pub current_tool_call_index: i32,
-    pub current_content_index: i32,
+    pub current_tool_call_index: Option<usize>,
+    pub current_content_index: Option<usize>,
     pub sent_role: bool,
     pub input_tokens: u64,
 }
@@ -360,8 +361,8 @@ pub struct TranslateState {
 | `response_id` | `String` | `""` | Generated response ID for the translated response. |
 | `model` | `String` | `""` | Model name for the translated response. |
 | `created` | `i64` | `0` | Unix timestamp for the translated response. |
-| `current_tool_call_index` | `i32` | `0` | Tracks the current tool call index during stream assembly. |
-| `current_content_index` | `i32` | `0` | Tracks the current content block index during stream assembly. |
+| `current_tool_call_index` | `Option<usize>` | `None` | Tracks the current tool call index during stream assembly. |
+| `current_content_index` | `Option<usize>` | `None` | Tracks the current content block index during stream assembly. |
 | `sent_role` | `bool` | `false` | Whether the assistant role delta has been emitted. |
 | `input_tokens` | `u64` | `0` | Accumulated input token count from upstream. |
 

--- a/docs/specs/completed/SPEC-012/technical-design.md
+++ b/docs/specs/completed/SPEC-012/technical-design.md
@@ -5,7 +5,7 @@
 | Spec ID   | SPEC-012       |
 | Title     | Rate Limiting  |
 | Author    | AI Proxy Team  |
-| Status    | Active         |
+| Status    | Completed      |
 | Created   | 2026-03-01     |
 | Updated   | 2026-03-01     |
 

--- a/docs/specs/completed/SPEC-013/technical-design.md
+++ b/docs/specs/completed/SPEC-013/technical-design.md
@@ -5,7 +5,7 @@
 | Spec ID   | SPEC-013                    |
 | Title     | Model Fallback & Debug Mode |
 | Author    | AI Proxy Team               |
-| Status    | Active                      |
+| Status    | Completed                   |
 | Created   | 2026-03-01                  |
 | Updated   | 2026-03-01                  |
 

--- a/docs/specs/completed/SPEC-014/technical-design.md
+++ b/docs/specs/completed/SPEC-014/technical-design.md
@@ -5,7 +5,7 @@
 | Spec ID   | SPEC-014       |
 | Title     | Cost Tracking  |
 | Author    | AI Proxy Team  |
-| Status    | Active         |
+| Status    | Completed      |
 | Created   | 2026-03-01     |
 | Updated   | 2026-03-01     |
 

--- a/docs/specs/completed/SPEC-038/technical-design.md
+++ b/docs/specs/completed/SPEC-038/technical-design.md
@@ -1,45 +1,28 @@
 # SPEC-038: Technical Design — Unify Provider Request Building
 
-## 1. New Helper in `common.rs`
+## 1. Shared Helpers in `common.rs`
 
 File: `crates/provider/src/common.rs`
 
-```rust
-pub fn build_provider_request(
-    client: &reqwest::Client,
-    url: &str,
-    auth: &AuthRecord,
-    payload: &[u8],
-    auth_header: AuthHeaderStyle,
-) -> reqwest::RequestBuilder {
-    let mut req = client
-        .post(url)
-        .header("content-type", "application/json")
-        .body(payload.to_vec());
-
-    req = match auth_header {
-        AuthHeaderStyle::Bearer => req.header("authorization", format!("Bearer {}", auth.api_key)),
-        AuthHeaderStyle::XApiKey => req.header("x-api-key", &auth.api_key),
-        AuthHeaderStyle::XGoogApiKey => req.header("x-goog-api-key", &auth.api_key),
-    };
-
-    req = apply_headers(req, &auth.headers);
-    req
-}
-
-pub enum AuthHeaderStyle {
-    Bearer,
-    XApiKey,
-    XGoogApiKey,
-}
-```
+Existing helpers used by all executors:
+- `build_client(auth, global_proxy)` — Creates `reqwest::Client` with optional proxy
+- `apply_headers(req, headers, auth)` — Applies custom headers and auth header based on provider format
 
 ## 2. Executor Updates
 
-- **Claude** (`claude.rs`): Use `build_provider_request(client, url, auth, payload, AuthHeaderStyle::XApiKey)`
-- **Gemini** (`gemini.rs`): Use `build_provider_request(client, url, auth, payload, AuthHeaderStyle::XGoogApiKey)`
-- **OpenAICompat** (`openai_compat.rs`): Use `build_provider_request(client, url, auth, payload, AuthHeaderStyle::Bearer)` in both `execute()` and `execute_stream()`
+- **Gemini** (`gemini.rs`): Changed from manual header loop to `common::apply_headers(req, &request.headers, auth)` for consistency
+- **OpenAICompat** (`openai_compat.rs`): Extracted `build_request()` method to deduplicate request building between `execute()` and `execute_stream()`:
 
-## 3. apply_headers stays in common.rs
+```rust
+fn build_request(
+    &self,
+    auth: &AuthRecord,
+    url: &str,
+    body: &[u8],
+    request_headers: &HashMap<String, String>,
+) -> Result<reqwest::RequestBuilder, ProxyError>
+```
 
-Already exists, just ensure all executors use it consistently.
+## 3. Design Decision
+
+Instead of creating a single `build_provider_request()` with an `AuthHeaderStyle` enum (as originally proposed), the implementation kept each executor's existing auth pattern (`apply_headers` handles this) and focused on deduplicating within each executor. This is simpler and avoids an unnecessary abstraction layer.


### PR DESCRIPTION
## Summary
- Fix all doc-code inconsistencies found by `/doc-audit full`
- 4 errors in reference type docs, 1 stale path in CLAUDE.md, 3 stale spec statuses

## Changes

### Reference Docs
- `docs/reference/types/provider.md` — TranslateState fields `i32` → `Option<usize>`, add `credential_index` to CredentialRouter
- `docs/reference/types/errors.md` — RateLimited variant from `(String)` to `{ message, retry_after_secs }`

### CLAUDE.md
- dispatch description updated to reflect `dispatch/` module split

### Specs
- SPEC-012/013/014 — Status `Active` → `Completed` in technical-design.md headers
- SPEC-038 — TD updated to match actual implementation (no AuthHeaderStyle enum)

## Spec & Reference Doc Impact
This PR IS the doc sync fix.

## Test Plan
- [x] No code changes — documentation only
- [x] All differences verified against source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)