### PR TITLE
chore: add frontend build to Docker image and auto-deploy to ECS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,3 +55,47 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to ECS
+    needs: [build-and-push]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.ECS_HOST }}
+          username: ${{ secrets.ECS_USER }}
+          key: ${{ secrets.ECS_SSH_KEY }}
+          script: |
+            set -e
+
+            cd /opt/prism
+
+            # Pull latest image
+            docker pull ghcr.io/wutongshenqiu/prism:latest
+
+            # Extract frontend dist from image
+            CONTAINER_ID=$(docker create ghcr.io/wutongshenqiu/prism:latest)
+            rm -rf /opt/prism/web-dist/*
+            docker cp "$CONTAINER_ID":/usr/share/prism/web/. /opt/prism/web-dist/
+            docker rm "$CONTAINER_ID"
+
+            # Restart prism service
+            docker compose down
+            docker compose up -d
+
+            # Wait for health check
+            echo "Waiting for health check..."
+            for i in $(seq 1 30); do
+              if curl -sf http://localhost:8317/health > /dev/null 2>&1; then
+                echo "Health check passed!"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "Health check failed after 60s"
+            docker compose logs --tail=50
+            exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,14 @@ RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release --bin prism
 
+# === Frontend: build dashboard SPA (parallel with Rust build) ===
+FROM node:20-alpine AS frontend
+WORKDIR /app
+COPY web/package.json web/package-lock.json* ./
+RUN npm ci
+COPY web/ .
+RUN npm run build
+
 # === Runtime ===
 FROM debian:bookworm-slim
 RUN apt-get update \
@@ -24,6 +32,7 @@ RUN apt-get update \
 
 RUN groupadd -g 1001 prism && useradd -u 1001 -g prism -s /bin/false prism
 COPY --from=builder /app/target/release/prism /usr/local/bin/prism
+COPY --from=frontend /app/dist /usr/share/prism/web
 
 USER prism
 EXPOSE 8317


### PR DESCRIPTION
## Summary
- Add parallel frontend build stage to Dockerfile so the React dashboard is built and bundled into the Docker image
- Add auto-deploy job to CD workflow — after image push, SSH to ECS to pull, extract frontend, and restart
- Faster builds via parallel Node.js + Rust build stages

## Changes
- **Dockerfile**: Added `node:20-alpine AS frontend` stage (runs in parallel with Rust build), copies built dist to `/usr/share/prism/web`
- **.github/workflows/cd.yml**: Added `deploy` job that SSHs to ECS, pulls latest image, extracts frontend dist, restarts containers, and verifies health

## Test Plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Docker build succeeds with frontend stage
- [ ] CD pipeline deploys to ECS after image push