### PR TITLE
fix: capture streaming token usage and improve token display UI

### DIFF
--- a/crates/core/src/request_log.rs
+++ b/crates/core/src/request_log.rs
@@ -128,6 +128,21 @@ impl RequestLogStore {
         }
     }
 
+    /// Update usage and cost for an existing log entry (used after streaming completes).
+    pub fn update_usage(
+        &self,
+        request_id: &str,
+        usage: crate::request_record::TokenUsage,
+        cost: Option<f64>,
+    ) {
+        if let Ok(mut entries) = self.entries.write()
+            && let Some(entry) = entries.iter_mut().rfind(|e| e.request_id == request_id)
+        {
+            entry.usage = Some(usage);
+            entry.cost = cost;
+        }
+    }
+
     /// Return summary statistics.
     pub fn stats(&self) -> serde_json::Value {
         let entries = self.entries.read().unwrap();

--- a/crates/core/src/request_record.rs
+++ b/crates/core/src/request_record.rs
@@ -22,6 +22,16 @@ impl TokenUsage {
     pub fn total(&self) -> u64 {
         self.total_input() + self.output_tokens
     }
+
+    /// Merge another usage into this one, taking the max of each field.
+    /// Claude sends input_tokens in `message_start` and output_tokens in `message_delta`,
+    /// so we accumulate by taking the max of each field across events.
+    pub fn merge(&mut self, other: &TokenUsage) {
+        self.input_tokens = self.input_tokens.max(other.input_tokens);
+        self.output_tokens = self.output_tokens.max(other.output_tokens);
+        self.cache_read_tokens = self.cache_read_tokens.max(other.cache_read_tokens);
+        self.cache_creation_tokens = self.cache_creation_tokens.max(other.cache_creation_tokens);
+    }
 }
 
 /// A single request record used for both in-memory log store and persistent audit.
@@ -87,6 +97,27 @@ mod tests {
     fn token_usage_default_is_zero() {
         let usage = TokenUsage::default();
         assert_eq!(usage.total(), 0);
+    }
+
+    #[test]
+    fn token_usage_merge_takes_max() {
+        let mut a = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_read_tokens: 50,
+            cache_creation_tokens: 0,
+        };
+        let b = TokenUsage {
+            input_tokens: 0,
+            output_tokens: 200,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 30,
+        };
+        a.merge(&b);
+        assert_eq!(a.input_tokens, 100);
+        assert_eq!(a.output_tokens, 200);
+        assert_eq!(a.cache_read_tokens, 50);
+        assert_eq!(a.cache_creation_tokens, 30);
     }
 
     #[test]

--- a/crates/server/src/dispatch.rs
+++ b/crates/server/src/dispatch.rs
@@ -13,7 +13,7 @@ use prism_core::error::ProxyError;
 use prism_core::provider::{Format, ProviderRequest, ProviderResponse};
 use retry::handle_retry_error;
 use std::time::{Duration, Instant};
-use streaming::{build_keepalive_body, translate_stream};
+use streaming::{StreamDoneContext, build_keepalive_body, translate_stream, with_usage_capture};
 
 /// A dispatch request encapsulating all information needed to route and execute an API call.
 pub struct DispatchRequest {
@@ -37,6 +37,8 @@ pub struct DispatchRequest {
     pub api_key: Option<String>,
     /// Client region (for geo-aware routing).
     pub client_region: Option<String>,
+    /// Request ID for correlating streaming usage updates with log entries.
+    pub request_id: Option<String>,
 }
 
 /// Debug information collected during dispatch for x-debug response headers.
@@ -285,13 +287,38 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
 
                             let keepalive = config.streaming.keepalive_seconds;
 
-                            // For streaming, we can't easily inject headers after the fact.
-                            // Debug info is not available for streaming responses.
+                            // Wrap upstream stream to capture token usage from SSE events.
+                            // When the stream ends, captured usage is written back to the
+                            // request log entry created by the logging middleware.
+                            let captured_stream = if let Some(ref rid) = req.request_id {
+                                with_usage_capture(
+                                    stream_result.stream,
+                                    StreamDoneContext {
+                                        request_id: rid.clone(),
+                                        model: debug_info.model.clone(),
+                                        request_logs: state.request_logs.clone(),
+                                        cost_calculator: state.cost_calculator.clone(),
+                                        metrics: state.metrics.clone(),
+                                    },
+                                )
+                            } else {
+                                stream_result.stream
+                            };
+
+                            let dispatch_meta = DispatchMeta {
+                                provider: debug_info.provider.clone(),
+                                model: debug_info.model.clone(),
+                                requested_model: Some(req.model.clone()),
+                                credential_name: debug_info.credential_name.clone(),
+                                stream: true,
+                                retry_count: total_attempts.saturating_sub(1),
+                                ..Default::default()
+                            };
+
                             if !need_translate {
                                 if req.source_format == Format::Claude {
-                                    let data_stream = tokio_stream::StreamExt::map(
-                                        stream_result.stream,
-                                        |result| {
+                                    let data_stream =
+                                        tokio_stream::StreamExt::map(captured_stream, |result| {
                                             result.map(|chunk| {
                                                 if let Some(ref event_type) = chunk.event_type {
                                                     format!(
@@ -302,39 +329,22 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                                                     chunk.data
                                                 }
                                             })
-                                        },
-                                    );
+                                        });
                                     let mut resp =
                                         build_sse_response(data_stream, keepalive).into_response();
-                                    resp.extensions_mut().insert(DispatchMeta {
-                                        provider: debug_info.provider.clone(),
-                                        model: debug_info.model.clone(),
-                                        requested_model: Some(req.model.clone()),
-                                        credential_name: debug_info.credential_name.clone(),
-                                        stream: true,
-                                        retry_count: total_attempts.saturating_sub(1),
-                                        ..Default::default()
-                                    });
+                                    resp.extensions_mut().insert(dispatch_meta);
                                     if req.debug {
                                         inject_debug_headers(&mut resp, &debug_info);
                                     }
                                     return Ok(resp);
                                 }
                                 let data_stream =
-                                    tokio_stream::StreamExt::map(stream_result.stream, |result| {
+                                    tokio_stream::StreamExt::map(captured_stream, |result| {
                                         result.map(|chunk| chunk.data)
                                     });
                                 let mut resp =
                                     build_sse_response(data_stream, keepalive).into_response();
-                                resp.extensions_mut().insert(DispatchMeta {
-                                    provider: debug_info.provider.clone(),
-                                    model: debug_info.model.clone(),
-                                    requested_model: Some(req.model.clone()),
-                                    credential_name: debug_info.credential_name.clone(),
-                                    stream: true,
-                                    retry_count: total_attempts.saturating_sub(1),
-                                    ..Default::default()
-                                });
+                                resp.extensions_mut().insert(dispatch_meta);
                                 if req.debug {
                                     inject_debug_headers(&mut resp, &debug_info);
                                 }
@@ -342,7 +352,7 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                             }
 
                             let translated_stream = translate_stream(
-                                stream_result.stream,
+                                captured_stream,
                                 state.translators.clone(),
                                 req.source_format,
                                 target_format,
@@ -352,15 +362,7 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
 
                             let mut resp =
                                 build_sse_response(translated_stream, keepalive).into_response();
-                            resp.extensions_mut().insert(DispatchMeta {
-                                provider: debug_info.provider.clone(),
-                                model: debug_info.model.clone(),
-                                requested_model: Some(req.model.clone()),
-                                credential_name: debug_info.credential_name.clone(),
-                                stream: true,
-                                retry_count: total_attempts.saturating_sub(1),
-                                ..Default::default()
-                            });
+                            resp.extensions_mut().insert(dispatch_meta);
                             if req.debug {
                                 inject_debug_headers(&mut resp, &debug_info);
                             }
@@ -422,7 +424,7 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                                     inject_dispatch_meta(
                                         &mut resp,
                                         &debug_info,
-                                        &translated,
+                                        &response.payload,
                                         &state.cost_calculator,
                                         &state.metrics,
                                         &req.model,
@@ -515,7 +517,7 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                             inject_dispatch_meta(
                                 &mut resp,
                                 &debug_info,
-                                &translated,
+                                &response.payload,
                                 &state.cost_calculator,
                                 &state.metrics,
                                 &req.model,
@@ -706,6 +708,7 @@ mod tests {
             debug: false,
             api_key: None,
             client_region: None,
+            request_id: None,
         };
 
         let chain: Vec<String> = if let Some(ref models) = req.models {

--- a/crates/server/src/dispatch/helpers.rs
+++ b/crates/server/src/dispatch/helpers.rs
@@ -8,6 +8,10 @@ use super::DispatchMeta;
 
 /// Extract token usage from a response payload (any format), including cache tokens.
 pub(super) fn extract_usage(payload: &str) -> Option<TokenUsage> {
+    // Quick string check to avoid JSON parsing on chunks without usage data
+    if !payload.contains("usage") && !payload.contains("usageMetadata") {
+        return None;
+    }
     let val: serde_json::Value = serde_json::from_str(payload).ok()?;
 
     // OpenAI format: usage.prompt_tokens / usage.completion_tokens
@@ -76,16 +80,21 @@ pub(super) fn extract_usage(payload: &str) -> Option<TokenUsage> {
 }
 
 /// Inject dispatch metadata into response extensions for request logging.
+///
+/// `upstream_payload` is the raw upstream response (before translation) — used for
+/// token extraction so that provider-specific fields (e.g. Claude's cache tokens)
+/// are not lost during format translation.
 pub(super) fn inject_dispatch_meta(
     response: &mut Response,
     debug: &DispatchDebug,
-    translated_payload: &str,
+    upstream_payload: &[u8],
     cost_calculator: &prism_core::cost::CostCalculator,
     metrics: &prism_core::metrics::Metrics,
     requested_model: &str,
     total_attempts: u32,
 ) {
-    let usage = extract_usage(translated_payload);
+    let upstream_str = std::str::from_utf8(upstream_payload).unwrap_or("");
+    let usage = extract_usage(upstream_str);
     let model = debug.model.as_deref();
     let cost = match (model, &usage) {
         (Some(m), Some(u)) => cost_calculator.calculate(m, u),

--- a/crates/server/src/dispatch/streaming.rs
+++ b/crates/server/src/dispatch/streaming.rs
@@ -1,8 +1,12 @@
 use bytes::Bytes;
 use prism_core::error::ProxyError;
 use prism_core::provider::{Format, ProviderResponse, StreamChunk};
+use prism_core::request_record::TokenUsage;
 use prism_translator::TranslateState;
+use std::sync::Arc;
 use std::time::Duration;
+
+use super::helpers::extract_usage;
 
 type ProviderResult = Result<ProviderResponse, ProxyError>;
 
@@ -132,4 +136,78 @@ pub(super) fn keepalive_error_json(msg: &str) -> String {
         "error": {"message": msg, "type": "server_error"}
     })
     .to_string()
+}
+
+/// Callback context for updating request logs after a stream completes.
+pub(super) struct StreamDoneContext {
+    pub request_id: String,
+    pub model: Option<String>,
+    pub request_logs: Arc<prism_core::request_log::RequestLogStore>,
+    pub cost_calculator: Arc<prism_core::cost::CostCalculator>,
+    pub metrics: Arc<prism_core::metrics::Metrics>,
+}
+
+/// Wrap an upstream `StreamChunk` stream to capture token usage from SSE events.
+///
+/// Each chunk's `data` is inspected for usage fields (supports OpenAI, Claude, and Gemini
+/// response formats). When the stream ends, the captured usage is written back to the
+/// request log entry and recorded in global metrics.
+pub(super) fn with_usage_capture(
+    stream: std::pin::Pin<
+        Box<dyn tokio_stream::Stream<Item = Result<StreamChunk, ProxyError>> + Send>,
+    >,
+    ctx: StreamDoneContext,
+) -> std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<StreamChunk, ProxyError>> + Send>> {
+    struct State {
+        inner: std::pin::Pin<
+            Box<dyn tokio_stream::Stream<Item = Result<StreamChunk, ProxyError>> + Send>,
+        >,
+        usage: Option<TokenUsage>,
+        ctx: StreamDoneContext,
+    }
+
+    let state = State {
+        inner: stream,
+        usage: None,
+        ctx,
+    };
+
+    Box::pin(futures::stream::unfold(state, |mut state| async move {
+        use tokio_stream::StreamExt;
+        match state.inner.next().await {
+            Some(result) => {
+                if let Ok(ref chunk) = result
+                    && let Some(u) = extract_usage(&chunk.data)
+                {
+                    match state.usage.as_mut() {
+                        Some(existing) => existing.merge(&u),
+                        None => state.usage = Some(u),
+                    }
+                }
+                Some((result, state))
+            }
+            None => {
+                // Stream ended — update log entry with captured usage
+                if let Some(ref usage) = state.usage {
+                    let cost = state
+                        .ctx
+                        .model
+                        .as_deref()
+                        .and_then(|m| state.ctx.cost_calculator.calculate(m, usage));
+                    state
+                        .ctx
+                        .metrics
+                        .record_tokens(usage.total_input(), usage.output_tokens);
+                    if let (Some(m), Some(c)) = (state.ctx.model.as_deref(), cost) {
+                        state.ctx.metrics.record_cost(m, c);
+                    }
+                    state
+                        .ctx
+                        .request_logs
+                        .update_usage(&state.ctx.request_id, usage.clone(), cost);
+                }
+                None
+            }
+        }
+    }))
 }

--- a/crates/server/src/handler/mod.rs
+++ b/crates/server/src/handler/mod.rs
@@ -97,6 +97,7 @@ pub(crate) async fn dispatch_api_request(
             debug: parsed.debug,
             api_key: ctx.auth_key.as_ref().map(|e| e.key.clone()),
             client_region: ctx.client_region.clone(),
+            request_id: Some(ctx.request_id.clone()),
         },
     )
     .await

--- a/web/src/pages/RequestLogs.tsx
+++ b/web/src/pages/RequestLogs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useLogsStore } from '../stores/logsStore';
 import type { RequestLogFilter } from '../types';
+import { formatNumber } from '../utils/format';
 import { FileText, ChevronLeft, ChevronRight, Search, X, ChevronDown, ChevronUp, Copy } from 'lucide-react';
 
 export default function RequestLogs() {
@@ -56,10 +57,20 @@ export default function RequestLogs() {
     return `$${cost.toFixed(4)}`;
   };
 
-  const formatTokens = (log: typeof logs[0]): string => {
+  const formatTotalTokens = (log: typeof logs[0]): string => {
     if (!log.usage) return '-';
-    const { input_tokens, output_tokens } = log.usage;
-    return `${input_tokens} / ${output_tokens}`;
+    const { input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens } = log.usage;
+    const total = input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens;
+    return formatNumber(total);
+  };
+
+  const tokenTooltip = (log: typeof logs[0]): string => {
+    if (!log.usage) return '';
+    const { input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens } = log.usage;
+    const parts = [`Input: ${input_tokens.toLocaleString()}`, `Output: ${output_tokens.toLocaleString()}`];
+    if (cache_read_tokens > 0) parts.push(`Cache Read: ${cache_read_tokens.toLocaleString()}`);
+    if (cache_creation_tokens > 0) parts.push(`Cache Write: ${cache_creation_tokens.toLocaleString()}`);
+    return parts.join('\n');
   };
 
   const toggleExpand = (id: string) => {
@@ -199,8 +210,12 @@ export default function RequestLogs() {
                         </span>
                       </td>
                       <td className="text-nowrap">{log.latency_ms}ms</td>
-                      <td className="text-nowrap" style={{ fontSize: '0.85rem' }}>
-                        {formatTokens(log)}
+                      <td
+                        className="text-nowrap"
+                        style={{ fontSize: '0.85rem', cursor: log.usage ? 'help' : 'default' }}
+                        title={tokenTooltip(log)}
+                      >
+                        {formatTotalTokens(log)}
                       </td>
                       <td className="text-nowrap" style={{ fontSize: '0.85rem' }}>
                         {formatCost(log.cost)}
@@ -283,22 +298,22 @@ export default function RequestLogs() {
                               )}
                               <div className="log-detail-item">
                                 <span className="log-detail-label">Input Tokens</span>
-                                <span className="log-detail-value">{log.usage?.input_tokens ?? '-'}</span>
+                                <span className="log-detail-value">{log.usage?.input_tokens?.toLocaleString() ?? '-'}</span>
                               </div>
                               <div className="log-detail-item">
                                 <span className="log-detail-label">Output Tokens</span>
-                                <span className="log-detail-value">{log.usage?.output_tokens ?? '-'}</span>
+                                <span className="log-detail-value">{log.usage?.output_tokens?.toLocaleString() ?? '-'}</span>
                               </div>
                               {(log.usage?.cache_read_tokens ?? 0) > 0 && (
                                 <div className="log-detail-item">
                                   <span className="log-detail-label">Cache Read Tokens</span>
-                                  <span className="log-detail-value">{log.usage?.cache_read_tokens}</span>
+                                  <span className="log-detail-value">{log.usage?.cache_read_tokens?.toLocaleString()}</span>
                                 </div>
                               )}
                               {(log.usage?.cache_creation_tokens ?? 0) > 0 && (
                                 <div className="log-detail-item">
-                                  <span className="log-detail-label">Cache Creation Tokens</span>
-                                  <span className="log-detail-value">{log.usage?.cache_creation_tokens}</span>
+                                  <span className="log-detail-label">Cache Write Tokens</span>
+                                  <span className="log-detail-value">{log.usage?.cache_creation_tokens?.toLocaleString()}</span>
                                 </div>
                               )}
                               <div className="log-detail-item">


### PR DESCRIPTION
## Summary
- Fix missing token information for streaming responses by wrapping upstream SSE streams with usage capture
- Fix non-streaming token extraction to use original upstream payload (preserving cache token fields)
- Add Cursor-like token display in dashboard with hover tooltip for breakdown

## Changes

### `crates/core/`
- `request_record.rs`: Add `TokenUsage::merge()` method (max semantics for streaming accumulation)
- `request_log.rs`: Add `RequestLogStore::update_usage()` for post-stream log updates

### `crates/server/`
- `dispatch/streaming.rs`: Add `StreamDoneContext` and `with_usage_capture()` stream wrapper
- `dispatch/helpers.rs`: Add string check shortcut in `extract_usage()` to skip JSON parsing on chunks without usage data
- `dispatch.rs`: Wire up streaming usage capture; pass upstream payload to `inject_dispatch_meta`
- `handler/mod.rs`: Pass `request_id` to `DispatchRequest`

### `web/`
- `pages/RequestLogs.tsx`: Show total tokens with K/M suffix in table, hover tooltip with input/output/cache breakdown; reuse `formatNumber` utility

## Spec & Reference Doc Impact
None

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] `npx tsc --noEmit` passes (frontend type check)
- [ ] Verify streaming requests show token counts in dashboard
- [ ] Verify non-streaming requests show cache token breakdown
- [ ] Verify hover tooltip displays input/output/cache breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)