### PR TITLE
fix: enable token usage extraction for streaming responses

### DIFF
--- a/crates/server/src/dispatch.rs
+++ b/crates/server/src/dispatch.rs
@@ -7,7 +7,8 @@ use crate::streaming::build_sse_response;
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use helpers::{
-    build_json_response, inject_debug_headers, inject_dispatch_meta, rewrite_model_in_body,
+    build_json_response, inject_debug_headers, inject_dispatch_meta, inject_stream_usage_option,
+    rewrite_model_in_body,
 };
 use prism_core::error::ProxyError;
 use prism_core::provider::{Format, ProviderRequest, ProviderResponse};
@@ -257,6 +258,16 @@ pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response
                         request_headers.insert(k.clone(), v.clone());
                     }
                 }
+
+                // Inject stream_options.include_usage for OpenAI-format streaming
+                // so that usage data is included in the final SSE chunk.
+                let translated_payload = if req.stream
+                    && matches!(target_format, Format::OpenAI | Format::OpenAICompat)
+                {
+                    inject_stream_usage_option(translated_payload)
+                } else {
+                    translated_payload
+                };
 
                 let provider_request = ProviderRequest {
                     model: actual_model.clone(),
@@ -777,5 +788,56 @@ mod tests {
         };
 
         assert_eq!(model_chain, vec!["gpt-4"]);
+    }
+
+    // === extract_usage: Claude streaming nested message.usage ===
+
+    #[test]
+    fn test_extract_usage_claude_message_start() {
+        let payload = r#"{"type":"message_start","message":{"id":"msg_1","model":"claude-3","usage":{"input_tokens":25,"cache_read_input_tokens":100,"cache_creation_input_tokens":10}}}"#;
+        let usage = extract_usage(payload).unwrap();
+        assert_eq!(usage.input_tokens, 25);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, 100);
+        assert_eq!(usage.cache_creation_tokens, 10);
+    }
+
+    #[test]
+    fn test_extract_usage_claude_message_delta() {
+        let payload = r#"{"type":"message_delta","usage":{"output_tokens":47}}"#;
+        let usage = extract_usage(payload).unwrap();
+        assert_eq!(usage.output_tokens, 47);
+    }
+
+    // === inject_stream_usage_option ===
+
+    #[test]
+    fn test_inject_stream_usage_option_adds_option() {
+        let payload =
+            serde_json::to_vec(&serde_json::json!({"model": "gpt-4", "stream": true})).unwrap();
+        let result = inject_stream_usage_option(payload);
+        let val: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(val["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn test_inject_stream_usage_option_preserves_existing() {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "model": "gpt-4",
+            "stream_options": {"include_usage": false, "other": 1}
+        }))
+        .unwrap();
+        let result = inject_stream_usage_option(payload);
+        let val: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        // Does not overwrite existing include_usage
+        assert_eq!(val["stream_options"]["include_usage"], false);
+        assert_eq!(val["stream_options"]["other"], 1);
+    }
+
+    #[test]
+    fn test_inject_stream_usage_option_invalid_json() {
+        let payload = b"not json".to_vec();
+        let result = inject_stream_usage_option(payload.clone());
+        assert_eq!(result, payload);
     }
 }

--- a/crates/server/src/dispatch/helpers.rs
+++ b/crates/server/src/dispatch/helpers.rs
@@ -14,8 +14,14 @@ pub(super) fn extract_usage(payload: &str) -> Option<TokenUsage> {
     }
     let val: serde_json::Value = serde_json::from_str(payload).ok()?;
 
+    // Claude streaming: message_start has usage nested inside "message"
+    // e.g. {"type":"message_start","message":{"usage":{"input_tokens":15}}}
+    let usage_obj = val
+        .get("usage")
+        .or_else(|| val.get("message").and_then(|m| m.get("usage")));
+
     // OpenAI format: usage.prompt_tokens / usage.completion_tokens
-    if let Some(usage) = val.get("usage") {
+    if let Some(usage) = usage_obj {
         let input = usage
             .get("prompt_tokens")
             .and_then(|v| v.as_u64())
@@ -159,6 +165,26 @@ pub(super) fn inject_debug_headers(response: &mut Response, debug: &DispatchDebu
             debug.attempts.join(", ").parse().unwrap(),
         );
     }
+}
+
+/// Inject `stream_options.include_usage = true` into an OpenAI-format streaming request
+/// payload so that the final SSE chunk includes token usage data.
+pub(super) fn inject_stream_usage_option(payload: Vec<u8>) -> Vec<u8> {
+    if let Ok(mut val) = serde_json::from_slice::<serde_json::Value>(&payload)
+        && let Some(obj) = val.as_object_mut()
+    {
+        let stream_opts = obj
+            .entry("stream_options")
+            .or_insert_with(|| serde_json::json!({}));
+        if let Some(opts) = stream_opts.as_object_mut() {
+            opts.entry("include_usage")
+                .or_insert(serde_json::Value::Bool(true));
+        }
+        if let Ok(bytes) = serde_json::to_vec(&val) {
+            return bytes;
+        }
+    }
+    payload
 }
 
 /// Rewrite the `model` field in a JSON request body to use a different model name.


### PR DESCRIPTION
## Summary
- Inject `stream_options.include_usage = true` for OpenAI/OpenAI-compat streaming requests so usage data appears in the final SSE chunk
- Fix Claude streaming token extraction by checking nested `message.usage` path (used in `message_start` events)

## Changes

### `crates/server/`
- `dispatch.rs`: Inject `stream_options.include_usage` for OpenAI-format streaming requests before sending to upstream
- `dispatch/helpers.rs`: 
  - `extract_usage()`: Check `message.usage` fallback for Claude's `message_start` SSE events where usage is nested inside `message`
  - `inject_stream_usage_option()`: New helper to inject `stream_options.include_usage = true` into request payload

## Root Cause Analysis

Two independent issues caused missing token information in streaming:

1. **OpenAI streaming**: Usage data is not included by default. OpenAI requires `stream_options: {"include_usage": true}` in the request. Without this, the final SSE chunk has `"usage": null`.

2. **Claude streaming**: The `message_start` event nests usage inside `message.usage` (e.g., `{"type":"message_start","message":{"usage":{"input_tokens":25}}}`), but `extract_usage` only checked the top-level `usage` key, missing `input_tokens` entirely.

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] New tests for Claude `message_start` nested usage extraction
- [x] New tests for `inject_stream_usage_option` (add, preserve existing, invalid JSON)
- [ ] Verify OpenAI streaming requests now show token counts
- [ ] Verify Claude streaming requests show both input and output tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)