### PR TITLE
chore: fix code formatting in streaming.rs

### DIFF
--- a/crates/server/src/dispatch/streaming.rs
+++ b/crates/server/src/dispatch/streaming.rs
@@ -263,7 +263,11 @@ pub(super) fn with_usage_capture(
                         if !body.is_empty() {
                             body.push('\n');
                         }
-                        let remaining = if limit == 0 { 0 } else { limit.saturating_sub(body.len()) };
+                        let remaining = if limit == 0 {
+                            0
+                        } else {
+                            limit.saturating_sub(body.len())
+                        };
                         body.push_str(&truncate_body(&chunk.data, remaining));
                     }
                 }


### PR DESCRIPTION
## Summary
- Expand inline ternary `if` expression in `streaming.rs` to multi-line format to satisfy `rustfmt`

## Changes
**`crates/server/src/dispatch/streaming.rs`**
- Reformatted `remaining` variable assignment from single-line to multi-line `if/else` block (line 263)

## Spec & Reference Doc Impact
None

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (338 tests)