### PR TITLE
feat: profile-based routing config (SPEC-048)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -4,6 +4,7 @@ use crate::circuit_breaker::CircuitBreakerConfig;
 use crate::file_audit::FileAuditConfig;
 use crate::payload::PayloadConfig;
 use crate::request_record::LogDetailLevel;
+pub use crate::routing::config::RoutingConfig;
 use arc_swap::ArcSwap;
 use notify::{RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
@@ -189,6 +190,9 @@ impl Config {
         if let Some(ref proxy) = self.proxy_url {
             crate::proxy::validate_proxy_url(proxy)?;
         }
+        self.routing
+            .validate()
+            .map_err(|e| anyhow::anyhow!("routing: {e}"))?;
         Ok(())
     }
 
@@ -430,85 +434,6 @@ pub struct TlsConfig {
     pub enable: bool,
     pub cert: Option<String>,
     pub key: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
-pub struct RoutingConfig {
-    pub strategy: RoutingStrategy,
-    pub fallback_enabled: bool,
-    /// EWMA smoothing factor for latency-aware routing (0.0-1.0, default 0.3).
-    pub ewma_alpha: f64,
-    /// Default region for geo-aware routing.
-    pub default_region: Option<String>,
-    /// Per-model routing strategy overrides (glob patterns supported).
-    #[serde(default)]
-    pub model_strategies: HashMap<String, RoutingStrategy>,
-    /// Server-side model fallback chains.
-    #[serde(default)]
-    pub model_fallbacks: HashMap<String, Vec<String>>,
-    /// Model rewrite rules: remap incoming model names before routing.
-    #[serde(default)]
-    pub model_rewrites: Vec<ModelRewriteRule>,
-}
-
-impl Default for RoutingConfig {
-    fn default() -> Self {
-        Self {
-            strategy: RoutingStrategy::RoundRobin,
-            fallback_enabled: true,
-            ewma_alpha: 0.3,
-            default_region: None,
-            model_strategies: HashMap::new(),
-            model_fallbacks: HashMap::new(),
-            model_rewrites: Vec::new(),
-        }
-    }
-}
-
-impl RoutingConfig {
-    /// Resolve the routing strategy for a given model.
-    /// Priority: exact match → glob match → default strategy.
-    pub fn resolve_strategy(&self, model: &str) -> RoutingStrategy {
-        crate::glob::glob_lookup(&self.model_strategies, model)
-            .copied()
-            .unwrap_or(self.strategy)
-    }
-
-    /// Resolve server-side fallback models for a given model.
-    /// Priority: exact match → glob match. Returns empty vec if none.
-    pub fn resolve_fallbacks(&self, model: &str) -> Vec<String> {
-        crate::glob::glob_lookup(&self.model_fallbacks, model)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    /// Apply model rewrite rules. Returns the target model name if a rule matches,
-    /// or `None` if no rule matches (model name unchanged).
-    pub fn resolve_model_rewrite(&self, model: &str) -> Option<&str> {
-        self.model_rewrites
-            .iter()
-            .find(|rule| crate::glob::glob_match(&rule.pattern, model))
-            .map(|rule| rule.target.as_str())
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct ModelRewriteRule {
-    /// Glob pattern to match incoming model names.
-    pub pattern: String,
-    /// Target model name to rewrite to.
-    pub target: String,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum RoutingStrategy {
-    RoundRobin,
-    FillFirst,
-    LatencyAware,
-    GeoAware,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -770,7 +695,7 @@ auth-keys:
     tenant-id: "t1"
     allowed-models: ["claude-*"]
 routing:
-  strategy: fill-first
+  default-profile: balanced
 claude-api-key:
   - api-key: "sk-ant-xxx"
     base-url: "https://api.anthropic.com"
@@ -784,7 +709,7 @@ claude-api-key:
         assert_eq!(config.auth_keys.len(), 1);
         assert_eq!(config.auth_keys[0].key, "test-key");
         assert_eq!(config.auth_keys[0].tenant_id.as_deref(), Some("t1"));
-        assert_eq!(config.routing.strategy, RoutingStrategy::FillFirst);
+        assert_eq!(config.routing.default_profile, "balanced");
         assert_eq!(config.claude_api_key.len(), 1);
         assert_eq!(config.claude_api_key[0].models.len(), 1);
     }
@@ -833,67 +758,10 @@ rate-limit:
     }
 
     #[test]
-    fn test_routing_strategy_variants() {
-        let yaml = r#"routing: { strategy: latency-aware }"#;
-        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
-        assert_eq!(config.routing.strategy, RoutingStrategy::LatencyAware);
-
-        let yaml = r#"routing: { strategy: geo-aware }"#;
-        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
-        assert_eq!(config.routing.strategy, RoutingStrategy::GeoAware);
-    }
-
-    #[test]
-    fn test_per_model_strategies() {
-        let yaml = r#"
-routing:
-  strategy: round-robin
-  model-strategies:
-    "claude-*": latency-aware
-    "gpt-4o": fill-first
-"#;
-        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
-        assert_eq!(config.routing.model_strategies.len(), 2);
-
-        // Exact match
-        assert_eq!(
-            config.routing.resolve_strategy("gpt-4o"),
-            RoutingStrategy::FillFirst
-        );
-        // Glob match
-        assert_eq!(
-            config.routing.resolve_strategy("claude-sonnet-4-6"),
-            RoutingStrategy::LatencyAware
-        );
-        // Default fallback
-        assert_eq!(
-            config.routing.resolve_strategy("gemini-pro"),
-            RoutingStrategy::RoundRobin
-        );
-    }
-
-    #[test]
-    fn test_model_fallbacks() {
-        let yaml = r#"
-routing:
-  strategy: round-robin
-  model-fallbacks:
-    gpt-4o: [gpt-4o-mini, gpt-3.5-turbo]
-    "claude-*": [claude-haiku-4-5-20251001]
-"#;
-        let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
-
-        // Exact match
-        let fb = config.routing.resolve_fallbacks("gpt-4o");
-        assert_eq!(fb, vec!["gpt-4o-mini", "gpt-3.5-turbo"]);
-
-        // Glob match
-        let fb = config.routing.resolve_fallbacks("claude-sonnet-4-6");
-        assert_eq!(fb, vec!["claude-haiku-4-5-20251001"]);
-
-        // No match
-        let fb = config.routing.resolve_fallbacks("gemini-pro");
-        assert!(fb.is_empty());
+    fn test_routing_config_defaults_in_config() {
+        let config = Config::default();
+        assert_eq!(config.routing.default_profile, "balanced");
+        assert_eq!(config.routing.profiles.len(), 4);
     }
 
     #[test]
@@ -1024,31 +892,25 @@ claude-api-key:
     }
 
     #[test]
-    fn test_model_rewrites() {
+    fn test_model_rewrites_in_config() {
         let yaml = r#"
 routing:
-  strategy: round-robin
-  model-rewrites:
-    - pattern: "gpt-4"
-      target: "gpt-4-turbo"
-    - pattern: "claude-*"
-      target: "claude-sonnet-4-20250514"
+  model-resolution:
+    rewrites:
+      - pattern: "gpt-4"
+        to: "gpt-4-turbo"
+      - pattern: "claude-*"
+        to: "claude-sonnet-4-20250514"
 "#;
         let config: Config = serde_yaml_ng::from_str(yaml).unwrap();
-
-        // Exact match
         assert_eq!(
             config.routing.resolve_model_rewrite("gpt-4"),
             Some("gpt-4-turbo")
         );
-
-        // Glob match
         assert_eq!(
             config.routing.resolve_model_rewrite("claude-3-opus"),
             Some("claude-sonnet-4-20250514")
         );
-
-        // No match
         assert_eq!(config.routing.resolve_model_rewrite("gemini-pro"), None);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,5 +19,6 @@ pub mod proxy;
 pub mod rate_limit;
 pub mod request_log;
 pub mod request_record;
+pub mod routing;
 pub mod secret;
 pub mod types;

--- a/crates/core/src/routing/config.rs
+++ b/crates/core/src/routing/config.rs
@@ -1,0 +1,825 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─── Top-level routing config ───────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct RoutingConfig {
+    /// Default profile name (must exist in profiles map).
+    pub default_profile: String,
+    /// Named routing profiles.
+    pub profiles: HashMap<String, RouteProfile>,
+    /// Request-to-profile matching rules (evaluated by specificity then order).
+    #[serde(default)]
+    pub rules: Vec<RouteRule>,
+    /// Model resolution config (aliases, rewrites, fallbacks, provider pins).
+    #[serde(default)]
+    pub model_resolution: ModelResolution,
+}
+
+impl Default for RoutingConfig {
+    fn default() -> Self {
+        Self {
+            default_profile: "balanced".to_string(),
+            profiles: Self::default_profiles(),
+            rules: Vec::new(),
+            model_resolution: ModelResolution::default(),
+        }
+    }
+}
+
+impl RoutingConfig {
+    /// Build the 4 preset profiles.
+    pub fn default_profiles() -> HashMap<String, RouteProfile> {
+        let mut profiles = HashMap::new();
+        profiles.insert("balanced".to_string(), RouteProfile::balanced());
+        profiles.insert("stable".to_string(), RouteProfile::stable());
+        profiles.insert("lowest-latency".to_string(), RouteProfile::lowest_latency());
+        profiles.insert("lowest-cost".to_string(), RouteProfile::lowest_cost());
+        profiles
+    }
+
+    /// Validate the config for internal consistency.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.profiles.is_empty() {
+            return Err("profiles must not be empty".to_string());
+        }
+        if !self.profiles.contains_key(&self.default_profile) {
+            return Err(format!(
+                "default-profile '{}' not found in profiles",
+                self.default_profile
+            ));
+        }
+        for rule in &self.rules {
+            if !self.profiles.contains_key(&rule.use_profile) {
+                return Err(format!(
+                    "rule '{}' references non-existent profile '{}'",
+                    rule.name, rule.use_profile
+                ));
+            }
+        }
+        for (name, profile) in &self.profiles {
+            profile
+                .validate()
+                .map_err(|e| format!("profile '{}': {}", name, e))?;
+        }
+        Ok(())
+    }
+}
+
+// ─── Route profile ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct RouteProfile {
+    pub provider_policy: ProviderPolicy,
+    pub credential_policy: CredentialPolicy,
+    pub health: HealthConfig,
+    pub failover: FailoverConfig,
+}
+
+impl Default for RouteProfile {
+    fn default() -> Self {
+        Self::balanced()
+    }
+}
+
+impl RouteProfile {
+    pub fn balanced() -> Self {
+        Self {
+            provider_policy: ProviderPolicy {
+                strategy: ProviderStrategy::WeightedRoundRobin,
+                ..Default::default()
+            },
+            credential_policy: CredentialPolicy {
+                strategy: CredentialStrategy::PriorityWeightedRR,
+            },
+            health: HealthConfig::default(),
+            failover: FailoverConfig {
+                credential_attempts: 2,
+                provider_attempts: 2,
+                model_attempts: 2,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn stable() -> Self {
+        Self {
+            provider_policy: ProviderPolicy {
+                strategy: ProviderStrategy::OrderedFallback,
+                ..Default::default()
+            },
+            credential_policy: CredentialPolicy {
+                strategy: CredentialStrategy::FillFirst,
+            },
+            health: HealthConfig::default(),
+            failover: FailoverConfig {
+                credential_attempts: 1,
+                provider_attempts: 1,
+                model_attempts: 1,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn lowest_latency() -> Self {
+        Self {
+            provider_policy: ProviderPolicy {
+                strategy: ProviderStrategy::EwmaLatency,
+                ..Default::default()
+            },
+            credential_policy: CredentialPolicy {
+                strategy: CredentialStrategy::LeastInflight,
+            },
+            health: HealthConfig::default(),
+            failover: FailoverConfig {
+                credential_attempts: 2,
+                provider_attempts: 2,
+                model_attempts: 1,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn lowest_cost() -> Self {
+        Self {
+            provider_policy: ProviderPolicy {
+                strategy: ProviderStrategy::LowestEstimatedCost,
+                ..Default::default()
+            },
+            credential_policy: CredentialPolicy {
+                strategy: CredentialStrategy::PriorityWeightedRR,
+            },
+            health: HealthConfig::default(),
+            failover: FailoverConfig {
+                credential_attempts: 1,
+                provider_attempts: 2,
+                model_attempts: 1,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        self.provider_policy.validate()?;
+        Ok(())
+    }
+}
+
+// ─── Provider policy ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct ProviderPolicy {
+    pub strategy: ProviderStrategy,
+    /// Sticky key expression (e.g. "tenant-id").
+    pub sticky_key: Option<String>,
+    /// Provider weights (provider name -> weight).
+    #[serde(default)]
+    pub weights: HashMap<String, u32>,
+    /// Explicit provider ordering (for ordered-fallback).
+    #[serde(default)]
+    pub order: Vec<String>,
+}
+
+impl Default for ProviderPolicy {
+    fn default() -> Self {
+        Self {
+            strategy: ProviderStrategy::WeightedRoundRobin,
+            sticky_key: None,
+            weights: HashMap::new(),
+            order: Vec::new(),
+        }
+    }
+}
+
+impl ProviderPolicy {
+    pub fn validate(&self) -> Result<(), String> {
+        match self.strategy {
+            ProviderStrategy::OrderedFallback => {
+                // Empty order is valid — means "all providers in config order"
+            }
+            ProviderStrategy::StickyHash => {
+                if self.sticky_key.is_none() {
+                    return Err("sticky-hash strategy requires 'sticky-key' to be set".to_string());
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderStrategy {
+    OrderedFallback,
+    #[default]
+    WeightedRoundRobin,
+    EwmaLatency,
+    LowestEstimatedCost,
+    StickyHash,
+}
+
+// ─── Credential policy ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CredentialPolicy {
+    pub strategy: CredentialStrategy,
+}
+
+impl Default for CredentialPolicy {
+    fn default() -> Self {
+        Self {
+            strategy: CredentialStrategy::PriorityWeightedRR,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialStrategy {
+    #[default]
+    #[serde(rename = "priority-weighted-rr")]
+    PriorityWeightedRR,
+    FillFirst,
+    LeastInflight,
+    EwmaLatency,
+    StickyHash,
+    RandomTwoChoices,
+}
+
+// ─── Health config ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct HealthConfig {
+    pub circuit_breaker: CircuitBreakerHealthConfig,
+    pub outlier_detection: OutlierDetectionConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct CircuitBreakerHealthConfig {
+    pub enabled: bool,
+    pub failure_threshold: u32,
+    pub cooldown_seconds: u64,
+}
+
+impl Default for CircuitBreakerHealthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            failure_threshold: 5,
+            cooldown_seconds: 30,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct OutlierDetectionConfig {
+    pub consecutive_5xx: u32,
+    pub consecutive_local_failures: u32,
+    pub base_eject_seconds: u64,
+    pub max_eject_seconds: u64,
+}
+
+impl Default for OutlierDetectionConfig {
+    fn default() -> Self {
+        Self {
+            consecutive_5xx: 3,
+            consecutive_local_failures: 2,
+            base_eject_seconds: 30,
+            max_eject_seconds: 300,
+        }
+    }
+}
+
+// ─── Failover config ────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct FailoverConfig {
+    pub credential_attempts: u32,
+    pub provider_attempts: u32,
+    pub model_attempts: u32,
+    pub retry_budget: RetryBudgetConfig,
+    #[serde(default)]
+    pub retry_on: Vec<RetryCondition>,
+}
+
+impl Default for FailoverConfig {
+    fn default() -> Self {
+        Self {
+            credential_attempts: 2,
+            provider_attempts: 2,
+            model_attempts: 2,
+            retry_budget: RetryBudgetConfig::default(),
+            retry_on: vec![
+                RetryCondition::Network,
+                RetryCondition::RateLimit,
+                RetryCondition::ServerError,
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct RetryBudgetConfig {
+    /// Max ratio of retries to total requests.
+    pub ratio: f64,
+    /// Minimum retries per second regardless of ratio.
+    pub min_retries_per_second: u32,
+}
+
+impl Default for RetryBudgetConfig {
+    fn default() -> Self {
+        Self {
+            ratio: 0.2,
+            min_retries_per_second: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RetryCondition {
+    Network,
+    #[serde(alias = "429")]
+    RateLimit,
+    #[serde(alias = "5xx")]
+    ServerError,
+}
+
+// ─── Route rules ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RouteRule {
+    pub name: String,
+    #[serde(default)]
+    pub priority: Option<i32>,
+    #[serde(rename = "match")]
+    pub match_conditions: RouteMatch,
+    pub use_profile: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct RouteMatch {
+    /// Glob patterns for model names.
+    #[serde(default)]
+    pub models: Vec<String>,
+    /// Glob patterns for tenant IDs.
+    #[serde(default)]
+    pub tenants: Vec<String>,
+    /// Endpoint names (e.g. "chat-completions", "messages").
+    #[serde(default)]
+    pub endpoints: Vec<String>,
+    /// Region identifiers.
+    #[serde(default)]
+    pub regions: Vec<String>,
+    /// Stream mode filter.
+    #[serde(default)]
+    pub stream: Option<bool>,
+    /// Header match conditions.
+    #[serde(default)]
+    pub headers: HashMap<String, Vec<String>>,
+}
+
+// ─── Model resolution ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case", default)]
+pub struct ModelResolution {
+    #[serde(default)]
+    pub aliases: Vec<ModelAlias>,
+    #[serde(default)]
+    pub rewrites: Vec<ModelRewrite>,
+    #[serde(default)]
+    pub fallbacks: Vec<ModelFallback>,
+    #[serde(default)]
+    pub provider_pins: Vec<ProviderPin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ModelAlias {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ModelRewrite {
+    /// Glob pattern to match incoming model names.
+    pub pattern: String,
+    /// Target model name to rewrite to.
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ModelFallback {
+    /// Glob pattern to match the primary model.
+    pub pattern: String,
+    /// Ordered fallback model names.
+    pub to: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ProviderPin {
+    /// Glob pattern to match model names.
+    pub pattern: String,
+    /// Only these providers can serve the matched models.
+    pub providers: Vec<String>,
+}
+
+// ─── Convenience methods (bridge for existing dispatch code) ─────────────────
+
+impl RoutingConfig {
+    /// Resolve server-side fallback models for a given model.
+    /// Uses the model-resolution fallback config.
+    pub fn resolve_fallbacks(&self, model: &str) -> Vec<String> {
+        for fb in &self.model_resolution.fallbacks {
+            if crate::glob::glob_match(&fb.pattern, model) {
+                return fb.to.clone();
+            }
+        }
+        Vec::new()
+    }
+
+    /// Apply model rewrite rules. Returns the target model name if a rule matches.
+    pub fn resolve_model_rewrite(&self, model: &str) -> Option<&str> {
+        // Check aliases first (exact match)
+        for alias in &self.model_resolution.aliases {
+            if alias.from == model {
+                return Some(&alias.to);
+            }
+        }
+        // Then rewrites (glob match)
+        for rewrite in &self.model_resolution.rewrites {
+            if crate::glob::glob_match(&rewrite.pattern, model) {
+                return Some(&rewrite.to);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = RoutingConfig::default();
+        assert_eq!(config.default_profile, "balanced");
+        assert_eq!(config.profiles.len(), 4);
+        assert!(config.profiles.contains_key("balanced"));
+        assert!(config.profiles.contains_key("stable"));
+        assert!(config.profiles.contains_key("lowest-latency"));
+        assert!(config.profiles.contains_key("lowest-cost"));
+        assert!(config.rules.is_empty());
+    }
+
+    #[test]
+    fn test_preset_balanced() {
+        let profile = RouteProfile::balanced();
+        assert_eq!(
+            profile.provider_policy.strategy,
+            ProviderStrategy::WeightedRoundRobin
+        );
+        assert_eq!(
+            profile.credential_policy.strategy,
+            CredentialStrategy::PriorityWeightedRR
+        );
+        assert_eq!(profile.failover.credential_attempts, 2);
+        assert_eq!(profile.failover.provider_attempts, 2);
+        assert_eq!(profile.failover.model_attempts, 2);
+    }
+
+    #[test]
+    fn test_preset_stable() {
+        let profile = RouteProfile::stable();
+        assert_eq!(
+            profile.provider_policy.strategy,
+            ProviderStrategy::OrderedFallback
+        );
+        assert_eq!(
+            profile.credential_policy.strategy,
+            CredentialStrategy::FillFirst
+        );
+        assert_eq!(profile.failover.credential_attempts, 1);
+    }
+
+    #[test]
+    fn test_preset_lowest_latency() {
+        let profile = RouteProfile::lowest_latency();
+        assert_eq!(
+            profile.provider_policy.strategy,
+            ProviderStrategy::EwmaLatency
+        );
+        assert_eq!(
+            profile.credential_policy.strategy,
+            CredentialStrategy::LeastInflight
+        );
+    }
+
+    #[test]
+    fn test_preset_lowest_cost() {
+        let profile = RouteProfile::lowest_cost();
+        assert_eq!(
+            profile.provider_policy.strategy,
+            ProviderStrategy::LowestEstimatedCost
+        );
+    }
+
+    #[test]
+    fn test_yaml_round_trip() {
+        let config = RoutingConfig::default();
+        let yaml = serde_yaml_ng::to_string(&config).unwrap();
+        let parsed: RoutingConfig = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(parsed.default_profile, config.default_profile);
+        assert_eq!(parsed.profiles.len(), config.profiles.len());
+    }
+
+    #[test]
+    fn test_yaml_deserialization_full() {
+        let yaml = r#"
+default-profile: balanced
+profiles:
+  balanced:
+    provider-policy:
+      strategy: weighted-round-robin
+      weights:
+        openai: 100
+        claude: 100
+    credential-policy:
+      strategy: priority-weighted-rr
+    health:
+      circuit-breaker:
+        enabled: true
+        failure-threshold: 5
+        cooldown-seconds: 30
+      outlier-detection:
+        consecutive-5xx: 3
+        consecutive-local-failures: 2
+        base-eject-seconds: 30
+        max-eject-seconds: 300
+    failover:
+      credential-attempts: 2
+      provider-attempts: 2
+      model-attempts: 2
+      retry-budget:
+        ratio: 0.2
+        min-retries-per-second: 5
+      retry-on:
+        - network
+        - 429
+        - 5xx
+rules:
+  - name: enterprise-latency
+    match:
+      tenants: ["enterprise-*"]
+      models: ["gpt-*", "claude-*"]
+    use-profile: balanced
+model-resolution:
+  aliases:
+    - from: gpt-5-default
+      to: gpt-5
+  rewrites:
+    - pattern: "claude-opus-*"
+      to: "claude-sonnet-4-5"
+  fallbacks:
+    - pattern: "gpt-5"
+      to: ["gpt-5-mini", "claude-sonnet-4-5"]
+  provider-pins:
+    - pattern: "gemini-*"
+      providers: [gemini]
+"#;
+        let config: RoutingConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.default_profile, "balanced");
+        assert_eq!(config.profiles.len(), 1);
+
+        let balanced = &config.profiles["balanced"];
+        assert_eq!(
+            balanced.provider_policy.strategy,
+            ProviderStrategy::WeightedRoundRobin
+        );
+        assert_eq!(
+            *balanced.provider_policy.weights.get("openai").unwrap(),
+            100
+        );
+        assert_eq!(balanced.failover.retry_on.len(), 3);
+
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].name, "enterprise-latency");
+        assert_eq!(config.rules[0].use_profile, "balanced");
+        assert_eq!(
+            config.rules[0].match_conditions.tenants,
+            vec!["enterprise-*"]
+        );
+
+        assert_eq!(config.model_resolution.aliases.len(), 1);
+        assert_eq!(config.model_resolution.aliases[0].from, "gpt-5-default");
+        assert_eq!(config.model_resolution.rewrites.len(), 1);
+        assert_eq!(config.model_resolution.fallbacks.len(), 1);
+        assert_eq!(config.model_resolution.provider_pins.len(), 1);
+    }
+
+    #[test]
+    fn test_yaml_minimal_defaults() {
+        let yaml = "{}";
+        let config: RoutingConfig = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(config.default_profile, "balanced");
+        assert_eq!(config.profiles.len(), 4);
+    }
+
+    #[test]
+    fn test_validate_valid() {
+        let config = RoutingConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_missing_default_profile() {
+        let config = RoutingConfig {
+            default_profile: "nonexistent".to_string(),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("default-profile"));
+    }
+
+    #[test]
+    fn test_validate_empty_profiles() {
+        let config = RoutingConfig {
+            profiles: HashMap::new(),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn test_validate_rule_references_missing_profile() {
+        let mut config = RoutingConfig::default();
+        config.rules.push(RouteRule {
+            name: "bad-rule".to_string(),
+            priority: None,
+            match_conditions: RouteMatch::default(),
+            use_profile: "nonexistent".to_string(),
+        });
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_validate_ordered_fallback_empty_order_ok() {
+        let mut config = RoutingConfig::default();
+        config.profiles.insert(
+            "ordered".to_string(),
+            RouteProfile {
+                provider_policy: ProviderPolicy {
+                    strategy: ProviderStrategy::OrderedFallback,
+                    order: vec![], // empty is valid — means all providers in config order
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_sticky_hash_requires_key() {
+        let mut config = RoutingConfig::default();
+        config.profiles.insert(
+            "bad".to_string(),
+            RouteProfile {
+                provider_policy: ProviderPolicy {
+                    strategy: ProviderStrategy::StickyHash,
+                    sticky_key: None, // missing!
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("sticky-key"));
+    }
+
+    #[test]
+    fn test_resolve_model_rewrite_alias() {
+        let config = RoutingConfig {
+            model_resolution: ModelResolution {
+                aliases: vec![ModelAlias {
+                    from: "gpt-5-default".to_string(),
+                    to: "gpt-5".to_string(),
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(config.resolve_model_rewrite("gpt-5-default"), Some("gpt-5"));
+        assert_eq!(config.resolve_model_rewrite("gpt-5"), None);
+    }
+
+    #[test]
+    fn test_resolve_model_rewrite_glob() {
+        let config = RoutingConfig {
+            model_resolution: ModelResolution {
+                rewrites: vec![ModelRewrite {
+                    pattern: "claude-opus-*".to_string(),
+                    to: "claude-sonnet-4-5".to_string(),
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            config.resolve_model_rewrite("claude-opus-2025"),
+            Some("claude-sonnet-4-5")
+        );
+        assert_eq!(config.resolve_model_rewrite("claude-sonnet-4-5"), None);
+    }
+
+    #[test]
+    fn test_resolve_fallbacks() {
+        let config = RoutingConfig {
+            model_resolution: ModelResolution {
+                fallbacks: vec![ModelFallback {
+                    pattern: "gpt-5".to_string(),
+                    to: vec!["gpt-5-mini".to_string(), "claude-sonnet".to_string()],
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            config.resolve_fallbacks("gpt-5"),
+            vec!["gpt-5-mini", "claude-sonnet"]
+        );
+        assert!(config.resolve_fallbacks("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn test_retry_condition_serde() {
+        let yaml = r#"["network", "429", "5xx"]"#;
+        let conditions: Vec<RetryCondition> = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(conditions.len(), 3);
+        assert_eq!(conditions[0], RetryCondition::Network);
+        assert_eq!(conditions[1], RetryCondition::RateLimit);
+        assert_eq!(conditions[2], RetryCondition::ServerError);
+    }
+
+    #[test]
+    fn test_provider_strategy_serde() {
+        let yaml = r#""ewma-latency""#;
+        let s: ProviderStrategy = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(s, ProviderStrategy::EwmaLatency);
+
+        let yaml = r#""lowest-estimated-cost""#;
+        let s: ProviderStrategy = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(s, ProviderStrategy::LowestEstimatedCost);
+    }
+
+    #[test]
+    fn test_credential_strategy_serde() {
+        let yaml = r#""least-inflight""#;
+        let s: CredentialStrategy = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(s, CredentialStrategy::LeastInflight);
+
+        let yaml = r#""random-two-choices""#;
+        let s: CredentialStrategy = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(s, CredentialStrategy::RandomTwoChoices);
+    }
+
+    #[test]
+    fn test_default_failover_has_all_retry_conditions() {
+        let config = FailoverConfig::default();
+        assert_eq!(config.retry_on.len(), 3);
+        assert!(config.retry_on.contains(&RetryCondition::Network));
+        assert!(config.retry_on.contains(&RetryCondition::RateLimit));
+        assert!(config.retry_on.contains(&RetryCondition::ServerError));
+    }
+
+    #[test]
+    fn test_health_config_defaults() {
+        let config = HealthConfig::default();
+        assert!(config.circuit_breaker.enabled);
+        assert_eq!(config.circuit_breaker.failure_threshold, 5);
+        assert_eq!(config.circuit_breaker.cooldown_seconds, 30);
+        assert_eq!(config.outlier_detection.consecutive_5xx, 3);
+        assert_eq!(config.outlier_detection.consecutive_local_failures, 2);
+        assert_eq!(config.outlier_detection.base_eject_seconds, 30);
+        assert_eq!(config.outlier_detection.max_eject_seconds, 300);
+    }
+}

--- a/crates/core/src/routing/mod.rs
+++ b/crates/core/src/routing/mod.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod types;

--- a/crates/core/src/routing/types.rs
+++ b/crates/core/src/routing/types.rs
@@ -1,0 +1,283 @@
+use crate::provider::Format;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+// ─── Request features ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteRequestFeatures {
+    pub requested_model: String,
+    pub endpoint: RouteEndpoint,
+    pub source_format: Format,
+    pub tenant_id: Option<String>,
+    pub api_key_id: Option<String>,
+    pub region: Option<String>,
+    pub stream: bool,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RouteEndpoint {
+    ChatCompletions,
+    Messages,
+    Responses,
+    Models,
+}
+
+// ─── Route plan ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RoutePlan {
+    pub profile: String,
+    pub model_chain: Vec<String>,
+    pub attempts: Vec<RouteAttemptPlan>,
+    pub trace: RouteTrace,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteAttemptPlan {
+    pub model: String,
+    pub provider: Format,
+    pub credential_id: String,
+    pub credential_name: String,
+    pub rank: u32,
+    pub score: RouteScore,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteScore {
+    pub weight: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inflight: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_cost: Option<f64>,
+    #[serde(default)]
+    pub health_penalty: f64,
+}
+
+// ─── Route trace ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteTrace {
+    pub matched_rule: Option<String>,
+    pub resolved_profile: String,
+    #[serde(default)]
+    pub model_resolution_steps: Vec<ModelResolutionStep>,
+    #[serde(default)]
+    pub candidates: Vec<RouteCandidate>,
+    #[serde(default)]
+    pub rejections: Vec<RouteRejection>,
+    #[serde(default)]
+    pub scoring: Vec<RouteScoringEntry>,
+    #[serde(default)]
+    pub fallback_events: Vec<RouteFallbackEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteCandidate {
+    pub provider: String,
+    pub credential_id: String,
+    pub credential_name: String,
+    pub model: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "step")]
+pub enum ModelResolutionStep {
+    AliasResolved {
+        from: String,
+        to: String,
+    },
+    RewriteApplied {
+        from: String,
+        to: String,
+        rule: String,
+    },
+    FallbackChainBuilt {
+        primary: String,
+        fallbacks: Vec<String>,
+    },
+    ProviderPinned {
+        model: String,
+        providers: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteRejection {
+    pub candidate: String,
+    pub reason: RejectReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RejectReason {
+    ModelNotSupported,
+    RegionMismatch,
+    ProviderPinExcluded,
+    CircuitBreakerOpen,
+    OutlierEjected,
+    CredentialDisabled,
+    AccessDenied,
+    CooldownActive,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteScoringEntry {
+    pub candidate: String,
+    pub score: RouteScore,
+    pub rank: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteFallbackEvent {
+    pub from_model: String,
+    pub to_model: String,
+    pub reason: String,
+}
+
+// ─── Route explanation (API response) ───────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RouteExplanation {
+    pub profile: String,
+    pub matched_rule: Option<String>,
+    pub model_chain: Vec<String>,
+    pub selected: Option<SelectedRoute>,
+    #[serde(default)]
+    pub alternates: Vec<SelectedRoute>,
+    #[serde(default)]
+    pub rejections: Vec<RouteRejection>,
+    #[serde(default)]
+    pub model_resolution: Vec<ModelResolutionStep>,
+    #[serde(default)]
+    pub scoring: Vec<RouteScoringEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SelectedRoute {
+    pub provider: String,
+    pub credential_name: String,
+    pub model: String,
+    pub score: RouteScore,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_route_endpoint_serde() {
+        let yaml = r#""chat-completions""#;
+        let ep: RouteEndpoint = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(ep, RouteEndpoint::ChatCompletions);
+    }
+
+    #[test]
+    fn test_reject_reason_serde() {
+        let yaml = r#""circuit_breaker_open""#;
+        let r: RejectReason = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(r, RejectReason::CircuitBreakerOpen);
+    }
+
+    #[test]
+    fn test_route_trace_default() {
+        let trace = RouteTrace::default();
+        assert!(trace.matched_rule.is_none());
+        assert!(trace.candidates.is_empty());
+        assert!(trace.rejections.is_empty());
+    }
+
+    #[test]
+    fn test_route_score_serialization() {
+        let score = RouteScore {
+            weight: 100.0,
+            latency_ms: Some(245.3),
+            inflight: None,
+            estimated_cost: None,
+            health_penalty: 0.0,
+        };
+        let json = serde_json::to_string(&score).unwrap();
+        assert!(json.contains("245.3"));
+        // inflight and estimated_cost should be skipped
+        assert!(!json.contains("inflight"));
+        assert!(!json.contains("estimated_cost"));
+    }
+
+    #[test]
+    fn test_model_resolution_step_tagged() {
+        let step = ModelResolutionStep::AliasResolved {
+            from: "gpt-5-default".to_string(),
+            to: "gpt-5".to_string(),
+        };
+        let json = serde_json::to_string(&step).unwrap();
+        assert!(json.contains("alias_resolved"));
+    }
+
+    #[test]
+    fn test_route_plan_serialization_round_trip() {
+        let plan = RoutePlan {
+            profile: "balanced".to_string(),
+            model_chain: vec!["gpt-5".to_string()],
+            attempts: vec![RouteAttemptPlan {
+                model: "gpt-5".to_string(),
+                provider: Format::OpenAI,
+                credential_id: "cred-1".to_string(),
+                credential_name: "prod-openai-1".to_string(),
+                rank: 1,
+                score: RouteScore {
+                    weight: 100.0,
+                    ..Default::default()
+                },
+            }],
+            trace: RouteTrace {
+                resolved_profile: "balanced".to_string(),
+                ..Default::default()
+            },
+        };
+        let json = serde_json::to_string(&plan).unwrap();
+        let parsed: RoutePlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.profile, "balanced");
+        assert_eq!(parsed.attempts.len(), 1);
+    }
+
+    #[test]
+    fn test_route_explanation_serialization() {
+        let explanation = RouteExplanation {
+            profile: "balanced".to_string(),
+            matched_rule: Some("enterprise-latency".to_string()),
+            model_chain: vec!["gpt-5".to_string()],
+            selected: Some(SelectedRoute {
+                provider: "openai".to_string(),
+                credential_name: "prod-1".to_string(),
+                model: "gpt-5".to_string(),
+                score: RouteScore::default(),
+            }),
+            alternates: vec![],
+            rejections: vec![RouteRejection {
+                candidate: "gemini/eu-1".to_string(),
+                reason: RejectReason::RegionMismatch,
+            }],
+            model_resolution: vec![],
+            scoring: vec![],
+        };
+        let json = serde_json::to_string(&explanation).unwrap();
+        assert!(json.contains("enterprise-latency"));
+        assert!(json.contains("region_mismatch"));
+    }
+}

--- a/crates/provider/src/routing.rs
+++ b/crates/provider/src/routing.rs
@@ -2,8 +2,9 @@ use prism_core::circuit_breaker::{
     CircuitBreakerConfig, CircuitBreakerPolicy, CircuitState, NoopCircuitBreaker,
     ThreeStateCircuitBreaker,
 };
-use prism_core::config::{Config, RoutingStrategy};
+use prism_core::config::Config;
 use prism_core::provider::{AuthRecord, Format, ModelEntry, ModelInfo};
+use prism_core::routing::config::CredentialStrategy;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -29,9 +30,7 @@ pub struct CredentialRouter {
     /// Index: credential_id → (Format, index in Vec) for O(1) lookup.
     credential_index: RwLock<HashMap<String, (Format, usize)>>,
     counters: RwLock<HashMap<String, AtomicUsize>>,
-    strategy: RwLock<RoutingStrategy>,
-    /// Per-model routing strategy overrides.
-    model_strategies: RwLock<HashMap<String, RoutingStrategy>>,
+    strategy: RwLock<CredentialStrategy>,
     /// EWMA latency per credential_id (ms).
     latency_ewma: RwLock<HashMap<String, f64>>,
     /// EWMA smoothing factor (0.0-1.0).
@@ -41,13 +40,12 @@ pub struct CredentialRouter {
 }
 
 impl CredentialRouter {
-    pub fn new(strategy: RoutingStrategy) -> Self {
+    pub fn new(strategy: CredentialStrategy) -> Self {
         Self {
             credentials: RwLock::new(HashMap::new()),
             credential_index: RwLock::new(HashMap::new()),
             counters: RwLock::new(HashMap::new()),
             strategy: RwLock::new(strategy),
-            model_strategies: RwLock::new(HashMap::new()),
             latency_ewma: RwLock::new(HashMap::new()),
             ewma_alpha: RwLock::new(0.3),
             cb_config: RwLock::new(CircuitBreakerConfig::default()),
@@ -63,7 +61,7 @@ impl CredentialRouter {
         provider: Format,
         model: &str,
         tried: &[String],
-        client_region: Option<&str>,
+        _client_region: Option<&str>,
         allowed_credentials: &[String],
     ) -> Option<AuthRecord> {
         let creds = self.credentials.read().ok()?;
@@ -84,26 +82,21 @@ impl CredentialRouter {
             return None;
         }
 
-        let strategy = self.resolve_strategy_for_model(model)?;
+        let strategy = self.strategy.read().ok().map(|s| *s)?;
         match strategy {
-            RoutingStrategy::FillFirst => {
-                // Always pick the first available credential
-                candidates.first().cloned().cloned()
+            CredentialStrategy::FillFirst => candidates.first().cloned().cloned(),
+            CredentialStrategy::PriorityWeightedRR => {
+                self.pick_round_robin(provider, model, &candidates)
             }
-            RoutingStrategy::RoundRobin => self.pick_round_robin(provider, model, &candidates),
-            RoutingStrategy::LatencyAware => self.pick_latency_aware(&candidates),
-            RoutingStrategy::GeoAware => self.pick_geo_aware(&candidates, client_region),
+            CredentialStrategy::EwmaLatency => self.pick_latency_aware(&candidates),
+            CredentialStrategy::LeastInflight
+            | CredentialStrategy::StickyHash
+            | CredentialStrategy::RandomTwoChoices => {
+                // These strategies will be fully implemented in SPEC-050.
+                // For now, fall back to round-robin behavior.
+                self.pick_round_robin(provider, model, &candidates)
+            }
         }
-    }
-
-    /// Resolve routing strategy for a model: per-model override → default.
-    fn resolve_strategy_for_model(&self, model: &str) -> Option<RoutingStrategy> {
-        if let Ok(ms) = self.model_strategies.read()
-            && let Some(s) = prism_core::glob::glob_lookup(&ms, model)
-        {
-            return Some(*s);
-        }
-        self.strategy.read().ok().map(|s| *s)
     }
 
     fn pick_round_robin(
@@ -158,27 +151,6 @@ impl CredentialRouter {
         }
 
         best.cloned()
-    }
-
-    fn pick_geo_aware(
-        &self,
-        candidates: &[&AuthRecord],
-        client_region: Option<&str>,
-    ) -> Option<AuthRecord> {
-        if let Some(region) = client_region {
-            // Prefer same-region credentials
-            let same_region: Vec<&&AuthRecord> = candidates
-                .iter()
-                .filter(|c| c.region.as_deref() == Some(region))
-                .collect();
-
-            if !same_region.is_empty() {
-                return same_region.first().cloned().cloned().cloned();
-            }
-        }
-
-        // Fallback to first available
-        candidates.first().cloned().cloned()
     }
 
     /// Record a credential's request latency for EWMA tracking.
@@ -236,12 +208,9 @@ impl CredentialRouter {
 
     /// Rebuild credentials from config, preserving circuit breaker state.
     pub fn update_from_config(&self, config: &Config) {
-        // Update CB config and EWMA alpha
+        // Update CB config
         if let Ok(mut cb) = self.cb_config.write() {
             *cb = config.circuit_breaker.clone();
-        }
-        if let Ok(mut alpha) = self.ewma_alpha.write() {
-            *alpha = config.routing.ewma_alpha;
         }
 
         let cb_config = config.circuit_breaker.clone();
@@ -280,7 +249,6 @@ impl CredentialRouter {
                         if let Some(old_auth) =
                             old_entries.iter().find(|o| o.api_key == new_auth.api_key)
                         {
-                            // Preserve CB state by reusing the old Arc
                             new_auth.circuit_breaker = old_auth.circuit_breaker.clone();
                         }
                     }
@@ -299,17 +267,12 @@ impl CredentialRouter {
             }
         }
 
-        // Preserve latency EWMA data (keyed by credential id changes, so
-        // we can't perfectly preserve — but it's ephemeral data anyway)
-
-        // Update strategy
+        // Update credential strategy from default profile
         if let Ok(mut strategy) = self.strategy.write() {
-            *strategy = config.routing.strategy;
-        }
-
-        // Update per-model strategies
-        if let Ok(mut ms) = self.model_strategies.write() {
-            *ms = config.routing.model_strategies.clone();
+            let profile_name = &config.routing.default_profile;
+            if let Some(profile) = config.routing.profiles.get(profile_name) {
+                *strategy = profile.credential_policy.strategy;
+            }
         }
     }
 
@@ -423,7 +386,7 @@ fn build_auth_record(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prism_core::config::RoutingStrategy;
+    use prism_core::routing::config::CredentialStrategy;
 
     /// Build a test AuthRecord with sensible defaults.
     fn make_auth(id: &str, format: Format, models: Vec<&str>) -> AuthRecord {
@@ -453,7 +416,7 @@ mod tests {
         }
     }
 
-    fn setup_router(strategy: RoutingStrategy, creds: Vec<AuthRecord>) -> CredentialRouter {
+    fn setup_router(strategy: CredentialStrategy, creds: Vec<AuthRecord>) -> CredentialRouter {
         let router = CredentialRouter::new(strategy);
         let mut map: HashMap<Format, Vec<AuthRecord>> = HashMap::new();
         for auth in creds {
@@ -468,7 +431,7 @@ mod tests {
     #[test]
     fn test_fill_first_picks_first() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![
                 make_auth("a", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("b", Format::OpenAI, vec!["gpt-4"]),
@@ -483,7 +446,7 @@ mod tests {
     #[test]
     fn test_fill_first_skips_tried() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![
                 make_auth("a", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("b", Format::OpenAI, vec!["gpt-4"]),
@@ -498,7 +461,7 @@ mod tests {
     #[test]
     fn test_fill_first_no_available() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![make_auth("a", Format::OpenAI, vec!["gpt-4"])],
         );
         let picked = router.pick(Format::OpenAI, "gpt-4", &["a".to_string()], None, &[]);
@@ -508,7 +471,7 @@ mod tests {
     #[test]
     fn test_fill_first_wrong_model() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![make_auth("a", Format::OpenAI, vec!["gpt-4"])],
         );
         let picked = router.pick(Format::OpenAI, "gpt-3.5", &[], None, &[]);
@@ -518,7 +481,7 @@ mod tests {
     #[test]
     fn test_fill_first_wrong_provider() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![make_auth("a", Format::OpenAI, vec!["gpt-4"])],
         );
         let picked = router.pick(Format::Claude, "gpt-4", &[], None, &[]);
@@ -530,7 +493,7 @@ mod tests {
     #[test]
     fn test_round_robin_cycles() {
         let router = setup_router(
-            RoutingStrategy::RoundRobin,
+            CredentialStrategy::PriorityWeightedRR,
             vec![
                 make_auth("a", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("b", Format::OpenAI, vec!["gpt-4"]),
@@ -563,7 +526,7 @@ mod tests {
         auth_a.weight = 2;
         let auth_b = make_auth("b", Format::OpenAI, vec!["gpt-4"]);
 
-        let router = setup_router(RoutingStrategy::RoundRobin, vec![auth_a, auth_b]);
+        let router = setup_router(CredentialStrategy::PriorityWeightedRR, vec![auth_a, auth_b]);
 
         // With weights 2:1, total weight = 3
         // slots: a(0), a(1), b(2)
@@ -583,7 +546,7 @@ mod tests {
     #[test]
     fn test_latency_aware_picks_lowest() {
         let router = setup_router(
-            RoutingStrategy::LatencyAware,
+            CredentialStrategy::EwmaLatency,
             vec![
                 make_auth("slow", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("fast", Format::OpenAI, vec!["gpt-4"]),
@@ -602,7 +565,7 @@ mod tests {
     #[test]
     fn test_latency_aware_unrecorded_defaults_to_zero() {
         let router = setup_router(
-            RoutingStrategy::LatencyAware,
+            CredentialStrategy::EwmaLatency,
             vec![
                 make_auth("recorded", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("unrecorded", Format::OpenAI, vec!["gpt-4"]),
@@ -617,49 +580,6 @@ mod tests {
         assert_eq!(picked.id, "unrecorded");
     }
 
-    // === GeoAware Strategy ===
-
-    #[test]
-    fn test_geo_aware_prefers_same_region() {
-        let mut auth_us = make_auth("us", Format::OpenAI, vec!["gpt-4"]);
-        auth_us.region = Some("US".to_string());
-        let mut auth_eu = make_auth("eu", Format::OpenAI, vec!["gpt-4"]);
-        auth_eu.region = Some("EU".to_string());
-
-        let router = setup_router(RoutingStrategy::GeoAware, vec![auth_us, auth_eu]);
-
-        let picked = router
-            .pick(Format::OpenAI, "gpt-4", &[], Some("EU"), &[])
-            .unwrap();
-        assert_eq!(picked.id, "eu");
-    }
-
-    #[test]
-    fn test_geo_aware_fallback_no_matching_region() {
-        let mut auth_us = make_auth("us", Format::OpenAI, vec!["gpt-4"]);
-        auth_us.region = Some("US".to_string());
-
-        let router = setup_router(RoutingStrategy::GeoAware, vec![auth_us]);
-
-        let picked = router
-            .pick(Format::OpenAI, "gpt-4", &[], Some("JP"), &[])
-            .unwrap();
-        assert_eq!(picked.id, "us"); // Falls back to first available
-    }
-
-    #[test]
-    fn test_geo_aware_no_client_region() {
-        let mut auth = make_auth("a", Format::OpenAI, vec!["gpt-4"]);
-        auth.region = Some("US".to_string());
-
-        let router = setup_router(RoutingStrategy::GeoAware, vec![auth]);
-
-        let picked = router
-            .pick(Format::OpenAI, "gpt-4", &[], None, &[])
-            .unwrap();
-        assert_eq!(picked.id, "a");
-    }
-
     // === Disabled credentials ===
 
     #[test]
@@ -668,7 +588,7 @@ mod tests {
         disabled.disabled = true;
         let enabled = make_auth("enabled", Format::OpenAI, vec!["gpt-4"]);
 
-        let router = setup_router(RoutingStrategy::FillFirst, vec![disabled, enabled]);
+        let router = setup_router(CredentialStrategy::FillFirst, vec![disabled, enabled]);
 
         let picked = router
             .pick(Format::OpenAI, "gpt-4", &[], None, &[])
@@ -680,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_record_latency_ewma() {
-        let router = CredentialRouter::new(RoutingStrategy::LatencyAware);
+        let router = CredentialRouter::new(CredentialStrategy::EwmaLatency);
         // alpha = 0.3 by default
 
         router.record_latency("cred1", 100.0);
@@ -699,7 +619,7 @@ mod tests {
     #[test]
     fn test_resolve_providers() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![
                 make_auth("oai", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("ds", Format::OpenAICompat, vec!["gpt-4"]),
@@ -716,7 +636,7 @@ mod tests {
     #[test]
     fn test_resolve_providers_no_match() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![make_auth("a", Format::OpenAI, vec!["gpt-4"])],
         );
         let providers = router.resolve_providers("nonexistent-model");
@@ -731,7 +651,7 @@ mod tests {
         auth_with_alias.models[0].alias = Some("my-gpt4".to_string());
 
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![
                 auth_with_alias,
                 make_auth("b", Format::Claude, vec!["claude-3"]),
@@ -748,7 +668,7 @@ mod tests {
     #[test]
     fn test_all_models_dedup() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![
                 make_auth("a", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("b", Format::OpenAI, vec!["gpt-4"]),
@@ -766,7 +686,7 @@ mod tests {
         let mut auth = make_auth("a", Format::OpenAI, vec!["gpt-4"]);
         auth.prefix = Some("myprefix".to_string());
 
-        let router = setup_router(RoutingStrategy::FillFirst, vec![auth]);
+        let router = setup_router(CredentialStrategy::FillFirst, vec![auth]);
 
         assert!(router.model_has_prefix("gpt-4"));
         assert!(!router.model_has_prefix("nonexistent"));
@@ -805,7 +725,7 @@ mod tests {
     #[test]
     fn test_pick_with_allowed_credentials() {
         let router = setup_router(
-            RoutingStrategy::FillFirst,
+            CredentialStrategy::FillFirst,
             vec![
                 make_auth("a", Format::OpenAI, vec!["gpt-4"]),
                 make_auth("b", Format::OpenAI, vec!["gpt-4"]),
@@ -827,34 +747,5 @@ mod tests {
             &["nonexistent".to_string()],
         );
         assert!(picked.is_none());
-    }
-
-    // === per-model routing strategy ===
-
-    #[test]
-    fn test_per_model_strategy() {
-        let router = setup_router(
-            RoutingStrategy::FillFirst,
-            vec![
-                make_auth("a", Format::OpenAI, vec!["gpt-4"]),
-                make_auth("b", Format::OpenAI, vec!["gpt-4"]),
-                make_auth("c", Format::OpenAI, vec!["gpt-4"]),
-            ],
-        );
-
-        // Set per-model strategy for gpt-4 to round-robin
-        {
-            let mut ms = router.model_strategies.write().unwrap();
-            ms.insert("gpt-4".to_string(), RoutingStrategy::RoundRobin);
-        }
-
-        // Should use round-robin for gpt-4
-        let first = router
-            .pick(Format::OpenAI, "gpt-4", &[], None, &[])
-            .unwrap();
-        let second = router
-            .pick(Format::OpenAI, "gpt-4", &[], None, &[])
-            .unwrap();
-        assert_ne!(first.id, second.id);
     }
 }

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -79,7 +79,13 @@ impl Application {
         let http_client_pool = Arc::new(prism_core::proxy::HttpClientPool::new());
         let executors =
             prism_provider::build_registry(config.proxy_url.clone(), http_client_pool.clone());
-        let credential_router = Arc::new(CredentialRouter::new(config.routing.strategy));
+        let default_cred_strategy = config
+            .routing
+            .profiles
+            .get(&config.routing.default_profile)
+            .map(|p| p.credential_policy.strategy)
+            .unwrap_or_default();
+        let credential_router = Arc::new(CredentialRouter::new(default_cred_strategy));
         credential_router.update_from_config(&config);
         let translators = Arc::new(prism_translator::build_registry());
         let executors = Arc::new(executors);

--- a/crates/server/src/dispatch.rs
+++ b/crates/server/src/dispatch.rs
@@ -176,13 +176,11 @@ pub async fn dispatch(state: &AppState, mut req: DispatchRequest) -> Result<Resp
         vec![req.model.clone()]
     };
 
-    // Append server-side fallbacks (if enabled and configured), deduplicated
-    if config.routing.fallback_enabled {
-        let server_fallbacks = config.routing.resolve_fallbacks(&req.model);
-        for fb in server_fallbacks {
-            if !model_chain.contains(&fb) {
-                model_chain.push(fb);
-            }
+    // Append server-side fallbacks (from model-resolution config), deduplicated
+    let server_fallbacks = config.routing.resolve_fallbacks(&req.model);
+    for fb in server_fallbacks {
+        if !model_chain.contains(&fb) {
+            model_chain.push(fb);
         }
     }
 

--- a/crates/server/src/handler/dashboard/routing.rs
+++ b/crates/server/src/handler/dashboard/routing.rs
@@ -3,36 +3,24 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use prism_core::config::{ModelRewriteRule, RoutingStrategy};
+use prism_core::routing::config::{ModelResolution, RouteProfile, RouteRule};
 use serde::Deserialize;
 use serde_json::json;
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct UpdateRoutingRequest {
-    pub strategy: Option<RoutingStrategy>,
-    pub request_retry: Option<u32>,
-    pub max_retry_interval: Option<u64>,
-    pub fallback_enabled: Option<bool>,
-    pub model_strategies: Option<std::collections::HashMap<String, RoutingStrategy>>,
-    pub model_fallbacks: Option<std::collections::HashMap<String, Vec<String>>>,
-    pub model_rewrites: Option<Vec<ModelRewriteRule>>,
+    pub default_profile: Option<String>,
+    pub profiles: Option<HashMap<String, RouteProfile>>,
+    pub rules: Option<Vec<RouteRule>>,
+    pub model_resolution: Option<ModelResolution>,
 }
 
 /// GET /api/dashboard/routing
 pub async fn get_routing(State(state): State<AppState>) -> impl IntoResponse {
     let config = state.config.load();
-    (
-        StatusCode::OK,
-        Json(json!({
-            "strategy": config.routing.strategy,
-            "fallback_enabled": config.routing.fallback_enabled,
-            "request_retry": config.request_retry,
-            "max_retry_interval": config.max_retry_interval,
-            "model_strategies": config.routing.model_strategies,
-            "model_fallbacks": config.routing.model_fallbacks,
-            "model_rewrites": config.routing.model_rewrites,
-        })),
-    )
+    (StatusCode::OK, Json(json!(&config.routing)))
 }
 
 /// PATCH /api/dashboard/routing
@@ -41,26 +29,17 @@ pub async fn update_routing(
     Json(body): Json<UpdateRoutingRequest>,
 ) -> impl IntoResponse {
     match super::providers::update_config_file_public(&state, move |config| {
-        if let Some(s) = body.strategy {
-            config.routing.strategy = s;
+        if let Some(dp) = body.default_profile {
+            config.routing.default_profile = dp;
         }
-        if let Some(fb) = body.fallback_enabled {
-            config.routing.fallback_enabled = fb;
+        if let Some(p) = body.profiles {
+            config.routing.profiles = p;
         }
-        if let Some(rr) = body.request_retry {
-            config.request_retry = rr;
+        if let Some(r) = body.rules {
+            config.routing.rules = r;
         }
-        if let Some(mri) = body.max_retry_interval {
-            config.max_retry_interval = mri;
-        }
-        if let Some(ms) = body.model_strategies {
-            config.routing.model_strategies = ms;
-        }
-        if let Some(mf) = body.model_fallbacks {
-            config.routing.model_fallbacks = mf;
-        }
-        if let Some(mr) = body.model_rewrites {
-            config.routing.model_rewrites = mr;
+        if let Some(mr) = body.model_resolution {
+            config.routing.model_resolution = mr;
         }
     })
     .await

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -1,7 +1,7 @@
 use arc_swap::ArcSwap;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use prism_core::config::{Config, DashboardConfig, RoutingStrategy};
+use prism_core::config::{Config, DashboardConfig};
 use prism_core::cost::CostCalculator;
 use prism_core::memory_log_store::InMemoryLogStore;
 use prism_core::metrics::Metrics;
@@ -47,7 +47,7 @@ fn create_test_harness() -> TestHarness {
     std::fs::write(&config_path, &yaml).expect("failed to write config");
 
     let config_arc = Arc::new(ArcSwap::new(Arc::new(config.clone())));
-    let credential_router = Arc::new(CredentialRouter::new(RoutingStrategy::RoundRobin));
+    let credential_router = Arc::new(CredentialRouter::new(Default::default()));
     credential_router.update_from_config(&config);
 
     let http_client_pool = Arc::new(prism_core::proxy::HttpClientPool::new());
@@ -679,20 +679,21 @@ async fn test_get_routing() {
     let req = authed_get("/api/dashboard/routing", &token);
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK);
-    // Default strategy is round-robin
-    assert_eq!(body["strategy"], "round-robin");
+    // Default profile is balanced
+    assert_eq!(body["default-profile"], "balanced");
+    assert!(body["profiles"]["balanced"].is_object());
 }
 
 #[tokio::test]
-async fn test_update_routing_strategy() {
+async fn test_update_routing_default_profile() {
     let harness = create_test_harness();
     let token = login_and_get_token(&harness).await;
 
-    // Update to fill-first
+    // Update default-profile to stable
     let req = authed_patch(
         "/api/dashboard/routing",
         &token,
-        json!({"strategy": "fill-first"}),
+        json!({"default-profile": "stable"}),
     );
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK, "update routing failed: {body:?}");
@@ -705,19 +706,19 @@ async fn test_update_routing_strategy() {
     let req = authed_get("/api/dashboard/routing", &token);
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["strategy"], "fill-first");
+    assert_eq!(body["default-profile"], "stable");
 }
 
 #[tokio::test]
-async fn test_update_routing_round_robin() {
+async fn test_update_routing_switch_profile() {
     let harness = create_test_harness();
     let token = login_and_get_token(&harness).await;
 
-    // Set to fill-first first
+    // Set to lowest-latency
     let req = authed_patch(
         "/api/dashboard/routing",
         &token,
-        json!({"strategy": "fill-first"}),
+        json!({"default-profile": "lowest-latency"}),
     );
     let (status, _) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK);
@@ -727,11 +728,11 @@ async fn test_update_routing_round_robin() {
     let new_config = Config::load(&config_path).expect("failed to reload config");
     harness.state.config.store(Arc::new(new_config));
 
-    // Set back to round-robin
+    // Switch back to balanced
     let req = authed_patch(
         "/api/dashboard/routing",
         &token,
-        json!({"strategy": "round-robin"}),
+        json!({"default-profile": "balanced"}),
     );
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK, "update routing failed: {body:?}");
@@ -744,22 +745,22 @@ async fn test_update_routing_round_robin() {
     let req = authed_get("/api/dashboard/routing", &token);
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body["strategy"], "round-robin");
+    assert_eq!(body["default-profile"], "balanced");
 }
 
 #[tokio::test]
-async fn test_update_routing_invalid_strategy() {
+async fn test_update_routing_unknown_fields_ignored() {
     let harness = create_test_harness();
     let token = login_and_get_token(&harness).await;
 
+    // Unknown fields are silently ignored by serde (deny_unknown_fields not set)
     let req = authed_patch(
         "/api/dashboard/routing",
         &token,
-        json!({"strategy": "random"}),
+        json!({"unknown-field": "value"}),
     );
     let (status, _body) = send_request(&harness, req).await;
-    // Serde rejects unknown strategy variants at deserialization time
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(status, StatusCode::OK);
 }
 
 // ===========================================================================

--- a/docs/specs/_index.md
+++ b/docs/specs/_index.md
@@ -35,6 +35,11 @@ All specifications for the AI Proxy Gateway project.
 | SPEC-036 | Add RequestContext to ProviderExecutor          | Draft     | [active/SPEC-036/](active/SPEC-036/) |
 | SPEC-042 | Crate Structure Refactoring                    | Draft     | [active/SPEC-042/](active/SPEC-042/) |
 | SPEC-047 | OAuth & Auth-File Upstream Onboarding             | Draft     | [active/SPEC-047/](active/SPEC-047/) |
+| SPEC-048 | Routing Config & Core Types                      | Draft     | [active/SPEC-048/](active/SPEC-048/) |
+| SPEC-049 | Route Planner & Match Engine                     | Draft     | [active/SPEC-049/](active/SPEC-049/) |
+| SPEC-050 | Health State & Selection Strategies              | Draft     | [active/SPEC-050/](active/SPEC-050/) |
+| SPEC-051 | Execution Controller & Dispatch Cutover          | Draft     | [active/SPEC-051/](active/SPEC-051/) |
+| SPEC-052 | Preview API & Dashboard UX                       | Draft     | [active/SPEC-052/](active/SPEC-052/) |
 
 ## Retroactively Completed
 

--- a/docs/specs/active/SPEC-048/prd.md
+++ b/docs/specs/active/SPEC-048/prd.md
@@ -1,0 +1,59 @@
+# PRD: Routing Config & Core Types
+
+| Field     | Value                              |
+|-----------|------------------------------------|
+| Spec ID   | SPEC-048                           |
+| Title     | Routing Config & Core Types        |
+| Author    | Claude                             |
+| Status    | Draft                              |
+| Created   | 2026-03-14                         |
+| Updated   | 2026-03-14                         |
+
+## Problem Statement
+
+Current `RoutingConfig` mixes model rewrite, model fallback, provider discovery, credential selection, and retry into a single flat structure. `routing.strategy` sounds global but only affects credential choice inside a provider. Weight is only used by weighted round-robin but the UI suggests otherwise. `default_region` exists but is unused at runtime.
+
+The new config model must separate routing intent (profiles), request matching (rules), and model naming (model-resolution) into independent, composable concerns.
+
+## Goals
+
+- Replace `RoutingConfig` and `RoutingStrategy` with a profile-based, layered config model
+- Separate provider-level policy from credential-level policy
+- Define 4 presets (Balanced, Stable, Lowest Latency, Lowest Cost)
+- Define route rule matching with explicit precedence
+- Define model resolution (aliases, rewrites, fallbacks, provider-pins) as independent config
+- Define all runtime types for route planning and tracing
+
+## Non-Goals
+
+- Runtime behavior changes (this spec is types only)
+- Dashboard UI changes
+- Health state implementation
+
+## User Stories
+
+- As an operator, I want to configure routing as a named profile so that I can reuse policies across rules.
+- As an operator, I want to match requests by model/tenant/endpoint/headers and bind them to different profiles.
+- As an operator, I want model aliasing, rewriting, fallback chains, and provider pinning as first-class config.
+
+## Success Metrics
+
+- All config types compile and serialize/deserialize correctly
+- 4 preset profiles produce valid default configs
+- Config YAML round-trips without data loss
+
+## Constraints
+
+- Types live in `crates/core/`
+- No runtime side effects in this spec
+
+## Open Questions
+
+- None
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Config location | New `routing/` submodule vs inline in config.rs | New `routing/` submodule | Separation of concerns, file size management |
+| Preset representation | Hardcoded vs config-defined | Config-defined with factory defaults | Flexibility, users can customize presets |

--- a/docs/specs/active/SPEC-048/technical-design.md
+++ b/docs/specs/active/SPEC-048/technical-design.md
@@ -1,0 +1,400 @@
+# Technical Design: Routing Config & Core Types
+
+| Field     | Value                              |
+|-----------|------------------------------------|
+| Spec ID   | SPEC-048                           |
+| Title     | Routing Config & Core Types        |
+| Author    | Claude                             |
+| Status    | Draft                              |
+| Created   | 2026-03-14                         |
+| Updated   | 2026-03-14                         |
+
+## Overview
+
+Replace the current flat `RoutingConfig` / `RoutingStrategy` with a layered, profile-based config model. All types are pure data with serde support. No runtime behavior changes.
+
+## API Design
+
+No new API endpoints in this spec.
+
+## Backend Implementation
+
+### Module Structure
+
+```
+crates/core/src/
+├── routing/
+│   ├── mod.rs          # re-exports
+│   ├── config.rs       # RoutingConfig, RouteProfile, policies, rules, model resolution
+│   └── types.rs        # RouteRequestFeatures, RoutePlan, RouteTrace, etc.
+└── config.rs           # top-level Config references routing::RoutingConfig
+```
+
+### Key Types
+
+#### Config Types (`routing/config.rs`)
+
+```rust
+/// Top-level routing configuration
+pub struct RoutingConfig {
+    /// Default profile name (must exist in profiles map)
+    pub default_profile: String,
+    /// Named routing profiles
+    pub profiles: HashMap<String, RouteProfile>,
+    /// Request-to-profile matching rules (evaluated in order)
+    pub rules: Vec<RouteRule>,
+    /// Model resolution config
+    pub model_resolution: ModelResolution,
+}
+
+/// A complete routing policy
+pub struct RouteProfile {
+    pub provider_policy: ProviderPolicy,
+    pub credential_policy: CredentialPolicy,
+    pub health: HealthConfig,
+    pub failover: FailoverConfig,
+}
+
+/// Provider-level selection policy
+pub struct ProviderPolicy {
+    pub strategy: ProviderStrategy,
+    /// Optional sticky key expression (e.g. "tenant-id")
+    pub sticky_key: Option<String>,
+    /// Provider weights (provider name -> weight)
+    pub weights: HashMap<String, u32>,
+    /// Explicit provider ordering (for ordered-fallback)
+    pub order: Vec<String>,
+}
+
+pub enum ProviderStrategy {
+    OrderedFallback,
+    WeightedRoundRobin,
+    EwmaLatency,
+    LowestEstimatedCost,
+    StickyHash,
+}
+
+/// Credential-level selection policy
+pub struct CredentialPolicy {
+    pub strategy: CredentialStrategy,
+}
+
+pub enum CredentialStrategy {
+    PriorityWeightedRR,
+    FillFirst,
+    LeastInflight,
+    EwmaLatency,
+    StickyHash,
+    RandomTwoChoices,
+}
+
+/// Health monitoring configuration
+pub struct HealthConfig {
+    pub circuit_breaker: CircuitBreakerHealthConfig,
+    pub outlier_detection: OutlierDetectionConfig,
+}
+
+pub struct CircuitBreakerHealthConfig {
+    pub enabled: bool,
+    pub failure_threshold: u32,
+    pub cooldown_seconds: u64,
+}
+
+pub struct OutlierDetectionConfig {
+    pub consecutive_5xx: u32,
+    pub consecutive_local_failures: u32,
+    pub base_eject_seconds: u64,
+    pub max_eject_seconds: u64,
+}
+
+/// Failover configuration
+pub struct FailoverConfig {
+    pub credential_attempts: u32,
+    pub provider_attempts: u32,
+    pub model_attempts: u32,
+    pub retry_budget: RetryBudgetConfig,
+    pub retry_on: Vec<RetryCondition>,
+}
+
+pub struct RetryBudgetConfig {
+    /// Max ratio of retries to total requests
+    pub ratio: f64,
+    /// Minimum retries per second regardless of ratio
+    pub min_retries_per_second: u32,
+}
+
+pub enum RetryCondition {
+    Network,
+    RateLimit,   // 429
+    ServerError, // 5xx
+}
+
+/// Request matching rule
+pub struct RouteRule {
+    pub name: String,
+    pub priority: Option<i32>,
+    pub match_conditions: RouteMatch,
+    pub use_profile: String,
+}
+
+pub struct RouteMatch {
+    pub models: Vec<String>,       // glob patterns
+    pub tenants: Vec<String>,      // glob patterns
+    pub endpoints: Vec<String>,    // e.g. "chat-completions"
+    pub regions: Vec<String>,
+    pub stream: Option<bool>,
+    pub headers: HashMap<String, Vec<String>>,
+}
+
+/// Model resolution configuration
+pub struct ModelResolution {
+    pub aliases: Vec<ModelAlias>,
+    pub rewrites: Vec<ModelRewrite>,
+    pub fallbacks: Vec<ModelFallback>,
+    pub provider_pins: Vec<ProviderPin>,
+}
+
+pub struct ModelAlias {
+    pub from: String,
+    pub to: String,
+}
+
+pub struct ModelRewrite {
+    pub pattern: String, // glob
+    pub to: String,
+}
+
+pub struct ModelFallback {
+    pub pattern: String, // glob
+    pub to: Vec<String>,
+}
+
+pub struct ProviderPin {
+    pub pattern: String, // glob
+    pub providers: Vec<String>,
+}
+```
+
+#### Runtime Types (`routing/types.rs`)
+
+```rust
+/// Extracted request features for route planning
+pub struct RouteRequestFeatures {
+    pub requested_model: String,
+    pub endpoint: RouteEndpoint,
+    pub source_format: Format,
+    pub tenant_id: Option<String>,
+    pub api_key_id: Option<String>,
+    pub region: Option<String>,
+    pub stream: bool,
+    pub headers: BTreeMap<String, String>,
+}
+
+pub enum RouteEndpoint {
+    ChatCompletions,
+    Messages,
+    Responses,
+    Models,
+}
+
+/// Complete route plan (pure data, no side effects)
+pub struct RoutePlan {
+    pub profile: String,
+    pub model_chain: Vec<String>,
+    pub attempts: Vec<RouteAttemptPlan>,
+    pub trace: RouteTrace,
+}
+
+pub struct RouteAttemptPlan {
+    pub model: String,
+    pub provider: Format,
+    pub credential_id: String,
+    pub credential_name: String,
+    pub rank: u32,
+    pub score: RouteScore,
+}
+
+pub struct RouteScore {
+    pub weight: f64,
+    pub latency_ms: Option<f64>,
+    pub inflight: Option<u64>,
+    pub estimated_cost: Option<f64>,
+    pub health_penalty: f64,
+}
+
+/// Full trace of routing decision
+pub struct RouteTrace {
+    pub matched_rule: Option<String>,
+    pub resolved_profile: String,
+    pub model_resolution_steps: Vec<ModelResolutionStep>,
+    pub candidates: Vec<RouteCandidate>,
+    pub rejections: Vec<RouteRejection>,
+    pub scoring: Vec<RouteScoringEntry>,
+    pub fallback_events: Vec<RouteFallbackEvent>,
+}
+
+pub struct RouteCandidate {
+    pub provider: String,
+    pub credential_id: String,
+    pub credential_name: String,
+    pub model: String,
+}
+
+pub enum ModelResolutionStep {
+    AliasResolved { from: String, to: String },
+    RewriteApplied { from: String, to: String, rule: String },
+    FallbackChainBuilt { primary: String, fallbacks: Vec<String> },
+    ProviderPinned { model: String, providers: Vec<String> },
+}
+
+pub struct RouteRejection {
+    pub candidate: String,
+    pub reason: RejectReason,
+}
+
+pub enum RejectReason {
+    ModelNotSupported,
+    RegionMismatch,
+    ProviderPinExcluded,
+    CircuitBreakerOpen,
+    OutlierEjected,
+    CredentialDisabled,
+    AccessDenied,
+    CooldownActive,
+}
+
+pub struct RouteScoringEntry {
+    pub candidate: String,
+    pub score: RouteScore,
+    pub rank: u32,
+}
+
+pub struct RouteFallbackEvent {
+    pub from_model: String,
+    pub to_model: String,
+    pub reason: String,
+}
+```
+
+### Preset Profiles
+
+```rust
+impl RoutingConfig {
+    pub fn default_profiles() -> HashMap<String, RouteProfile> {
+        // balanced, stable, lowest-latency, lowest-cost
+        // See TD section 7.1 for definitions
+    }
+}
+```
+
+| Preset | Provider Strategy | Credential Strategy | Failover |
+|--------|-------------------|---------------------|----------|
+| Balanced | WeightedRoundRobin | PriorityWeightedRR | 2/2/2 |
+| Stable | OrderedFallback | FillFirst | 1/1/1 |
+| Lowest Latency | EwmaLatency | LeastInflight | 2/2/1 |
+| Lowest Cost | LowestEstimatedCost | PriorityWeightedRR | 1/2/1 |
+
+### Changes to Existing Code
+
+1. **Remove** `RoutingStrategy` enum from `config.rs`
+2. **Replace** `RoutingConfig` in `config.rs` with new profile-based version
+3. **Remove** `ModelRewriteRule` from `config.rs` (replaced by `ModelResolution`)
+4. **Replace** `Config.routing` field type with new `routing::RoutingConfig`
+5. **Remove** `model_strategies`, `model_fallbacks`, `model_rewrites` from config
+
+## Configuration Changes
+
+Old config (removed):
+
+```yaml
+routing:
+  strategy: round-robin
+  fallback_enabled: true
+  ewma_alpha: 0.3
+  default_region: us-east
+  model_strategies: {}
+  model_fallbacks: {}
+  model_rewrites: []
+```
+
+New config:
+
+```yaml
+routing:
+  default-profile: balanced
+  profiles:
+    balanced:
+      provider-policy:
+        strategy: weighted-round-robin
+        weights:
+          openai: 100
+          claude: 100
+      credential-policy:
+        strategy: priority-weighted-rr
+      health:
+        circuit-breaker:
+          enabled: true
+          failure-threshold: 5
+          cooldown-seconds: 30
+        outlier-detection:
+          consecutive-5xx: 3
+          consecutive-local-failures: 2
+          base-eject-seconds: 30
+          max-eject-seconds: 300
+      failover:
+        credential-attempts: 2
+        provider-attempts: 2
+        model-attempts: 2
+        retry-budget:
+          ratio: 0.2
+          min-retries-per-second: 5
+        retry-on: [network, 429, 5xx]
+  rules: []
+  model-resolution:
+    aliases: []
+    rewrites: []
+    fallbacks: []
+    provider-pins: []
+```
+
+## Provider Compatibility
+
+| Provider | Supported | Notes |
+|----------|-----------|-------|
+| OpenAI   | Yes       | No provider-specific config type changes |
+| Claude   | Yes       | No provider-specific config type changes |
+| Gemini   | Yes       | No provider-specific config type changes |
+
+## Task Breakdown
+
+- [ ] Create `crates/core/src/routing/mod.rs`
+- [ ] Create `crates/core/src/routing/config.rs` with all config types + serde
+- [ ] Create `crates/core/src/routing/types.rs` with all runtime types + serde
+- [ ] Implement 4 preset profile factory methods
+- [ ] Implement `Default` for `RoutingConfig` (uses balanced preset)
+- [ ] Replace `RoutingConfig`, `RoutingStrategy`, `ModelRewriteRule` in `config.rs`
+- [ ] Update `Config.routing` to reference new type
+- [ ] Unit tests: YAML deserialization, serialization round-trip, preset defaults
+- [ ] Unit tests: config validation (rule references non-existent profile, empty profiles map)
+- [ ] Unit tests: default/missing field handling (omitted optional fields deserialize to defaults)
+- [ ] Unit tests: strategy + parameter consistency (ordered-fallback requires non-empty order, weighted-rr requires non-empty weights)
+- [ ] Unit tests: model resolution config (alias, rewrite, fallback, provider-pin serialization)
+- [ ] Unit tests: `serde(deny_unknown_fields)` rejects unknown keys
+
+## Test Strategy
+
+- **Unit tests:**
+  - Config deserialization from YAML: full config, minimal config, each preset profile
+  - Round-trip serialization: serialize -> deserialize -> assert equality
+  - Preset factory: each of 4 presets produces valid, non-empty config
+  - Default values: omitted fields get correct defaults (e.g., `credential-attempts` defaults to 1)
+  - Validation: rule referencing missing profile returns error, empty profiles map returns error
+  - Strategy parameter consistency: `ordered-fallback` without `order` returns error, `weighted-round-robin` without `weights` returns error
+  - Unknown fields: YAML with unknown keys is rejected
+- **Integration tests:** None (types only)
+- **Manual verification:** None needed
+
+## Rollout Plan
+
+1. Replace config types in a single commit
+2. Update all downstream references (CredentialRouter, dispatch) in the same commit to compile

--- a/docs/specs/active/SPEC-049/prd.md
+++ b/docs/specs/active/SPEC-049/prd.md
@@ -1,0 +1,58 @@
+# PRD: Route Planner & Match Engine
+
+| Field     | Value                                    |
+|-----------|------------------------------------------|
+| Spec ID   | SPEC-049                                 |
+| Title     | Route Planner & Match Engine             |
+| Author    | Claude                                   |
+| Status    | Draft                                    |
+| Created   | 2026-03-14                               |
+| Updated   | 2026-03-14                               |
+
+## Problem Statement
+
+Current routing decisions are embedded inside `dispatch.rs` and `CredentialRouter.pick()`. There is no way to preview a routing decision without executing an upstream call. The route planner must be a pure function that takes immutable snapshots and produces a deterministic `RoutePlan`.
+
+## Goals
+
+- Implement a pure, side-effect-free route planner
+- Implement request-to-profile matching with explicit specificity-based precedence
+- Implement model resolution (alias, rewrite, fallback chain, provider pin)
+- Implement route explanation as structured data
+- All planner logic must be deterministic and testable with snapshot-style tests
+
+## Non-Goals
+
+- Runtime health state (SPEC-050)
+- Selection strategy algorithms (SPEC-050)
+- Execution / failover (SPEC-051)
+- Dashboard UI (SPEC-052)
+
+## User Stories
+
+- As an operator, I want to preview which route a request would take before it executes.
+- As an operator, I want to understand why a specific credential was rejected with a structured reason.
+- As an operator, I want model aliasing and rewriting to happen transparently before provider selection.
+
+## Success Metrics
+
+- Planner produces identical output for identical inputs (determinism)
+- All routing decisions include structured reject reasons
+- 100% unit test coverage for match engine specificity rules
+
+## Constraints
+
+- Planner must not hold mutable state
+- Planner must not perform I/O
+- Planner input is snapshots only (config, inventory, health)
+
+## Open Questions
+
+- None
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Planner purity | Planner owns state vs planner is pure | Pure function | Testability, separation of concerns |
+| Specificity | First-match vs most-specific | Most-specific wins | More predictable for operators |

--- a/docs/specs/active/SPEC-049/technical-design.md
+++ b/docs/specs/active/SPEC-049/technical-design.md
@@ -1,0 +1,263 @@
+# Technical Design: Route Planner & Match Engine
+
+| Field     | Value                                    |
+|-----------|------------------------------------------|
+| Spec ID   | SPEC-049                                 |
+| Title     | Route Planner & Match Engine             |
+| Author    | Claude                                   |
+| Status    | Draft                                    |
+| Created   | 2026-03-14                               |
+| Updated   | 2026-03-14                               |
+
+## Overview
+
+Implement the pure route planning layer: match engine, model resolver, planner, and explainer. All functions take immutable data and return deterministic results. Depends on SPEC-048 types.
+
+## API Design
+
+No new HTTP endpoints in this spec (Preview API is SPEC-052).
+
+### Internal API
+
+```rust
+// Entry point
+impl RoutePlanner {
+    pub fn plan(
+        features: &RouteRequestFeatures,
+        config: &RoutingConfig,
+        inventory: &InventorySnapshot,
+        health: &HealthSnapshot,
+    ) -> RoutePlan;
+}
+```
+
+## Backend Implementation
+
+### Module Structure
+
+```
+crates/core/src/routing/
+├── mod.rs
+├── config.rs           # (from SPEC-048)
+├── types.rs            # (from SPEC-048)
+├── match_engine.rs     # Rule matching with specificity
+├── model_resolver.rs   # Alias, rewrite, fallback, pin
+├── planner.rs          # Pure route planner
+└── explain.rs          # Structured explanation builder
+```
+
+### Key Types
+
+#### Inventory & Health Snapshots
+
+```rust
+/// Point-in-time snapshot of available providers and credentials
+pub struct InventorySnapshot {
+    pub providers: Vec<ProviderEntry>,
+}
+
+pub struct ProviderEntry {
+    pub format: Format,
+    pub name: String, // e.g. "openai", "claude"
+    pub credentials: Vec<CredentialEntry>,
+}
+
+pub struct CredentialEntry {
+    pub id: String,
+    pub name: String,
+    pub models: Vec<String>,
+    pub excluded_models: Vec<String>,
+    pub region: Option<String>,
+    pub weight: u32,
+    pub priority: u32,
+    pub disabled: bool,
+}
+
+/// Point-in-time snapshot of health state
+pub struct HealthSnapshot {
+    pub credentials: HashMap<String, CredentialHealth>,
+}
+
+pub struct CredentialHealth {
+    pub circuit_state: CircuitState,
+    pub ejected: bool,
+    pub eject_until: Option<Instant>,
+    pub inflight: u64,
+    pub ewma_latency_ms: f64,
+    pub ewma_cost_micro_usd: f64,
+    pub recent_429_rate: f64,
+    pub recent_5xx_rate: f64,
+    pub cooldown_until: Option<Instant>,
+}
+
+pub enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+```
+
+### Match Engine (`match_engine.rs`)
+
+```rust
+pub fn match_rule<'a>(
+    features: &RouteRequestFeatures,
+    rules: &'a [RouteRule],
+) -> Option<&'a RouteRule>;
+
+pub fn resolve_profile<'a>(
+    features: &RouteRequestFeatures,
+    config: &'a RoutingConfig,
+) -> (&'a str, &'a RouteProfile);
+```
+
+Specificity calculation:
+1. Exact model > glob model > no model constraint
+2. More match dimensions > fewer match dimensions
+3. Exact tenant/header/region > wildcard
+4. Higher explicit `priority` wins ties
+5. Declaration order breaks remaining ties
+
+### Model Resolver (`model_resolver.rs`)
+
+```rust
+pub struct ResolvedModel {
+    pub model_chain: Vec<String>,     // primary + fallbacks
+    pub pinned_providers: Option<Vec<String>>,
+    pub resolution_steps: Vec<ModelResolutionStep>,
+}
+
+pub fn resolve_model(
+    requested: &str,
+    resolution: &ModelResolution,
+) -> ResolvedModel;
+```
+
+Resolution order:
+1. Apply alias (exact match only, single pass)
+2. Apply rewrite (glob match, first match wins)
+3. Build fallback chain (glob match, primary model is first)
+4. Apply provider pin (glob match)
+
+### Planner (`planner.rs`)
+
+```rust
+pub struct RoutePlanner;
+
+impl RoutePlanner {
+    pub fn plan(
+        features: &RouteRequestFeatures,
+        config: &RoutingConfig,
+        inventory: &InventorySnapshot,
+        health: &HealthSnapshot,
+    ) -> RoutePlan {
+        // 1. Resolve profile via match engine
+        // 2. Resolve model chain
+        // 3. For each model in chain:
+        //    a. Filter eligible providers (model support, pin, health)
+        //    b. Filter eligible credentials per provider (model support, region, health, access)
+        //    c. Record rejections with reasons
+        //    d. Score and rank candidates using profile strategy
+        // 4. Build ordered RouteAttemptPlan list
+        // 5. Build RouteTrace
+    }
+}
+```
+
+### Explain (`explain.rs`)
+
+```rust
+pub struct RouteExplanation {
+    pub profile: String,
+    pub matched_rule: Option<String>,
+    pub model_chain: Vec<String>,
+    pub selected: Option<SelectedRoute>,
+    pub alternates: Vec<SelectedRoute>,
+    pub rejections: Vec<RouteRejection>,
+}
+
+pub struct SelectedRoute {
+    pub provider: String,
+    pub credential_name: String,
+    pub model: String,
+    pub score: RouteScore,
+}
+
+pub fn explain(plan: &RoutePlan) -> RouteExplanation;
+```
+
+### Flow
+
+```
+RouteRequestFeatures
+    |
+    v
+[Match Engine] -- rules + specificity --> profile name
+    |
+    v
+[Model Resolver] -- aliases, rewrites, fallbacks, pins --> model chain
+    |
+    v
+[Planner] -- inventory + health snapshots --> RoutePlan
+    |
+    v
+[Explain] -- RoutePlan --> RouteExplanation (structured JSON)
+```
+
+## Configuration Changes
+
+No config changes (uses SPEC-048 types).
+
+## Provider Compatibility
+
+| Provider | Supported | Notes |
+|----------|-----------|-------|
+| OpenAI   | Yes       | Planner is provider-agnostic |
+| Claude   | Yes       | Planner is provider-agnostic |
+| Gemini   | Yes       | Planner is provider-agnostic |
+
+## Task Breakdown
+
+- [ ] Create `crates/core/src/routing/match_engine.rs` with specificity-based rule matching
+- [ ] Create `crates/core/src/routing/model_resolver.rs` with alias/rewrite/fallback/pin
+- [ ] Define `InventorySnapshot` and `HealthSnapshot` types
+- [ ] Create `crates/core/src/routing/planner.rs` with pure planning logic
+- [ ] Create `crates/core/src/routing/explain.rs` with explanation builder
+- [ ] Unit tests: match engine specificity (exact > glob, more dims > fewer)
+- [ ] Unit tests: match engine — no rule matched falls back to default profile
+- [ ] Unit tests: match engine — multiple dimensions beat single dimension
+- [ ] Unit tests: match engine — priority field overrides specificity tie
+- [ ] Unit tests: match engine — declaration order breaks final tie
+- [ ] Unit tests: model resolver — alias resolution (single pass, no chaining)
+- [ ] Unit tests: model resolver — rewrite with glob pattern (first match wins)
+- [ ] Unit tests: model resolver — fallback chain construction
+- [ ] Unit tests: model resolver — provider pin filters providers
+- [ ] Unit tests: model resolver — no matching alias/rewrite returns original
+- [ ] Unit tests: planner determinism (same input -> same output, run 100x)
+- [ ] Unit tests: planner — empty inventory returns empty attempts with trace
+- [ ] Unit tests: planner — all credentials unhealthy returns all rejected
+- [ ] Unit tests: planner — provider pin excludes non-pinned providers
+- [ ] Unit tests: planner — region mismatch produces RegionMismatch rejection
+- [ ] Unit tests: planner — disabled credential produces CredentialDisabled rejection
+- [ ] Unit tests: planner — circuit breaker open produces CircuitBreakerOpen rejection
+- [ ] Unit tests: planner — model not supported produces ModelNotSupported rejection
+- [ ] Unit tests: planner — scoring ranks candidates correctly per strategy
+- [ ] Unit tests: explain output matches plan data
+
+## Test Strategy
+
+- **Unit tests:**
+  - **Match engine:** Specificity-based rule selection with all precedence levels. Cases: exact model > glob model, more dimensions > fewer, priority tiebreak, declaration order tiebreak, no rule matched -> default profile, empty rules list -> default profile.
+  - **Model resolver:** Alias (exact match only, no alias chaining), rewrite (glob, first match wins), fallback chain (glob), provider pin (glob). Edge cases: no match returns original, multiple rewrites only first applies.
+  - **Planner determinism:** Same `(features, config, inventory, health)` inputs produce identical `RoutePlan` across 100 invocations.
+  - **Planner edge cases:** Empty inventory, all credentials unhealthy, all providers pinned-away, single candidate, model chain with 0 fallbacks.
+  - **Planner rejections:** Each `RejectReason` variant produced under the correct condition.
+  - **Planner scoring:** Candidates ranked correctly for each provider/credential strategy given known health snapshot values.
+  - **Explain:** Output fields match plan data; rejections list matches plan rejections.
+- **Integration tests:** None (pure functions only)
+- **Manual verification:** None needed
+
+## Rollout Plan
+
+1. Implement and test all pure planner code
+2. No runtime impact until SPEC-051 wires it into dispatch

--- a/docs/specs/active/SPEC-050/prd.md
+++ b/docs/specs/active/SPEC-050/prd.md
@@ -1,0 +1,60 @@
+# PRD: Health State & Selection Strategies
+
+| Field     | Value                                         |
+|-----------|-----------------------------------------------|
+| Spec ID   | SPEC-050                                      |
+| Title     | Health State & Selection Strategies            |
+| Author    | Claude                                        |
+| Status    | Draft                                         |
+| Created   | 2026-03-14                                    |
+| Updated   | 2026-03-14                                    |
+
+## Problem Statement
+
+Current `CredentialRouter` mixes credential inventory, health tracking (circuit breaker + EWMA latency), and selection strategy into one struct. Health state is limited to circuit breaker and EWMA latency. There is no outlier detection, no inflight tracking, no retry budget, no 429/5xx rate tracking, and no temporary ejection.
+
+Selection strategies are limited to 4 options (RoundRobin, FillFirst, LatencyAware, GeoAware), all operating at credential level only. There is no provider-level selection policy.
+
+## Goals
+
+- Replace `CredentialRouter` with separated `HealthManager` + `ProviderCatalog` + selection strategies
+- Implement comprehensive health tracking: circuit breaker, outlier detection, ejection, inflight, EWMA latency/cost, 429/5xx rates, cooldown
+- Implement 5 provider selection strategies
+- Implement 6 credential selection strategies with priority tiering
+- Health state is read-only for selectors (write happens after attempt results)
+
+## Non-Goals
+
+- Dispatch integration (SPEC-051)
+- Dashboard UI (SPEC-052)
+
+## User Stories
+
+- As an operator, I want unhealthy credentials to be temporarily ejected rather than waiting for circuit breaker to fully open.
+- As an operator, I want provider selection to be independent from credential selection.
+- As an operator, I want priority tiers so that backup credentials are only used when primary tier is exhausted.
+- As an operator, I want inflight-aware routing so no single credential gets overwhelmed.
+
+## Success Metrics
+
+- HealthManager tracks all 8 health signals per credential
+- Each selection strategy produces correct ordering in unit tests
+- Priority tiering correctly groups and orders within tiers
+- Retry budget correctly limits retry rate
+
+## Constraints
+
+- `HealthManager` does not choose routes; it only exposes state
+- Selection strategies must be deterministic given the same health snapshot
+- Priority tier logic applies before any credential strategy
+
+## Open Questions
+
+- None
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Health ownership | Per-credential vs centralized | Centralized HealthManager | Single source of truth, easier snapshotting |
+| Selector interface | Concrete fns vs trait | Trait-based | Testable, swappable |

--- a/docs/specs/active/SPEC-050/technical-design.md
+++ b/docs/specs/active/SPEC-050/technical-design.md
@@ -1,0 +1,317 @@
+# Technical Design: Health State & Selection Strategies
+
+| Field     | Value                                         |
+|-----------|-----------------------------------------------|
+| Spec ID   | SPEC-050                                      |
+| Title     | Health State & Selection Strategies            |
+| Author    | Claude                                        |
+| Status    | Draft                                         |
+| Created   | 2026-03-14                                    |
+| Updated   | 2026-03-14                                    |
+
+## Overview
+
+Replace `CredentialRouter` with three focused components: `HealthManager` (mutable runtime state), `ProviderCatalog` (inventory), and trait-based selection strategies. Depends on SPEC-048 types and SPEC-049 snapshot types.
+
+## API Design
+
+No new HTTP endpoints. Internal APIs only.
+
+## Backend Implementation
+
+### Module Structure
+
+```
+crates/provider/src/
+├── catalog.rs              # ProviderCatalog (inventory management)
+├── health.rs               # HealthManager (mutable health state)
+├── provider_selector.rs    # Provider selection strategies
+├── credential_selector.rs  # Credential selection strategies
+└── routing.rs              # Remove or reduce to re-exports
+```
+
+### HealthManager (`health.rs`)
+
+```rust
+pub struct HealthManager {
+    states: RwLock<HashMap<String, CredentialHealthState>>,
+    retry_budget: RetryBudgetState,
+}
+
+struct CredentialHealthState {
+    // Circuit breaker
+    circuit: ThreeStateCircuitBreaker,
+    // Outlier detection
+    consecutive_5xx: u32,
+    consecutive_local_failures: u32,
+    // Ejection
+    ejected: bool,
+    eject_until: Option<Instant>,
+    eject_count: u32, // for exponential backoff
+    // Inflight
+    inflight: AtomicU64,
+    // EWMA
+    ewma_latency_ms: f64,
+    ewma_cost_micro_usd: f64,
+    ewma_alpha: f64,
+    // Rate tracking (sliding window)
+    recent_429: SlidingWindowCounter,
+    recent_5xx: SlidingWindowCounter,
+    recent_total: SlidingWindowCounter,
+    // Cooldown
+    cooldown_until: Option<Instant>,
+}
+
+pub struct RetryBudgetState {
+    config: RetryBudgetConfig,
+    recent_requests: SlidingWindowCounter,
+    recent_retries: SlidingWindowCounter,
+}
+
+/// Simple sliding window counter
+struct SlidingWindowCounter {
+    window_seconds: u64,
+    buckets: Vec<AtomicU64>,
+    // ...
+}
+
+impl HealthManager {
+    /// Create snapshot for planner consumption (read-only)
+    pub fn snapshot(&self) -> HealthSnapshot;
+
+    /// Record attempt start (increment inflight)
+    pub fn record_attempt_start(&self, credential_id: &str);
+
+    /// Record attempt end with result
+    pub fn record_attempt_result(&self, credential_id: &str, result: &AttemptResult);
+
+    /// Check if retry budget allows another retry
+    pub fn retry_budget_allows(&self) -> bool;
+
+    /// Record a retry attempt against the budget
+    pub fn record_retry(&self);
+
+    /// Initialize health state for a credential
+    pub fn register_credential(&self, credential_id: &str, config: &HealthConfig);
+
+    /// Remove health state for a removed credential
+    pub fn unregister_credential(&self, credential_id: &str);
+
+    /// Update health config (on config reload)
+    pub fn update_config(&self, config: &HealthConfig);
+}
+
+pub struct AttemptResult {
+    pub latency_ms: f64,
+    pub cost_micro_usd: Option<u64>,
+    pub status: AttemptStatus,
+}
+
+pub enum AttemptStatus {
+    Success,
+    RateLimit,    // 429
+    ServerError,  // 5xx
+    NetworkError,
+    Timeout,
+    ClientError,  // 4xx (not 429)
+}
+```
+
+Outlier ejection logic:
+- On consecutive 5xx >= threshold OR consecutive local failures >= threshold: eject
+- Ejection duration: `min(base_eject * 2^eject_count, max_eject)`
+- On success: reset consecutive counters, clear ejection
+
+### ProviderCatalog (`catalog.rs`)
+
+```rust
+pub struct ProviderCatalog {
+    providers: RwLock<Vec<ProviderEntry>>,
+}
+
+impl ProviderCatalog {
+    /// Create inventory snapshot for planner
+    pub fn snapshot(&self) -> InventorySnapshot;
+
+    /// Rebuild from config (on reload)
+    pub fn update_from_config(&self, config: &Config);
+
+    /// Find credential by ID
+    pub fn find_credential(&self, id: &str) -> Option<(Format, AuthRecord)>;
+}
+```
+
+### Provider Selection (`provider_selector.rs`)
+
+```rust
+pub trait ProviderSelector: Send + Sync {
+    fn select(
+        &self,
+        candidates: &[ProviderCandidate],
+        context: &SelectionContext,
+    ) -> Vec<ProviderCandidate>; // ordered by preference
+}
+
+pub struct ProviderCandidate {
+    pub format: Format,
+    pub name: String,
+    pub weight: u32,
+    pub health: AggregatedProviderHealth, // aggregated from credentials
+}
+
+pub struct SelectionContext {
+    pub sticky_key: Option<String>,
+    pub request_features: RouteRequestFeatures,
+}
+
+// Implementations
+pub struct OrderedFallbackSelector { pub order: Vec<String> }
+pub struct WeightedRoundRobinSelector { pub counter: AtomicU64 }
+pub struct EwmaLatencySelector;
+pub struct LowestEstimatedCostSelector;
+pub struct StickyHashSelector;
+```
+
+### Credential Selection (`credential_selector.rs`)
+
+```rust
+pub trait CredentialSelector: Send + Sync {
+    fn select(
+        &self,
+        candidates: &[CredentialCandidate],
+        context: &SelectionContext,
+    ) -> Vec<CredentialCandidate>; // ordered by preference
+}
+
+pub struct CredentialCandidate {
+    pub id: String,
+    pub name: String,
+    pub weight: u32,
+    pub priority: u32,
+    pub health: CredentialHealth,
+}
+
+// Implementations
+pub struct PriorityWeightedRRSelector { pub counter: AtomicU64 }
+pub struct FillFirstSelector;
+pub struct LeastInflightSelector;
+pub struct EwmaLatencyCredSelector;
+pub struct StickyHashCredSelector;
+pub struct RandomTwoChoicesSelector;
+```
+
+Priority tiering (applies to all credential strategies):
+```rust
+fn apply_priority_tiers(candidates: &[CredentialCandidate]) -> Vec<Vec<CredentialCandidate>> {
+    // Group by priority, sort groups by priority (lower = higher priority)
+    // Within each tier, apply the credential strategy
+    // Only fall to next tier if current tier is exhausted (all unhealthy)
+}
+```
+
+### Integration with Planner
+
+The planner (SPEC-049) calls selectors with snapshot data:
+
+```rust
+// In planner.rs, scoring step:
+fn score_candidates(
+    profile: &RouteProfile,
+    providers: Vec<ProviderCandidate>,
+    credentials: HashMap<String, Vec<CredentialCandidate>>,
+) -> Vec<RouteAttemptPlan> {
+    let provider_selector = build_provider_selector(&profile.provider_policy);
+    let credential_selector = build_credential_selector(&profile.credential_policy);
+
+    let ordered_providers = provider_selector.select(&providers, &ctx);
+    for provider in ordered_providers {
+        let creds = credentials.get(&provider.name);
+        let ordered_creds = credential_selector.select(creds, &ctx);
+        // Build RouteAttemptPlan entries
+    }
+}
+```
+
+### Changes to Existing Code
+
+1. **Remove** `CredentialRouter` (replaced by ProviderCatalog + HealthManager + selectors)
+2. **Remove** `routing.rs` round-robin counter, latency_ewma, strategy-specific pick methods
+3. **Migrate** circuit breaker state preservation logic to `HealthManager.update_config()`
+4. **Migrate** `all_models()`, `resolve_providers()` to `ProviderCatalog`
+
+## Configuration Changes
+
+No new config fields. Consumes `HealthConfig` and `FailoverConfig` from SPEC-048.
+
+## Provider Compatibility
+
+| Provider | Supported | Notes |
+|----------|-----------|-------|
+| OpenAI   | Yes       | Selectors are provider-agnostic |
+| Claude   | Yes       | Selectors are provider-agnostic |
+| Gemini   | Yes       | Selectors are provider-agnostic |
+
+## Task Breakdown
+
+- [ ] Implement `SlidingWindowCounter` utility
+- [ ] Implement `HealthManager` with all 8 health signals
+- [ ] Implement `HealthSnapshot` generation
+- [ ] Implement `RetryBudgetState`
+- [ ] Implement `ProviderCatalog` with `update_from_config()` and `snapshot()`
+- [ ] Implement `ProviderSelector` trait + 5 strategies
+- [ ] Implement `CredentialSelector` trait + 6 strategies
+- [ ] Implement priority tiering logic
+- [ ] Integrate selectors into planner scoring step
+- [ ] Remove `CredentialRouter`
+- [ ] Unit tests: circuit breaker state transitions (Closed->Open on threshold, Open->HalfOpen on cooldown, HalfOpen->Closed on success, HalfOpen->Open on failure)
+- [ ] Unit tests: outlier detection (consecutive 5xx triggers ejection, consecutive local failures triggers ejection, success resets counters)
+- [ ] Unit tests: ejection timing (exponential backoff: base * 2^count, capped at max)
+- [ ] Unit tests: ejection recovery (success after eject clears ejection, resets eject count)
+- [ ] Unit tests: EWMA latency convergence (alpha=1.0 gives instant, alpha=0.0 gives no change)
+- [ ] Unit tests: EWMA cost tracking
+- [ ] Unit tests: sliding window counter (increment, window expiry, rate calculation)
+- [ ] Unit tests: inflight counter (increment on start, decrement on result)
+- [ ] Unit tests: retry budget — allows when under ratio
+- [ ] Unit tests: retry budget — blocks when over ratio
+- [ ] Unit tests: retry budget — min-retries-per-second floor
+- [ ] Unit tests: snapshot reflects current state accurately
+- [ ] Unit tests: register/unregister credential lifecycle
+- [ ] Unit tests: OrderedFallbackSelector — respects configured order
+- [ ] Unit tests: WeightedRoundRobinSelector — distributes proportionally over N calls
+- [ ] Unit tests: EwmaLatencySelector — picks lowest latency provider
+- [ ] Unit tests: LowestEstimatedCostSelector — picks cheapest healthy provider
+- [ ] Unit tests: StickyHashSelector — same key always selects same provider
+- [ ] Unit tests: PriorityWeightedRRSelector — stays in highest tier until exhausted
+- [ ] Unit tests: FillFirstSelector — always picks first available in highest tier
+- [ ] Unit tests: LeastInflightSelector — picks credential with fewest inflight
+- [ ] Unit tests: EwmaLatencyCredSelector — picks lowest latency credential
+- [ ] Unit tests: StickyHashCredSelector — same key always selects same credential
+- [ ] Unit tests: RandomTwoChoicesSelector — picks better of two random candidates
+- [ ] Unit tests: priority tiering — groups by priority, only falls to next tier when current exhausted
+- [ ] Unit tests: all selectors — empty candidates returns empty result
+- [ ] Unit tests: all selectors — single candidate returns that candidate
+- [ ] Concurrency tests: HealthManager under concurrent record_attempt_start/result from multiple tasks
+- [ ] Concurrency tests: snapshot consistency during concurrent writes
+
+## Test Strategy
+
+- **Unit tests:**
+  - **Circuit breaker:** All 4 state transitions with exact threshold values. Verify cooldown timing.
+  - **Outlier detection:** Consecutive failure counting, ejection trigger, exponential backoff duration (`base * 2^count` capped at max), reset on success.
+  - **EWMA:** Convergence behavior with alpha=0.0, 0.5, 1.0. Verify formula `new = alpha * current + (1-alpha) * previous`.
+  - **Sliding window:** Counter increment, bucket expiry after window passes, rate calculation accuracy.
+  - **Inflight:** Atomic increment on start, decrement on result. Verify counter never goes negative.
+  - **Retry budget:** Allow/block based on ratio, min-retries-per-second floor, sliding window tracking.
+  - **Snapshot:** Generated snapshot matches current mutable state for all fields.
+  - **Provider selectors (5):** Each strategy with 3+ providers, verify ordering. Edge cases: empty list, all equal weights/latency, single provider.
+  - **Credential selectors (6):** Each strategy with 3+ credentials, verify ordering. Edge cases: empty list, single credential, all same priority.
+  - **Priority tiering:** 3 tiers with mixed health, verify tier-1 used first, tier-2 only when tier-1 exhausted, tier-3 only when tier-1+2 exhausted.
+- **Concurrency tests:** Spawn 10 tokio tasks concurrently calling `record_attempt_start`/`record_attempt_result` on same HealthManager. Verify no panics, no data races, snapshot remains internally consistent.
+- **Manual verification:** None needed.
+
+## Rollout Plan
+
+1. Implement HealthManager and ProviderCatalog
+2. Implement selectors
+3. Wire into planner
+4. Remove CredentialRouter

--- a/docs/specs/active/SPEC-051/prd.md
+++ b/docs/specs/active/SPEC-051/prd.md
@@ -1,0 +1,60 @@
+# PRD: Execution Controller & Dispatch Cutover
+
+| Field     | Value                                               |
+|-----------|-----------------------------------------------------|
+| Spec ID   | SPEC-051                                            |
+| Title     | Execution Controller & Dispatch Cutover              |
+| Author    | Claude                                              |
+| Status    | Draft                                               |
+| Created   | 2026-03-14                                          |
+| Updated   | 2026-03-14                                          |
+
+## Problem Statement
+
+Current `dispatch.rs` embeds routing logic inline: it loops through providers, calls `router.pick()`, handles retries with exponential backoff, and mixes route selection with request execution. Retry is not stage-aware (credential hop vs provider hop vs model hop share the same counter). There is no per-try timeout, no retry budget enforcement, and no structured route trace output.
+
+## Goals
+
+- Replace dispatch inline routing with `ExecutionController` that consumes a `RoutePlan`
+- Implement stage-aware failover: credential retry -> provider failover -> model fallback
+- Each stage has independent attempt limits
+- Add per-try timeout
+- Enforce retry budget
+- Produce `RouteTrace` events for every attempt
+- Wire route trace into request logs and debug headers
+
+## Non-Goals
+
+- Translation/cloaking/payload rules logic changes
+- Dashboard UI (SPEC-052)
+
+## User Stories
+
+- As an operator, I want credential retries, provider failover, and model fallback to have separate attempt limits.
+- As an operator, I want per-try timeouts so a slow upstream doesn't consume my entire timeout budget.
+- As an operator, I want retry budgets so retries don't amplify upstream load.
+- As an operator, I want to see the full route trace in request logs when debugging.
+
+## Success Metrics
+
+- Dispatch no longer contains route selection logic
+- Each failover stage has its own counter visible in traces
+- Route trace appears in request logs
+- Debug headers contain route summary from trace
+
+## Constraints
+
+- Must not change translation, cloaking, or payload rules logic
+- Must preserve streaming and keepalive behavior
+- `ExecutionController` consumes `RoutePlan` from planner, does not build routes
+
+## Open Questions
+
+- None
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Execution model | Sequential attempts vs pre-built plan | Pre-built plan from planner | Separation of planning and execution |
+| Retry scope | Global counter vs per-stage | Per-stage counters | Finer control, matches TD requirement |

--- a/docs/specs/active/SPEC-051/technical-design.md
+++ b/docs/specs/active/SPEC-051/technical-design.md
@@ -1,0 +1,343 @@
+# Technical Design: Execution Controller & Dispatch Cutover
+
+| Field     | Value                                               |
+|-----------|-----------------------------------------------------|
+| Spec ID   | SPEC-051                                            |
+| Title     | Execution Controller & Dispatch Cutover              |
+| Author    | Claude                                              |
+| Status    | Draft                                               |
+| Created   | 2026-03-14                                          |
+| Updated   | 2026-03-14                                          |
+
+## Overview
+
+Replace the inline routing loop in `dispatch.rs` with an `ExecutionController` that consumes a `RoutePlan` and executes attempts in stage order: credential retry -> provider failover -> model fallback. Each stage has independent limits. Depends on SPEC-048 (types), SPEC-049 (planner), SPEC-050 (health + selectors).
+
+## API Design
+
+### Modified Response Headers (debug mode)
+
+```
+x-prism-route-id: <uuid>
+x-prism-route-summary: profile=balanced provider=openai credential=prod-us-1 model=gpt-5
+x-prism-route-attempts: 2
+x-prism-route-fallback: false
+```
+
+Replaces current `x-debug-*` headers.
+
+## Backend Implementation
+
+### Module Structure
+
+```
+crates/server/src/dispatch/
+├── mod.rs              # dispatch() entry point (simplified)
+├── features.rs         # Extract RouteRequestFeatures from DispatchRequest
+├── executor.rs         # ExecutionController
+├── helpers.rs          # (existing, updated)
+├── streaming.rs        # (existing, unchanged)
+└── retry.rs            # Remove (replaced by ExecutionController)
+```
+
+### Features Extraction (`features.rs`)
+
+```rust
+pub fn extract_features(req: &DispatchRequest) -> RouteRequestFeatures {
+    RouteRequestFeatures {
+        requested_model: req.model.clone(),
+        endpoint: match req.source_format { /* ... */ },
+        source_format: req.source_format,
+        tenant_id: req.tenant_id.clone(),
+        api_key_id: req.api_key_id.clone(),
+        region: req.client_region.clone(),
+        stream: req.stream,
+        headers: /* extract from req */,
+    }
+}
+```
+
+### ExecutionController (`executor.rs`)
+
+```rust
+pub struct ExecutionController<'a> {
+    state: &'a AppState,
+    health: &'a HealthManager,
+    catalog: &'a ProviderCatalog,
+}
+
+pub struct ExecutionResult {
+    pub response: Response<Body>,
+    pub trace: RouteTrace,
+}
+
+impl<'a> ExecutionController<'a> {
+    pub async fn execute(
+        &self,
+        plan: &RoutePlan,
+        req: &DispatchRequest,
+    ) -> Result<ExecutionResult, ProxyError> {
+        let failover_config = &plan.failover;
+        let mut trace = plan.trace.clone();
+
+        // Stage 1: Walk the model chain
+        for (model_idx, model) in plan.model_chain.iter().enumerate() {
+            if model_idx >= failover_config.model_attempts as usize {
+                break;
+            }
+
+            // Stage 2: Walk providers for this model
+            let provider_attempts = self.attempts_for_model(&plan.attempts, model);
+            for (prov_idx, provider_group) in provider_attempts.iter().enumerate() {
+                if prov_idx >= failover_config.provider_attempts as usize {
+                    break;
+                }
+
+                // Stage 3: Walk credentials for this provider
+                for (cred_idx, attempt) in provider_group.iter().enumerate() {
+                    if cred_idx >= failover_config.credential_attempts as usize {
+                        break;
+                    }
+
+                    // Check retry budget
+                    if model_idx > 0 || prov_idx > 0 || cred_idx > 0 {
+                        if !self.health.retry_budget_allows() {
+                            trace.add_event("retry_budget_exhausted");
+                            return Err(ProxyError::RetryBudgetExhausted);
+                        }
+                        self.health.record_retry();
+                    }
+
+                    // Execute single attempt with per-try timeout
+                    match self.execute_attempt(attempt, req, &mut trace).await {
+                        Ok(response) => return Ok(ExecutionResult { response, trace }),
+                        Err(err) => {
+                            trace.fallback_events.push(RouteFallbackEvent {
+                                from_model: model.clone(),
+                                to_model: model.clone(),
+                                reason: format!("{err}"),
+                            });
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            // Model fallback event
+            if model_idx + 1 < plan.model_chain.len() {
+                trace.fallback_events.push(RouteFallbackEvent {
+                    from_model: model.clone(),
+                    to_model: plan.model_chain[model_idx + 1].clone(),
+                    reason: "all_providers_exhausted".into(),
+                });
+            }
+        }
+
+        Err(ProxyError::AllAttemptsExhausted { trace })
+    }
+
+    async fn execute_attempt(
+        &self,
+        attempt: &RouteAttemptPlan,
+        req: &DispatchRequest,
+        trace: &mut RouteTrace,
+    ) -> Result<Response<Body>, ProxyError> {
+        // 1. Find credential from catalog
+        let (format, auth) = self.catalog.find_credential(&attempt.credential_id)?;
+
+        // 2. Record attempt start
+        self.health.record_attempt_start(&attempt.credential_id);
+
+        let start = Instant::now();
+
+        // 3. Get executor
+        let executor = self.state.executors.get(&format)?;
+
+        // 4. Translate request (reuse existing translation logic)
+        let translated = self.translate_request(req, &auth, &attempt.model)?;
+
+        // 5. Apply cloaking + payload rules (reuse existing logic)
+        let final_payload = self.apply_transforms(translated, &auth, req)?;
+
+        // 6. Execute with per-try timeout
+        let per_try_timeout = Duration::from_secs(30); // configurable
+        let result = tokio::time::timeout(
+            per_try_timeout,
+            if req.stream {
+                executor.execute_stream(/* ... */)
+            } else {
+                executor.execute(/* ... */)
+            }
+        ).await;
+
+        // 7. Record result
+        let latency = start.elapsed().as_millis() as f64;
+        let attempt_result = match &result {
+            Ok(Ok(_)) => AttemptResult::success(latency),
+            Ok(Err(e)) => AttemptResult::from_error(e, latency),
+            Err(_) => AttemptResult::timeout(latency),
+        };
+        self.health.record_attempt_result(&attempt.credential_id, &attempt_result);
+
+        result.map_err(|_| ProxyError::Timeout)?
+    }
+}
+```
+
+### Simplified dispatch entry point (`mod.rs`)
+
+```rust
+pub async fn dispatch(state: &AppState, req: DispatchRequest) -> Result<Response<Body>, ProxyError> {
+    // 1. Extract features
+    let features = extract_features(&req);
+
+    // 2. Plan route (pure)
+    let config = state.config.load();
+    let inventory = state.catalog.snapshot();
+    let health = state.health.snapshot();
+    let plan = RoutePlanner::plan(&features, &config.routing, &inventory, &health);
+
+    // 3. Check cache (existing logic, reuse)
+    if let Some(cached) = try_cache(&req, &plan) {
+        return Ok(cached);
+    }
+
+    // 4. Execute plan
+    let controller = ExecutionController::new(state);
+    let result = controller.execute(&plan, &req).await?;
+
+    // 5. Write to request log with trace
+    state.request_log.record(/* ... include result.trace ... */);
+
+    // 6. Add debug headers if requested
+    if req.debug {
+        inject_route_headers(&mut result.response, &result.trace);
+    }
+
+    Ok(result.response)
+}
+```
+
+### Changes to Existing Code
+
+1. **Remove** inline routing loop from `dispatch.rs` (provider iteration, `router.pick()` calls)
+2. **Remove** `dispatch/retry.rs` (replaced by ExecutionController stage logic)
+3. **Remove** `DispatchDebug` struct (replaced by `RouteTrace`)
+4. **Update** `helpers.rs`: replace `inject_debug_headers` with `inject_route_headers`
+5. **Keep** `streaming.rs` (SSE translation, keepalive, usage capture unchanged)
+6. **Update** `AppState` to hold `HealthManager` + `ProviderCatalog` instead of `CredentialRouter`
+
+### Flow
+
+```
+DispatchRequest
+    |
+    v
+[extract_features] --> RouteRequestFeatures
+    |
+    v
+[RoutePlanner::plan] --> RoutePlan (pure, from SPEC-049)
+    |
+    v
+[try_cache] --> cache hit? return early
+    |
+    v
+[ExecutionController::execute]
+    |
+    ├─ Model Chain Loop (model_attempts limit)
+    │   ├─ Provider Loop (provider_attempts limit)
+    │   │   ├─ Credential Loop (credential_attempts limit)
+    │   │   │   ├─ retry_budget check
+    │   │   │   ├─ health.record_attempt_start()
+    │   │   │   ├─ translate + cloak + payload rules
+    │   │   │   ├─ executor.execute() with per-try timeout
+    │   │   │   ├─ health.record_attempt_result()
+    │   │   │   └─ success? return / failure? continue
+    │   │   └─ all creds exhausted -> next provider
+    │   └─ all providers exhausted -> next model (fallback event)
+    └─ all models exhausted -> AllAttemptsExhausted
+    |
+    v
+[record request log with RouteTrace]
+    |
+    v
+[inject route debug headers if debug mode]
+    |
+    v
+Response
+```
+
+## Configuration Changes
+
+No new config fields. Consumes `FailoverConfig` from SPEC-048 profiles.
+
+## Provider Compatibility
+
+| Provider | Supported | Notes |
+|----------|-----------|-------|
+| OpenAI   | Yes       | Translation and execution unchanged |
+| Claude   | Yes       | Cloaking logic reused as-is |
+| Gemini   | Yes       | Translation and execution unchanged |
+
+## Task Breakdown
+
+- [ ] Create `dispatch/features.rs` with `extract_features()`
+- [ ] Create `dispatch/executor.rs` with `ExecutionController`
+- [ ] Implement stage-aware failover loop (credential -> provider -> model)
+- [ ] Implement per-try timeout
+- [ ] Integrate retry budget checks
+- [ ] Rewrite `dispatch/mod.rs` to use planner + executor pattern
+- [ ] Update `AppState` to hold `HealthManager` + `ProviderCatalog`
+- [ ] Update debug headers to use `RouteTrace`
+- [ ] Update request log to include route trace data
+- [ ] Remove `dispatch/retry.rs`
+- [ ] Remove `DispatchDebug`, inline routing loop
+- [ ] Unit tests: extract_features maps all DispatchRequest fields correctly
+- [ ] Unit tests: extract_features handles missing optional fields
+- [ ] Integration tests: single attempt success — no failover triggered
+- [ ] Integration tests: credential failover — first credential fails, second succeeds within same provider
+- [ ] Integration tests: provider failover — all credentials of first provider fail, second provider succeeds
+- [ ] Integration tests: model fallback — all providers fail for primary model, fallback model succeeds
+- [ ] Integration tests: credential-attempts limit — stops trying credentials after limit reached
+- [ ] Integration tests: provider-attempts limit — stops trying providers after limit reached
+- [ ] Integration tests: model-attempts limit — stops trying models after limit reached
+- [ ] Integration tests: retry budget exhaustion — returns RetryBudgetExhausted when budget is spent
+- [ ] Integration tests: per-try timeout — slow executor triggers timeout, failover to next attempt
+- [ ] Integration tests: streaming failover — stream attempt fails, failover to next credential
+- [ ] Integration tests: cache hit short-circuits — no executor called when cache hits
+- [ ] Integration tests: health feedback loop — failed attempt updates health, next plan reflects unhealthy credential
+- [ ] Integration tests: all attempts exhausted — returns AllAttemptsExhausted with complete trace
+- [ ] Integration tests: route trace completeness — trace contains all attempted credentials with results
+- [ ] Integration tests: debug headers — response contains x-prism-route-id, x-prism-route-summary
+- [ ] Integration tests: request log — trace data written to request log store
+- [ ] Regression tests: existing /v1/chat/completions behavior unchanged for single-provider config
+- [ ] Regression tests: existing /v1/messages behavior unchanged
+- [ ] Regression tests: existing streaming + keepalive behavior unchanged
+
+## Test Strategy
+
+- **Unit tests:**
+  - Feature extraction: all `DispatchRequest` fields mapped to `RouteRequestFeatures`. Missing optional fields default correctly.
+- **Integration tests (mock executors):**
+  - **Success path:** Single attempt succeeds, response returned, health updated with success, trace shows 1 attempt.
+  - **Credential failover:** Mock executor fails for credential-1, succeeds for credential-2. Verify attempt order matches plan, health updated for both.
+  - **Provider failover:** All credentials of provider-1 fail (up to credential-attempts limit), provider-2 credential succeeds. Trace shows cross-provider fallback event.
+  - **Model fallback:** All providers fail for model-1, model-2 succeeds. Trace shows model fallback event.
+  - **Stage limits:** Verify credential-attempts, provider-attempts, model-attempts limits are respected exactly.
+  - **Retry budget:** Exhaust budget mid-failover, verify `RetryBudgetExhausted` error with partial trace.
+  - **Per-try timeout:** Mock executor sleeps beyond timeout, verify timeout error, failover to next attempt.
+  - **Streaming failover:** Stream executor returns error, failover to next credential with non-stream or stream retry.
+  - **Cache interaction:** Pre-populate cache, verify executor never called, response served from cache.
+  - **Health feedback loop:** Execute a request that fails (updates health), execute a second request, verify planner avoids the failed credential.
+  - **All exhausted:** All attempts fail, verify `AllAttemptsExhausted` error with complete trace listing every attempt.
+  - **Debug headers:** `x-prism-route-id` is a valid UUID, `x-prism-route-summary` contains provider/credential/model.
+  - **Request log:** After dispatch, `RequestLogStore` contains entry with route trace data.
+- **Regression tests:**
+  - Single-provider config: `/v1/chat/completions`, `/v1/messages`, `/v1/responses` produce same response shape as before.
+  - Streaming + keepalive: SSE stream with keepalive spaces works as before.
+- **Manual verification:** None needed (all automated).
+
+## Rollout Plan
+
+1. Replace dispatch entry point with planner + executor pattern
+2. Remove inline routing loop and retry.rs in the same commit

--- a/docs/specs/active/SPEC-052/prd.md
+++ b/docs/specs/active/SPEC-052/prd.md
@@ -1,0 +1,57 @@
+# PRD: Preview API & Dashboard UX
+
+| Field     | Value                                    |
+|-----------|------------------------------------------|
+| Spec ID   | SPEC-052                                 |
+| Title     | Preview API & Dashboard UX               |
+| Author    | Claude                                   |
+| Status    | Draft                                    |
+| Created   | 2026-03-14                               |
+| Updated   | 2026-03-14                               |
+
+## Problem Statement
+
+There is no first-class "why was this route chosen?" API. The dashboard UI suggests stronger semantics than the code provides. Current routing page exposes a single strategy dropdown that does not reflect the actual routing behavior. Operators cannot preview or debug routing decisions without reading code or analyzing logs after the fact.
+
+## Goals
+
+- Add preview and explain API endpoints using the same planner as production
+- Dashboard routing page with preset cards, rule table, advanced editor, and route preview
+- Show human-intent labels before algorithm names
+- Display effective policy, not raw config fragments
+- Validate impossible combinations in UI before save
+- Remove legacy routing UI and obsolete config fields
+
+## Non-Goals
+
+- Semantic routing
+- Custom strategy plugins
+
+## User Stories
+
+- As an operator, I want to select a routing preset (Balanced/Stable/Lowest Latency/Lowest Cost) and understand what it does in plain language.
+- As an operator, I want to define rules that match requests by model/tenant/endpoint and bind them to profiles.
+- As an operator, I want to preview a route by entering model/endpoint/tenant and seeing which credential would be selected and why.
+- As an operator, I want to see why specific credentials were rejected (region mismatch, circuit breaker open, etc.).
+
+## Success Metrics
+
+- Preview API returns same result as production planner for identical inputs
+- Operators can understand routing decisions without reading code
+- Dashboard validates config before save
+
+## Constraints
+
+- Preview uses exact same planner as production (no separate preview logic)
+- Route preview must work without executing upstream calls
+
+## Open Questions
+
+- None
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Preview fidelity | Simplified preview vs same planner | Same planner | Eliminates preview/production divergence |
+| UI approach | Single page vs multi-tab | Single page with sections | Progressive disclosure |

--- a/docs/specs/active/SPEC-052/technical-design.md
+++ b/docs/specs/active/SPEC-052/technical-design.md
@@ -1,0 +1,336 @@
+# Technical Design: Preview API & Dashboard UX
+
+| Field     | Value                                    |
+|-----------|------------------------------------------|
+| Spec ID   | SPEC-052                                 |
+| Title     | Preview API & Dashboard UX               |
+| Author    | Claude                                   |
+| Status    | Draft                                    |
+| Created   | 2026-03-14                               |
+| Updated   | 2026-03-14                               |
+
+## Overview
+
+Add dashboard API endpoints for routing config management and route preview/explain. Build a new dashboard routing page with presets, rules, advanced editor, and live preview. Depends on all prior specs (SPEC-048 through SPEC-051).
+
+## API Design
+
+### Endpoints
+
+```
+GET    /api/dashboard/routing       # Get routing config
+PATCH  /api/dashboard/routing       # Update routing config
+POST   /api/dashboard/routing/preview   # Preview route plan
+POST   /api/dashboard/routing/explain   # Explain route decision
+```
+
+Uses new profile-based config shape.
+
+### Preview Request
+
+```json
+{
+  "model": "gpt-5",
+  "endpoint": "chat-completions",
+  "source_format": "openai",
+  "tenant_id": "enterprise-acme",
+  "api_key_id": "sk-proxy-123",
+  "region": "us-east",
+  "stream": false,
+  "headers": {
+    "x-job-class": "interactive"
+  }
+}
+```
+
+### Preview Response
+
+```json
+{
+  "profile": "balanced",
+  "matched_rule": "enterprise-latency",
+  "model_chain": ["gpt-5", "gpt-5-mini", "claude-sonnet-4-5"],
+  "selected": {
+    "provider": "openai",
+    "credential_name": "prod-openai-us-1",
+    "model": "gpt-5",
+    "score": {
+      "weight": 100.0,
+      "latency_ms": 245.3,
+      "inflight": 12,
+      "health_penalty": 0.0
+    }
+  },
+  "alternates": [
+    {
+      "provider": "openai",
+      "credential_name": "prod-openai-us-2",
+      "model": "gpt-5",
+      "score": { "weight": 100.0, "latency_ms": 312.1, "inflight": 8, "health_penalty": 0.0 }
+    }
+  ],
+  "rejections": [
+    {
+      "candidate": "gemini/eu-1",
+      "reason": "region_mismatch"
+    }
+  ],
+  "model_resolution": [
+    { "step": "fallback_chain_built", "primary": "gpt-5", "fallbacks": ["gpt-5-mini", "claude-sonnet-4-5"] }
+  ]
+}
+```
+
+### Explain Response
+
+Same as preview response with additional scoring details:
+
+```json
+{
+  "...preview fields...",
+  "scoring": [
+    {
+      "candidate": "openai/prod-openai-us-1",
+      "score": { "weight": 100.0, "latency_ms": 245.3 },
+      "rank": 1
+    },
+    {
+      "candidate": "openai/prod-openai-us-2",
+      "score": { "weight": 100.0, "latency_ms": 312.1 },
+      "rank": 2
+    }
+  ]
+}
+```
+
+## Backend Implementation
+
+### Module Structure
+
+```
+crates/server/src/handler/dashboard/
+├── routing.rs          # Profile-based routing handlers
+
+web/src/
+├── pages/
+│   └── Routing.tsx     # Profile-based routing page
+├── components/routing/
+│   ├── PresetCards.tsx
+│   ├── RuleTable.tsx
+│   ├── AdvancedEditor.tsx
+│   └── RoutePreview.tsx
+├── services/
+│   └── api.ts          # Add preview/explain API calls
+```
+
+### Backend Handlers (`routing.rs`)
+
+```rust
+/// GET /api/dashboard/routing
+pub async fn get_routing(State(state): State<AppState>) -> impl IntoResponse {
+    let config = state.config.load();
+    Json(&config.routing) // new RoutingConfig from SPEC-048
+}
+
+/// PATCH /api/dashboard/routing
+pub async fn update_routing(
+    State(state): State<AppState>,
+    Json(update): Json<RoutingConfigUpdate>,
+) -> impl IntoResponse {
+    // Validate config
+    // Apply to config
+    // Trigger hot reload
+}
+
+/// POST /api/dashboard/routing/preview
+pub async fn preview_route(
+    State(state): State<AppState>,
+    Json(req): Json<PreviewRequest>,
+) -> impl IntoResponse {
+    let features = RouteRequestFeatures::from(req);
+    let config = state.config.load();
+    let inventory = state.catalog.snapshot();
+    let health = state.health.snapshot();
+
+    let plan = RoutePlanner::plan(&features, &config.routing, &inventory, &health);
+    let explanation = explain(&plan);
+
+    Json(explanation)
+}
+
+/// POST /api/dashboard/routing/explain
+pub async fn explain_route(
+    State(state): State<AppState>,
+    Json(req): Json<PreviewRequest>,
+) -> impl IntoResponse {
+    // Same as preview but includes scoring details
+    let features = RouteRequestFeatures::from(req);
+    let config = state.config.load();
+    let inventory = state.catalog.snapshot();
+    let health = state.health.snapshot();
+
+    let plan = RoutePlanner::plan(&features, &config.routing, &inventory, &health);
+    let explanation = explain_detailed(&plan);
+
+    Json(explanation)
+}
+```
+
+### Frontend Components
+
+#### Page Layout (`Routing.tsx`)
+
+```
++------------------------------------------+
+| Section 1: Routing Mode                  |
+| +--------+ +--------+ +--------+ +----+ |
+| |Balanced| | Stable | |Low Lat | |Cost| |
+| |  (*)   | |        | |        | |    | |
+| +--------+ +--------+ +--------+ +----+ |
++------------------------------------------+
+| Section 2: Rules                         |
+| +------+--------+----------+--------+   |
+| | Name | Match  | Profile  | Action |   |
+| +------+--------+----------+--------+   |
+| | ent  | gpt-*  | low-lat  | [edit] |   |
+| | bg   | header | low-cost | [edit] |   |
+| +------+--------+----------+--------+   |
+| [+ Add Rule]                             |
++------------------------------------------+
+| Section 3: Advanced Policy               |
+| [Provider] [Credential] [Health] [Fail]  |
+| +--------------------------------------+ |
+| | Strategy: weighted-round-robin       | |
+| | Weights: openai=100 claude=100       | |
+| +--------------------------------------+ |
++------------------------------------------+
+| Section 4: Route Preview                 |
+| +------------------+-------------------+ |
+| | Model: [gpt-5  ] | Selected:         | |
+| | Endpoint: [chat ] |   openai/prod-1   | |
+| | Tenant: [acme   ] | Alternates:       | |
+| | Region: [us-east] |   openai/prod-2   | |
+| | Stream: [ ] No   |   claude/prod-1   | |
+| | [Preview]         | Rejected:         | |
+| |                   |   gemini/eu-1:    | |
+| |                   |   region_mismatch | |
+| +------------------+-------------------+ |
++------------------------------------------+
+```
+
+#### PresetCards.tsx
+
+- 4 cards with icon, title, description
+- Descriptions use human intent language:
+  - Balanced: "Distribute requests evenly across providers and credentials"
+  - Stable: "Always use the same provider, failover only when unhealthy"
+  - Lowest Latency: "Route to the fastest responding provider"
+  - Lowest Cost: "Route to the cheapest available provider"
+- Selecting a preset updates the active profile
+
+#### RuleTable.tsx
+
+- CRUD table for route rules
+- Match columns: model (glob), tenant (glob), endpoint, stream, region, headers
+- Profile column: dropdown of available profiles
+- Priority: drag-to-reorder or explicit number
+- Inline validation
+
+#### AdvancedEditor.tsx
+
+- 4 tabs: Provider Policy, Credential Policy, Health, Failover
+- Each tab shows the effective config for the selected profile
+- Strategy dropdown with description
+- Parameter editors (weights, thresholds, timeouts)
+
+#### RoutePreview.tsx
+
+- Left: form with model, endpoint, tenant, region, stream, headers
+- Right: preview result (calls `POST /api/dashboard/routing/preview`)
+- Shows: selected route, alternates, rejections with reasons, model chain
+- Auto-refreshes on form change (debounced)
+
+### UX Rules
+
+1. Show human intent label (e.g., "Distribute evenly") before algorithm name (e.g., "weighted-round-robin")
+2. Display effective policy (merged defaults + overrides), not raw config fragments
+3. Validate impossible combinations before save:
+   - `ordered-fallback` requires non-empty `order` list
+   - `weighted-round-robin` requires non-empty `weights`
+   - Profile referenced by rule must exist
+4. Preview uses same planner code path as production
+
+### Changes to Existing Code
+
+1. **Rewrite** `handler/dashboard/routing.rs` with profile-based handlers
+2. **Rewrite** `web/src/pages/Routing.tsx` with presets + rules + preview layout
+3. **Remove** strategy dropdown UI
+4. **Update** `web/src/services/api.ts` with preview/explain API calls
+5. **Update** Axum router to register new endpoints
+
+## Configuration Changes
+
+No new config fields beyond SPEC-048.
+
+## Provider Compatibility
+
+| Provider | Supported | Notes |
+|----------|-----------|-------|
+| OpenAI   | Yes       | Preview is provider-agnostic |
+| Claude   | Yes       | Preview is provider-agnostic |
+| Gemini   | Yes       | Preview is provider-agnostic |
+
+## Task Breakdown
+
+- [ ] Implement `preview_route` handler
+- [ ] Implement `explain_route` handler
+- [ ] Rewrite `get_routing` handler for profile-based config shape
+- [ ] Rewrite `update_routing` handler with validation
+- [ ] Register new routes in Axum router
+- [ ] Create `PresetCards.tsx` component
+- [ ] Create `RuleTable.tsx` component with CRUD
+- [ ] Create `AdvancedEditor.tsx` component with 4 tabs
+- [ ] Create `RoutePreview.tsx` component with live preview
+- [ ] Rewrite `Routing.tsx` page with presets + rules + preview layout
+- [ ] Update `api.ts` with preview/explain API calls
+- [ ] Remove legacy routing strategy dropdown code
+- [ ] Integration tests: preview API — returns correct selected route, alternates, rejections
+- [ ] Integration tests: preview API — empty inventory returns empty selected with rejections
+- [ ] Integration tests: preview API — invalid request body returns 400 with error detail
+- [ ] Integration tests: preview API — missing required fields return 400
+- [ ] Integration tests: explain API — includes scoring entries for all candidates
+- [ ] Integration tests: explain API — scoring rank order matches selected + alternates order
+- [ ] Integration tests: GET routing — returns current config in profile-based shape
+- [ ] Integration tests: PATCH routing — valid update applies and persists after reload
+- [ ] Integration tests: PATCH routing — rule references non-existent profile returns 422
+- [ ] Integration tests: PATCH routing — ordered-fallback without order list returns 422
+- [ ] Integration tests: PATCH routing — weighted-rr without weights returns 422
+- [ ] Integration tests: PATCH routing — empty profiles map returns 422
+- [ ] Integration tests: config hot-reload — updated routing config reflected in subsequent preview calls
+- [ ] Frontend: `npx tsc --noEmit` passes (type-check)
+- [ ] Frontend: API type definitions match backend response shapes
+- [ ] E2E test: full routing stack — config update via PATCH, then preview reflects the change
+
+## Test Strategy
+
+- **Unit tests:** None (handler + UI layer)
+- **Integration tests:**
+  - **Preview API:** Mock inventory with 3 providers, 5 credentials (some unhealthy, some region-mismatched). Verify selected, alternates, and rejections match expected. Edge case: empty inventory returns no selected with empty alternates.
+  - **Explain API:** Same setup as preview, verify scoring entries present for all non-rejected candidates, rank order consistent with selected + alternates ordering.
+  - **GET routing:** Returns complete `RoutingConfig` with all profiles, rules, model-resolution.
+  - **PATCH routing:** Valid update persists. Invalid updates (missing profile ref, missing strategy params, empty profiles) return 422 with specific error message.
+  - **Config hot-reload:** PATCH config, then call preview, verify new config is active.
+  - **Error responses:** Invalid JSON body returns 400, missing required fields returns 400 with field-level errors.
+- **Frontend:**
+  - TypeScript type-check: `npx tsc --noEmit` passes.
+  - API type consistency: frontend type definitions for preview/explain response match backend serde output (verified by shared type generation or manual comparison).
+- **E2E test:**
+  - Full stack: update config via PATCH -> preview via POST -> verify preview uses new config. This validates the config -> planner -> preview pipeline end-to-end.
+- **Manual verification:** Dashboard routing page layout, preset card interaction, rule CRUD, advanced editor tabs, route preview live updates.
+
+## Rollout Plan
+
+1. Backend handlers first
+2. Frontend components
+3. Clean up legacy routing code
+4. End-to-end manual verification

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -35,7 +35,13 @@ pub struct TestServer {
 impl TestServer {
     /// Start a new test server with the given config.
     pub async fn start(config: Config) -> Self {
-        let credential_router = Arc::new(CredentialRouter::new(config.routing.strategy));
+        let default_cred_strategy = config
+            .routing
+            .profiles
+            .get(&config.routing.default_profile)
+            .map(|p| p.credential_policy.strategy)
+            .unwrap_or_default();
+        let credential_router = Arc::new(CredentialRouter::new(default_cred_strategy));
         credential_router.update_from_config(&config);
 
         let http_client_pool = Arc::new(prism_core::proxy::HttpClientPool::new());

--- a/web/src/__tests__/services/api.test.ts
+++ b/web/src/__tests__/services/api.test.ts
@@ -43,61 +43,29 @@ describe('API service', () => {
 });
 
 describe('routingApi', () => {
-  it('sends strategy directly to backend', async () => {
+  it('sends default-profile to backend', async () => {
     const mod = await import('../../services/api');
     const instance = vi.mocked(axios.create).mock.results[0]?.value;
     vi.mocked(instance.patch).mockResolvedValueOnce({ data: {} });
 
-    await mod.routingApi.update({ strategy: 'round-robin' });
+    await mod.routingApi.update({ 'default-profile': 'balanced' });
 
     expect(instance.patch).toHaveBeenCalledWith(
       '/routing',
-      expect.objectContaining({ strategy: 'round-robin' })
+      expect.objectContaining({ 'default-profile': 'balanced' })
     );
   });
 
-  it('sends fill-first strategy', async () => {
+  it('sends profile update', async () => {
     const mod = await import('../../services/api');
     const instance = vi.mocked(axios.create).mock.results[0]?.value;
     vi.mocked(instance.patch).mockResolvedValueOnce({ data: {} });
 
-    await mod.routingApi.update({ strategy: 'fill-first' });
+    await mod.routingApi.update({ 'default-profile': 'lowest-latency' });
 
     expect(instance.patch).toHaveBeenCalledWith(
       '/routing',
-      expect.objectContaining({ strategy: 'fill-first' })
-    );
-  });
-
-  it('sends request_retry and max_retry_interval directly', async () => {
-    const mod = await import('../../services/api');
-    const instance = vi.mocked(axios.create).mock.results[0]?.value;
-    vi.mocked(instance.patch).mockResolvedValueOnce({ data: {} });
-
-    await mod.routingApi.update({ request_retry: 5, max_retry_interval: 30 });
-
-    expect(instance.patch).toHaveBeenCalledWith(
-      '/routing',
-      expect.objectContaining({ request_retry: 5, max_retry_interval: 30 })
-    );
-  });
-
-  it('sends model_strategies and model_fallbacks', async () => {
-    const mod = await import('../../services/api');
-    const instance = vi.mocked(axios.create).mock.results[0]?.value;
-    vi.mocked(instance.patch).mockResolvedValueOnce({ data: {} });
-
-    await mod.routingApi.update({
-      model_strategies: { 'claude-*': 'latency-aware' },
-      model_fallbacks: { 'gpt-4o': ['gpt-4o-mini'] },
-    });
-
-    expect(instance.patch).toHaveBeenCalledWith(
-      '/routing',
-      expect.objectContaining({
-        model_strategies: { 'claude-*': 'latency-aware' },
-        model_fallbacks: { 'gpt-4o': ['gpt-4o-mini'] },
-      })
+      expect.objectContaining({ 'default-profile': 'lowest-latency' })
     );
   });
 });

--- a/web/src/pages/Routing.tsx
+++ b/web/src/pages/Routing.tsx
@@ -1,40 +1,30 @@
 import { useEffect, useState } from 'react';
 import { routingApi } from '../services/api';
-import type { RoutingConfig, RoutingStrategy } from '../types';
-import { GitBranch, Save, RotateCcw, Plus, Trash2 } from 'lucide-react';
+import type { RoutingConfig } from '../types';
+import { GitBranch, Save, RotateCcw } from 'lucide-react';
 
-const STRATEGIES: { value: RoutingStrategy; label: string; description: string }[] = [
+const PRESETS = [
   {
-    value: 'round-robin',
-    label: 'Round Robin',
-    description: 'Distribute requests evenly across all active credentials in sequence.',
+    key: 'balanced',
+    label: 'Balanced',
+    description: 'Distribute requests evenly across providers and credentials.',
   },
   {
-    value: 'fill-first',
-    label: 'Fill First',
-    description: 'Prioritize the first credential by weight, only use others when exhausted.',
+    key: 'stable',
+    label: 'Stable',
+    description: 'Always use the same provider, failover only when unhealthy.',
   },
   {
-    value: 'latency-aware',
-    label: 'Latency Aware',
-    description: 'Route to the credential with the lowest average response time.',
+    key: 'lowest-latency',
+    label: 'Lowest Latency',
+    description: 'Route to the fastest responding provider.',
   },
   {
-    value: 'geo-aware',
-    label: 'Geo Aware',
-    description: 'Route based on client region matching credential region tags.',
+    key: 'lowest-cost',
+    label: 'Lowest Cost',
+    description: 'Route to the cheapest available provider.',
   },
 ];
-
-interface ModelStrategyRow {
-  pattern: string;
-  strategy: RoutingStrategy;
-}
-
-interface ModelFallbackRow {
-  pattern: string;
-  fallbacks: string;
-}
 
 export default function Routing() {
   const [config, setConfig] = useState<RoutingConfig | null>(null);
@@ -43,29 +33,11 @@ export default function Routing() {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
 
-  // Editable state
-  const [strategy, setStrategy] = useState<RoutingStrategy>('round-robin');
-  const [fallbackEnabled, setFallbackEnabled] = useState(true);
-  const [requestRetry, setRequestRetry] = useState(3);
-  const [maxRetryInterval, setMaxRetryInterval] = useState(30);
-  const [modelStrategies, setModelStrategies] = useState<ModelStrategyRow[]>([]);
-  const [modelFallbacks, setModelFallbacks] = useState<ModelFallbackRow[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState('balanced');
 
   const loadConfig = (data: RoutingConfig) => {
     setConfig(data);
-    setStrategy(data.strategy);
-    setFallbackEnabled(data.fallback_enabled);
-    setRequestRetry(data.request_retry);
-    setMaxRetryInterval(data.max_retry_interval);
-    setModelStrategies(
-      Object.entries(data.model_strategies).map(([pattern, strategy]) => ({ pattern, strategy }))
-    );
-    setModelFallbacks(
-      Object.entries(data.model_fallbacks).map(([pattern, fallbacks]) => ({
-        pattern,
-        fallbacks: fallbacks.join(', '),
-      }))
-    );
+    setSelectedProfile(data['default-profile']);
   };
 
   const fetchConfig = async () => {
@@ -83,43 +55,16 @@ export default function Routing() {
     fetchConfig();
   }, []);
 
-  const buildPayload = () => {
-    const ms: Record<string, RoutingStrategy> = {};
-    for (const row of modelStrategies) {
-      if (row.pattern.trim()) ms[row.pattern.trim()] = row.strategy;
-    }
-    const mf: Record<string, string[]> = {};
-    for (const row of modelFallbacks) {
-      if (row.pattern.trim()) {
-        mf[row.pattern.trim()] = row.fallbacks.split(',').map((s) => s.trim()).filter(Boolean);
-      }
-    }
-    return {
-      strategy,
-      fallback_enabled: fallbackEnabled,
-      request_retry: requestRetry,
-      max_retry_interval: maxRetryInterval,
-      model_strategies: ms,
-      model_fallbacks: mf,
-    };
-  };
-
   const handleSave = async () => {
     setSaving(true);
     setError('');
     setSaved(false);
 
     try {
-      const payload = buildPayload();
-      await routingApi.update(payload);
-      loadConfig({
-        strategy: payload.strategy,
-        fallback_enabled: payload.fallback_enabled,
-        request_retry: payload.request_retry,
-        max_retry_interval: payload.max_retry_interval,
-        model_strategies: payload.model_strategies,
-        model_fallbacks: payload.model_fallbacks,
-      });
+      await routingApi.update({ 'default-profile': selectedProfile });
+      if (config) {
+        loadConfig({ ...config, 'default-profile': selectedProfile });
+      }
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (err) {
@@ -151,7 +96,7 @@ export default function Routing() {
       <div className="page-header">
         <div>
           <h2>Routing</h2>
-          <p className="page-subtitle">Configure request routing strategy</p>
+          <p className="page-subtitle">Configure request routing profile</p>
         </div>
         <div className="page-header-actions">
           <button className="btn btn-secondary" onClick={handleReset}>
@@ -172,31 +117,31 @@ export default function Routing() {
       {error && <div className="alert alert-error" style={{ marginBottom: '1.5rem' }}>{error}</div>}
       {saved && <div className="alert alert-success" style={{ marginBottom: '1.5rem' }}>Routing configuration updated successfully.</div>}
 
-      {/* Strategy Selection */}
+      {/* Profile Selection */}
       <div className="card">
         <div className="card-header">
-          <h3>Default Routing Strategy</h3>
+          <h3>Routing Profile</h3>
         </div>
         <div className="card-body">
           <div className="strategy-grid">
-            {STRATEGIES.map((s) => (
+            {PRESETS.map((p) => (
               <label
-                key={s.value}
-                className={`strategy-option ${strategy === s.value ? 'strategy-option--selected' : ''}`}
+                key={p.key}
+                className={`strategy-option ${selectedProfile === p.key ? 'strategy-option--selected' : ''}`}
               >
                 <input
                   type="radio"
-                  name="strategy"
-                  value={s.value}
-                  checked={strategy === s.value}
-                  onChange={() => setStrategy(s.value)}
+                  name="profile"
+                  value={p.key}
+                  checked={selectedProfile === p.key}
+                  onChange={() => setSelectedProfile(p.key)}
                 />
                 <div className="strategy-option-content">
                   <div className="strategy-option-header">
                     <GitBranch size={18} />
-                    <span className="strategy-option-label">{s.label}</span>
+                    <span className="strategy-option-label">{p.label}</span>
                   </div>
-                  <p className="strategy-option-desc">{s.description}</p>
+                  <p className="strategy-option-desc">{p.description}</p>
                 </div>
               </label>
             ))}
@@ -204,172 +149,42 @@ export default function Routing() {
         </div>
       </div>
 
-      {/* Per-Model Strategies */}
-      <div className="card">
-        <div className="card-header card-header--actions">
-          <h3>Per-Model Strategies</h3>
-          <button
-            className="btn btn-ghost btn-sm"
-            onClick={() => setModelStrategies([...modelStrategies, { pattern: '', strategy: 'round-robin' }])}
-          >
-            <Plus size={14} />
-            Add Rule
-          </button>
-        </div>
-        <div className="card-body">
-          {modelStrategies.length === 0 ? (
-            <p className="text-muted">
-              No per-model strategy overrides. All models use the default strategy above.
-            </p>
-          ) : (
-            <div className="kv-rows">
-              {modelStrategies.map((row, idx) => (
-                <div key={idx} className="kv-row">
-                  <input
-                    type="text"
-                    value={row.pattern}
-                    onChange={(e) => {
-                      const next = [...modelStrategies];
-                      next[idx] = { ...next[idx], pattern: e.target.value };
-                      setModelStrategies(next);
-                    }}
-                    placeholder="claude-*, gpt-4o"
-                    style={{ flex: 1 }}
-                  />
-                  <select
-                    value={row.strategy}
-                    onChange={(e) => {
-                      const next = [...modelStrategies];
-                      next[idx] = { ...next[idx], strategy: e.target.value as RoutingStrategy };
-                      setModelStrategies(next);
-                    }}
-                  >
-                    {STRATEGIES.map((s) => (
-                      <option key={s.value} value={s.value}>{s.label}</option>
-                    ))}
-                  </select>
-                  <button
-                    className="btn btn-ghost btn-sm btn-danger-ghost"
-                    onClick={() => setModelStrategies(modelStrategies.filter((_, i) => i !== idx))}
-                  >
-                    <Trash2 size={14} />
-                  </button>
+      {/* Current Profile Details */}
+      {config && config.profiles[selectedProfile] && (
+        <div className="card">
+          <div className="card-header">
+            <h3>Profile Details: {selectedProfile}</h3>
+          </div>
+          <div className="card-body">
+            <div className="settings-form">
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Provider Strategy</label>
+                  <code>{config.profiles[selectedProfile]['provider-policy'].strategy}</code>
                 </div>
-              ))}
-            </div>
-          )}
-          <span className="form-help">
-            Model patterns support glob wildcards (*). More specific patterns take priority over the default.
-          </span>
-        </div>
-      </div>
-
-      {/* Model Fallbacks */}
-      <div className="card">
-        <div className="card-header card-header--actions">
-          <h3>Model Fallbacks</h3>
-          <button
-            className="btn btn-ghost btn-sm"
-            onClick={() => setModelFallbacks([...modelFallbacks, { pattern: '', fallbacks: '' }])}
-          >
-            <Plus size={14} />
-            Add Fallback
-          </button>
-        </div>
-        <div className="card-body">
-          {modelFallbacks.length === 0 ? (
-            <p className="text-muted">
-              No model fallback chains configured. Requests will only try the requested model.
-            </p>
-          ) : (
-            <div className="kv-rows">
-              {modelFallbacks.map((row, idx) => (
-                <div key={idx} className="kv-row">
-                  <input
-                    type="text"
-                    value={row.pattern}
-                    onChange={(e) => {
-                      const next = [...modelFallbacks];
-                      next[idx] = { ...next[idx], pattern: e.target.value };
-                      setModelFallbacks(next);
-                    }}
-                    placeholder="gpt-4o"
-                    style={{ width: '30%' }}
-                  />
-                  <span className="text-muted" style={{ flexShrink: 0 }}>&rarr;</span>
-                  <input
-                    type="text"
-                    value={row.fallbacks}
-                    onChange={(e) => {
-                      const next = [...modelFallbacks];
-                      next[idx] = { ...next[idx], fallbacks: e.target.value };
-                      setModelFallbacks(next);
-                    }}
-                    placeholder="gpt-4o-mini, gpt-3.5-turbo"
-                    style={{ flex: 1 }}
-                  />
-                  <button
-                    className="btn btn-ghost btn-sm btn-danger-ghost"
-                    onClick={() => setModelFallbacks(modelFallbacks.filter((_, i) => i !== idx))}
-                  >
-                    <Trash2 size={14} />
-                  </button>
+                <div className="form-group">
+                  <label>Credential Strategy</label>
+                  <code>{config.profiles[selectedProfile]['credential-policy'].strategy}</code>
                 </div>
-              ))}
-            </div>
-          )}
-          <span className="form-help">
-            When all credentials for the primary model are exhausted, the system tries fallback models in order. Comma-separated.
-          </span>
-        </div>
-      </div>
-
-      {/* Additional Settings */}
-      <div className="card">
-        <div className="card-header">
-          <h3>Settings</h3>
-        </div>
-        <div className="card-body">
-          <div className="settings-form">
-            <div className="form-group form-group-inline">
-              <label className="checkbox-label">
-                <input
-                  type="checkbox"
-                  checked={fallbackEnabled}
-                  onChange={(e) => setFallbackEnabled(e.target.checked)}
-                />
-                Enable fallback (model fallback chains and provider retry on failure)
-              </label>
-            </div>
-
-            <div className="form-row">
-              <div className="form-group">
-                <label>Retry Count</label>
-                <input
-                  type="number"
-                  value={requestRetry}
-                  onChange={(e) => setRequestRetry(parseInt(e.target.value, 10) || 0)}
-                  min="0"
-                  max="10"
-                />
-                <span className="form-help">Number of retries on failure (0-10)</span>
               </div>
-
-              <div className="form-group">
-                <label>Max Retry Interval (seconds)</label>
-                <input
-                  type="number"
-                  value={maxRetryInterval}
-                  onChange={(e) => setMaxRetryInterval(parseInt(e.target.value, 10) || 5)}
-                  min="1"
-                  max="300"
-                />
-                <span className="form-help">Maximum wait between retries in seconds</span>
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Credential Attempts</label>
+                  <code>{config.profiles[selectedProfile].failover['credential-attempts']}</code>
+                </div>
+                <div className="form-group">
+                  <label>Provider Attempts</label>
+                  <code>{config.profiles[selectedProfile].failover['provider-attempts']}</code>
+                </div>
+                <div className="form-group">
+                  <label>Model Attempts</label>
+                  <code>{config.profiles[selectedProfile].failover['model-attempts']}</code>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -169,17 +169,9 @@ export const authKeysApi = {
 export const routingApi = {
   get: () =>
     api.get('/routing').then((res) => {
-      const raw = res.data;
       return {
         ...res,
-        data: {
-          strategy: raw.strategy ?? 'round-robin',
-          fallback_enabled: raw.fallback_enabled ?? false,
-          request_retry: raw.request_retry ?? 3,
-          max_retry_interval: raw.max_retry_interval ?? 30,
-          model_strategies: raw.model_strategies ?? {},
-          model_fallbacks: raw.model_fallbacks ?? {},
-        } as RoutingConfig,
+        data: res.data as RoutingConfig,
       };
     }) as Promise<{ data: RoutingConfig } & Record<string, unknown>>,
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -122,24 +122,89 @@ export interface AuthKeyCreateResponse {
 
 // ── Routing ──
 
-export type RoutingStrategy = 'round-robin' | 'fill-first' | 'latency-aware' | 'geo-aware';
+export type ProviderStrategy =
+  | 'ordered-fallback'
+  | 'weighted-round-robin'
+  | 'ewma-latency'
+  | 'lowest-estimated-cost'
+  | 'sticky-hash';
+
+export type CredentialStrategy =
+  | 'priority-weighted-rr'
+  | 'fill-first'
+  | 'least-inflight'
+  | 'ewma-latency'
+  | 'sticky-hash'
+  | 'random-two-choices';
+
+export interface RouteProfile {
+  'provider-policy': {
+    strategy: ProviderStrategy;
+    'sticky-key'?: string;
+    weights?: Record<string, number>;
+    order?: string[];
+  };
+  'credential-policy': {
+    strategy: CredentialStrategy;
+  };
+  health: {
+    'circuit-breaker': {
+      enabled: boolean;
+      'failure-threshold': number;
+      'cooldown-seconds': number;
+    };
+    'outlier-detection': {
+      'consecutive-5xx': number;
+      'consecutive-local-failures': number;
+      'base-eject-seconds': number;
+      'max-eject-seconds': number;
+    };
+  };
+  failover: {
+    'credential-attempts': number;
+    'provider-attempts': number;
+    'model-attempts': number;
+    'retry-budget': {
+      ratio: number;
+      'min-retries-per-second': number;
+    };
+    'retry-on': string[];
+  };
+}
+
+export interface RouteRule {
+  name: string;
+  priority?: number;
+  match: {
+    models?: string[];
+    tenants?: string[];
+    endpoints?: string[];
+    regions?: string[];
+    stream?: boolean;
+    headers?: Record<string, string[]>;
+  };
+  'use-profile': string;
+}
+
+export interface ModelResolution {
+  aliases?: { from: string; to: string }[];
+  rewrites?: { pattern: string; to: string }[];
+  fallbacks?: { pattern: string; to: string[] }[];
+  'provider-pins'?: { pattern: string; providers: string[] }[];
+}
 
 export interface RoutingConfig {
-  strategy: RoutingStrategy;
-  fallback_enabled: boolean;
-  request_retry: number;
-  max_retry_interval: number;
-  model_strategies: Record<string, RoutingStrategy>;
-  model_fallbacks: Record<string, string[]>;
+  'default-profile': string;
+  profiles: Record<string, RouteProfile>;
+  rules: RouteRule[];
+  'model-resolution': ModelResolution;
 }
 
 export interface RoutingUpdateRequest {
-  strategy?: RoutingStrategy;
-  fallback_enabled?: boolean;
-  request_retry?: number;
-  max_retry_interval?: number;
-  model_strategies?: Record<string, RoutingStrategy>;
-  model_fallbacks?: Record<string, string[]>;
+  'default-profile'?: string;
+  profiles?: Record<string, RouteProfile>;
+  rules?: RouteRule[];
+  'model-resolution'?: ModelResolution;
 }
 
 // ── Metrics (real-time WebSocket snapshot) ──


### PR DESCRIPTION
## Summary

- Replace single `RoutingStrategy` enum with layered profile-based routing configuration
- Add 4 preset profiles: balanced, stable, lowest-latency, lowest-cost
- Separate provider policy, credential policy, health config, and failover config per profile
- Add model resolution layer (aliases, rewrites, fallbacks, provider pins)
- Add route rules for conditional profile selection
- Update dashboard API, frontend Routing page, and all tests
- Add spec documents for SPEC-048 through SPEC-052

Closes #173

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo test --workspace` — 375 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 44 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)