### PR TITLE
feat: route planner & match engine (SPEC-049)

### DIFF
--- a/crates/core/src/routing/explain.rs
+++ b/crates/core/src/routing/explain.rs
@@ -1,0 +1,169 @@
+use super::types::*;
+
+/// Convert a RoutePlan into a structured RouteExplanation for API responses.
+pub fn explain(plan: &RoutePlan) -> RouteExplanation {
+    let selected = plan.attempts.first().map(|a| SelectedRoute {
+        provider: format!("{:?}", a.provider).to_lowercase(),
+        credential_name: a.credential_name.clone(),
+        model: a.model.clone(),
+        score: a.score.clone(),
+    });
+
+    let alternates = plan
+        .attempts
+        .iter()
+        .skip(1)
+        .map(|a| SelectedRoute {
+            provider: format!("{:?}", a.provider).to_lowercase(),
+            credential_name: a.credential_name.clone(),
+            model: a.model.clone(),
+            score: a.score.clone(),
+        })
+        .collect();
+
+    RouteExplanation {
+        profile: plan.profile.clone(),
+        matched_rule: plan.trace.matched_rule.clone(),
+        model_chain: plan.model_chain.clone(),
+        selected,
+        alternates,
+        rejections: plan.trace.rejections.clone(),
+        model_resolution: plan.trace.model_resolution_steps.clone(),
+        scoring: plan.trace.scoring.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::Format;
+
+    #[test]
+    fn test_explain_empty_plan() {
+        let plan = RoutePlan {
+            profile: "balanced".to_string(),
+            model_chain: vec!["gpt-4".to_string()],
+            attempts: vec![],
+            trace: RouteTrace {
+                resolved_profile: "balanced".to_string(),
+                ..Default::default()
+            },
+        };
+        let explanation = explain(&plan);
+        assert_eq!(explanation.profile, "balanced");
+        assert!(explanation.selected.is_none());
+        assert!(explanation.alternates.is_empty());
+    }
+
+    #[test]
+    fn test_explain_with_attempts() {
+        let plan = RoutePlan {
+            profile: "balanced".to_string(),
+            model_chain: vec!["gpt-4".to_string()],
+            attempts: vec![
+                RouteAttemptPlan {
+                    model: "gpt-4".to_string(),
+                    provider: Format::OpenAI,
+                    credential_id: "cred-1".to_string(),
+                    credential_name: "prod-1".to_string(),
+                    rank: 1,
+                    score: RouteScore {
+                        weight: 100.0,
+                        ..Default::default()
+                    },
+                },
+                RouteAttemptPlan {
+                    model: "gpt-4".to_string(),
+                    provider: Format::OpenAI,
+                    credential_id: "cred-2".to_string(),
+                    credential_name: "prod-2".to_string(),
+                    rank: 2,
+                    score: RouteScore {
+                        weight: 50.0,
+                        ..Default::default()
+                    },
+                },
+            ],
+            trace: RouteTrace {
+                resolved_profile: "balanced".to_string(),
+                ..Default::default()
+            },
+        };
+        let explanation = explain(&plan);
+        assert!(explanation.selected.is_some());
+        assert_eq!(
+            explanation.selected.as_ref().unwrap().credential_name,
+            "prod-1"
+        );
+        assert_eq!(explanation.alternates.len(), 1);
+        assert_eq!(explanation.alternates[0].credential_name, "prod-2");
+    }
+
+    #[test]
+    fn test_explain_preserves_rejections() {
+        let plan = RoutePlan {
+            profile: "stable".to_string(),
+            model_chain: vec!["gpt-4".to_string()],
+            attempts: vec![],
+            trace: RouteTrace {
+                resolved_profile: "stable".to_string(),
+                rejections: vec![
+                    RouteRejection {
+                        candidate: "claude/prod".to_string(),
+                        reason: RejectReason::ModelNotSupported,
+                    },
+                    RouteRejection {
+                        candidate: "openai/prod".to_string(),
+                        reason: RejectReason::CircuitBreakerOpen,
+                    },
+                ],
+                ..Default::default()
+            },
+        };
+        let explanation = explain(&plan);
+        assert_eq!(explanation.rejections.len(), 2);
+        assert_eq!(
+            explanation.rejections[0].reason,
+            RejectReason::ModelNotSupported
+        );
+    }
+
+    #[test]
+    fn test_explain_preserves_matched_rule() {
+        let plan = RoutePlan {
+            profile: "stable".to_string(),
+            model_chain: vec!["gpt-4".to_string()],
+            attempts: vec![],
+            trace: RouteTrace {
+                matched_rule: Some("enterprise-latency".to_string()),
+                resolved_profile: "stable".to_string(),
+                ..Default::default()
+            },
+        };
+        let explanation = explain(&plan);
+        assert_eq!(
+            explanation.matched_rule,
+            Some("enterprise-latency".to_string())
+        );
+    }
+
+    #[test]
+    fn test_explain_preserves_model_resolution() {
+        let plan = RoutePlan {
+            profile: "balanced".to_string(),
+            model_chain: vec!["gpt-4".to_string(), "gpt-3.5-turbo".to_string()],
+            attempts: vec![],
+            trace: RouteTrace {
+                resolved_profile: "balanced".to_string(),
+                model_resolution_steps: vec![ModelResolutionStep::FallbackChainBuilt {
+                    primary: "gpt-4".to_string(),
+                    fallbacks: vec!["gpt-3.5-turbo".to_string()],
+                }],
+                ..Default::default()
+            },
+        };
+        let explanation = explain(&plan);
+        assert_eq!(explanation.model_resolution.len(), 1);
+        assert_eq!(explanation.model_chain.len(), 2);
+    }
+}

--- a/crates/core/src/routing/match_engine.rs
+++ b/crates/core/src/routing/match_engine.rs
@@ -1,0 +1,403 @@
+use super::config::{RouteMatch, RouteRule, RoutingConfig};
+use super::types::RouteRequestFeatures;
+use crate::glob::glob_match;
+use crate::routing::config::RouteProfile;
+
+/// Find the best matching rule for the given request features.
+/// Rules are ranked by specificity, then explicit priority, then declaration order.
+/// Returns `None` if no rule matches.
+pub fn match_rule<'a>(
+    features: &RouteRequestFeatures,
+    rules: &'a [RouteRule],
+) -> Option<&'a RouteRule> {
+    let mut best: Option<(usize, i32, i32)> = None; // (index, specificity, priority)
+
+    for (i, rule) in rules.iter().enumerate() {
+        if !matches_rule(features, &rule.match_conditions) {
+            continue;
+        }
+        let specificity = compute_specificity(features, &rule.match_conditions);
+        let priority = rule.priority.unwrap_or(0);
+
+        if let Some((_, best_spec, best_pri)) = best {
+            if specificity > best_spec || (specificity == best_spec && priority > best_pri) {
+                best = Some((i, specificity, priority));
+            }
+            // On full tie, earlier declaration wins (keep current best)
+        } else {
+            best = Some((i, specificity, priority));
+        }
+    }
+
+    best.map(|(i, _, _)| &rules[i])
+}
+
+/// Resolve the effective profile for the given request features.
+/// First tries rule matching; falls back to the default profile.
+pub fn resolve_profile<'a>(
+    features: &RouteRequestFeatures,
+    config: &'a RoutingConfig,
+) -> (&'a str, &'a RouteProfile) {
+    if let Some(rule) =
+        match_rule(features, &config.rules).filter(|r| config.profiles.contains_key(&r.use_profile))
+    {
+        let profile = &config.profiles[&rule.use_profile];
+        return (&rule.use_profile, profile);
+    }
+    let profile = config
+        .profiles
+        .get(&config.default_profile)
+        .expect("default profile must exist (validated at config load)");
+    (&config.default_profile, profile)
+}
+
+/// Check whether a rule's match conditions are satisfied by the features.
+fn matches_rule(features: &RouteRequestFeatures, cond: &RouteMatch) -> bool {
+    // Model match
+    if !cond.models.is_empty()
+        && !cond
+            .models
+            .iter()
+            .any(|p| glob_match(p, &features.requested_model))
+    {
+        return false;
+    }
+
+    // Tenant match
+    if !cond.tenants.is_empty() {
+        match &features.tenant_id {
+            Some(tid) => {
+                if !cond.tenants.iter().any(|p| glob_match(p, tid)) {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
+
+    // Endpoint match
+    if !cond.endpoints.is_empty() {
+        let ep_str = serde_json::to_value(features.endpoint)
+            .ok()
+            .and_then(|v| v.as_str().map(String::from))
+            .unwrap_or_default();
+        if !cond.endpoints.iter().any(|e| e == ep_str.as_str()) {
+            return false;
+        }
+    }
+
+    // Region match
+    if !cond.regions.is_empty() {
+        match &features.region {
+            Some(r) => {
+                if !cond.regions.iter().any(|p| glob_match(p, r)) {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
+
+    // Stream match
+    if cond.stream.is_some_and(|stream| features.stream != stream) {
+        return false;
+    }
+
+    // Header match
+    for (key, patterns) in &cond.headers {
+        match features.headers.get(key) {
+            Some(val) => {
+                if !patterns.iter().any(|p| glob_match(p, val)) {
+                    return false;
+                }
+            }
+            None => return false,
+        }
+    }
+
+    true
+}
+
+/// Compute specificity score for a matching rule.
+/// Higher score = more specific match.
+fn compute_specificity(features: &RouteRequestFeatures, cond: &RouteMatch) -> i32 {
+    let mut score = 0i32;
+
+    // Each non-empty dimension adds base points
+    if !cond.models.is_empty() {
+        // Exact model match > glob match
+        if cond.models.iter().any(|p| p == &features.requested_model) {
+            score += 10; // exact
+        } else {
+            score += 5; // glob
+        }
+    }
+    if let Some(tid) = features
+        .tenant_id
+        .as_ref()
+        .filter(|_| !cond.tenants.is_empty())
+    {
+        if cond.tenants.iter().any(|p| p == tid) {
+            score += 10;
+        } else {
+            score += 5;
+        }
+    }
+    if !cond.endpoints.is_empty() {
+        score += 10; // endpoints are always exact
+    }
+    if let Some(r) = features
+        .region
+        .as_ref()
+        .filter(|_| !cond.regions.is_empty())
+    {
+        if cond.regions.iter().any(|p| p == r) {
+            score += 10;
+        } else {
+            score += 5;
+        }
+    }
+    if cond.stream.is_some() {
+        score += 5;
+    }
+    // Each header constraint adds points
+    score += (cond.headers.len() as i32) * 5;
+
+    score
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::Format;
+    use crate::routing::types::RouteEndpoint;
+    use std::collections::BTreeMap;
+
+    fn features(model: &str) -> RouteRequestFeatures {
+        RouteRequestFeatures {
+            requested_model: model.to_string(),
+            endpoint: RouteEndpoint::ChatCompletions,
+            source_format: Format::OpenAI,
+            tenant_id: None,
+            api_key_id: None,
+            region: None,
+            stream: false,
+            headers: BTreeMap::new(),
+        }
+    }
+
+    fn rule(name: &str, models: &[&str], profile: &str) -> RouteRule {
+        RouteRule {
+            name: name.to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                models: models.iter().map(|s| s.to_string()).collect(),
+                ..Default::default()
+            },
+            use_profile: profile.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_no_rules_returns_none() {
+        let f = features("gpt-4");
+        assert!(match_rule(&f, &[]).is_none());
+    }
+
+    #[test]
+    fn test_exact_model_match() {
+        let rules = vec![rule("r1", &["gpt-4"], "stable")];
+        let f = features("gpt-4");
+        let matched = match_rule(&f, &rules).unwrap();
+        assert_eq!(matched.name, "r1");
+    }
+
+    #[test]
+    fn test_glob_model_match() {
+        let rules = vec![rule("r1", &["gpt-*"], "stable")];
+        let f = features("gpt-4");
+        let matched = match_rule(&f, &rules).unwrap();
+        assert_eq!(matched.name, "r1");
+    }
+
+    #[test]
+    fn test_no_match() {
+        let rules = vec![rule("r1", &["claude-*"], "stable")];
+        let f = features("gpt-4");
+        assert!(match_rule(&f, &rules).is_none());
+    }
+
+    #[test]
+    fn test_exact_model_beats_glob() {
+        let rules = vec![
+            rule("glob", &["gpt-*"], "balanced"),
+            rule("exact", &["gpt-4"], "stable"),
+        ];
+        let f = features("gpt-4");
+        let matched = match_rule(&f, &rules).unwrap();
+        assert_eq!(matched.name, "exact");
+    }
+
+    #[test]
+    fn test_more_dimensions_beats_fewer() {
+        let r1 = RouteRule {
+            name: "model-only".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                models: vec!["gpt-4".to_string()],
+                ..Default::default()
+            },
+            use_profile: "balanced".to_string(),
+        };
+        let r2 = RouteRule {
+            name: "model-and-tenant".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                models: vec!["gpt-4".to_string()],
+                tenants: vec!["enterprise-*".to_string()],
+                ..Default::default()
+            },
+            use_profile: "stable".to_string(),
+        };
+        let mut f = features("gpt-4");
+        f.tenant_id = Some("enterprise-acme".to_string());
+        let rules = [r1, r2];
+        let matched = match_rule(&f, &rules).unwrap();
+        assert_eq!(matched.name, "model-and-tenant");
+    }
+
+    #[test]
+    fn test_priority_overrides_specificity_tie() {
+        let r1 = rule("low", &["gpt-4"], "balanced");
+        let mut r2 = rule("high", &["gpt-4"], "stable");
+        r2.priority = Some(10);
+        let f = features("gpt-4");
+        let rules = [r1, r2];
+        let matched = match_rule(&f, &rules).unwrap();
+        assert_eq!(matched.name, "high");
+    }
+
+    #[test]
+    fn test_declaration_order_breaks_tie() {
+        let r1 = rule("first", &["gpt-4"], "balanced");
+        let r2 = rule("second", &["gpt-4"], "stable");
+        let f = features("gpt-4");
+        let rules = [r1, r2];
+        let matched = match_rule(&f, &rules).unwrap();
+        assert_eq!(matched.name, "first");
+    }
+
+    #[test]
+    fn test_stream_filter() {
+        let r = RouteRule {
+            name: "streaming".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                stream: Some(true),
+                ..Default::default()
+            },
+            use_profile: "balanced".to_string(),
+        };
+        let mut f = features("gpt-4");
+        assert!(match_rule(&f, std::slice::from_ref(&r)).is_none());
+        f.stream = true;
+        assert!(match_rule(&f, &[r]).is_some());
+    }
+
+    #[test]
+    fn test_header_match() {
+        let mut headers_cond = std::collections::HashMap::new();
+        headers_cond.insert("x-priority".to_string(), vec!["high".to_string()]);
+        let r = RouteRule {
+            name: "priority".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                headers: headers_cond,
+                ..Default::default()
+            },
+            use_profile: "stable".to_string(),
+        };
+        let mut f = features("gpt-4");
+        assert!(match_rule(&f, std::slice::from_ref(&r)).is_none());
+        f.headers
+            .insert("x-priority".to_string(), "high".to_string());
+        assert!(match_rule(&f, &[r]).is_some());
+    }
+
+    #[test]
+    fn test_resolve_profile_default_no_rules() {
+        let config = RoutingConfig::default();
+        let f = features("gpt-4");
+        let (name, _profile) = resolve_profile(&f, &config);
+        assert_eq!(name, "balanced");
+    }
+
+    #[test]
+    fn test_resolve_profile_matched_rule() {
+        let mut config = RoutingConfig::default();
+        config.rules.push(RouteRule {
+            name: "stable-for-claude".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                models: vec!["claude-*".to_string()],
+                ..Default::default()
+            },
+            use_profile: "stable".to_string(),
+        });
+        let f = features("claude-3-opus");
+        let (name, _profile) = resolve_profile(&f, &config);
+        assert_eq!(name, "stable");
+    }
+
+    #[test]
+    fn test_tenant_required_when_specified() {
+        let r = RouteRule {
+            name: "enterprise".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                tenants: vec!["ent-*".to_string()],
+                ..Default::default()
+            },
+            use_profile: "stable".to_string(),
+        };
+        // No tenant_id -> no match
+        let f = features("gpt-4");
+        assert!(match_rule(&f, &[r]).is_none());
+    }
+
+    #[test]
+    fn test_region_match() {
+        let r = RouteRule {
+            name: "us-only".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                regions: vec!["us-*".to_string()],
+                ..Default::default()
+            },
+            use_profile: "stable".to_string(),
+        };
+        let mut f = features("gpt-4");
+        f.region = Some("eu-west-1".to_string());
+        assert!(match_rule(&f, std::slice::from_ref(&r)).is_none());
+        f.region = Some("us-east-1".to_string());
+        assert!(match_rule(&f, &[r]).is_some());
+    }
+
+    #[test]
+    fn test_endpoint_match() {
+        let r = RouteRule {
+            name: "messages-only".to_string(),
+            priority: None,
+            match_conditions: RouteMatch {
+                endpoints: vec!["messages".to_string()],
+                ..Default::default()
+            },
+            use_profile: "stable".to_string(),
+        };
+        let f = features("gpt-4"); // endpoint = ChatCompletions
+        assert!(match_rule(&f, std::slice::from_ref(&r)).is_none());
+        let mut f2 = features("gpt-4");
+        f2.endpoint = RouteEndpoint::Messages;
+        assert!(match_rule(&f2, &[r]).is_some());
+    }
+}

--- a/crates/core/src/routing/mod.rs
+++ b/crates/core/src/routing/mod.rs
@@ -1,2 +1,6 @@
 pub mod config;
+pub mod explain;
+pub mod match_engine;
+pub mod model_resolver;
+pub mod planner;
 pub mod types;

--- a/crates/core/src/routing/model_resolver.rs
+++ b/crates/core/src/routing/model_resolver.rs
@@ -1,0 +1,291 @@
+use super::config::ModelResolution;
+use super::types::ModelResolutionStep;
+use crate::glob::glob_match;
+
+/// Result of model resolution.
+#[derive(Debug, Clone)]
+pub struct ResolvedModel {
+    /// Primary model followed by fallback models.
+    pub model_chain: Vec<String>,
+    /// If set, only these providers may serve the matched models.
+    pub pinned_providers: Option<Vec<String>>,
+    /// Trace of resolution steps applied.
+    pub resolution_steps: Vec<ModelResolutionStep>,
+}
+
+/// Resolve a requested model name through the model resolution pipeline.
+///
+/// Resolution order (single pass each):
+/// 1. Alias — exact match only, no chaining
+/// 2. Rewrite — glob match, first match wins
+/// 3. Fallback chain — glob match on resolved model
+/// 4. Provider pin — glob match on resolved model
+pub fn resolve_model(requested: &str, resolution: &ModelResolution) -> ResolvedModel {
+    let mut steps = Vec::new();
+    let mut model = requested.to_string();
+
+    // 1. Alias (exact match only, single pass — no chaining)
+    for alias in &resolution.aliases {
+        if alias.from == model {
+            steps.push(ModelResolutionStep::AliasResolved {
+                from: model.clone(),
+                to: alias.to.clone(),
+            });
+            model = alias.to.clone();
+            break;
+        }
+    }
+
+    // 2. Rewrite (glob match, first match wins)
+    for rewrite in &resolution.rewrites {
+        if glob_match(&rewrite.pattern, &model) {
+            steps.push(ModelResolutionStep::RewriteApplied {
+                from: model.clone(),
+                to: rewrite.to.clone(),
+                rule: rewrite.pattern.clone(),
+            });
+            model = rewrite.to.clone();
+            break;
+        }
+    }
+
+    // 3. Fallback chain (glob match, primary model is first)
+    let mut model_chain = vec![model.clone()];
+    for fb in &resolution.fallbacks {
+        if glob_match(&fb.pattern, &model) {
+            let fallbacks: Vec<String> = fb
+                .to
+                .iter()
+                .filter(|m| **m != model) // Don't duplicate primary
+                .cloned()
+                .collect();
+            if !fallbacks.is_empty() {
+                steps.push(ModelResolutionStep::FallbackChainBuilt {
+                    primary: model.clone(),
+                    fallbacks: fallbacks.clone(),
+                });
+                model_chain.extend(fallbacks);
+            }
+            break;
+        }
+    }
+
+    // 4. Provider pin (glob match)
+    let mut pinned_providers = None;
+    for pin in &resolution.provider_pins {
+        if glob_match(&pin.pattern, &model) {
+            steps.push(ModelResolutionStep::ProviderPinned {
+                model: model.clone(),
+                providers: pin.providers.clone(),
+            });
+            pinned_providers = Some(pin.providers.clone());
+            break;
+        }
+    }
+
+    ResolvedModel {
+        model_chain,
+        pinned_providers,
+        resolution_steps: steps,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::config::*;
+
+    fn empty_resolution() -> ModelResolution {
+        ModelResolution::default()
+    }
+
+    #[test]
+    fn test_no_resolution_returns_original() {
+        let r = resolve_model("gpt-4", &empty_resolution());
+        assert_eq!(r.model_chain, vec!["gpt-4"]);
+        assert!(r.pinned_providers.is_none());
+        assert!(r.resolution_steps.is_empty());
+    }
+
+    #[test]
+    fn test_alias_exact_match() {
+        let res = ModelResolution {
+            aliases: vec![ModelAlias {
+                from: "gpt-5-default".to_string(),
+                to: "gpt-5".to_string(),
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("gpt-5-default", &res);
+        assert_eq!(r.model_chain, vec!["gpt-5"]);
+        assert_eq!(r.resolution_steps.len(), 1);
+        assert!(matches!(
+            &r.resolution_steps[0],
+            ModelResolutionStep::AliasResolved { from, to }
+            if from == "gpt-5-default" && to == "gpt-5"
+        ));
+    }
+
+    #[test]
+    fn test_alias_no_chaining() {
+        // alias A->B and B->C should not chain: requesting A yields B, not C
+        let res = ModelResolution {
+            aliases: vec![
+                ModelAlias {
+                    from: "a".to_string(),
+                    to: "b".to_string(),
+                },
+                ModelAlias {
+                    from: "b".to_string(),
+                    to: "c".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let r = resolve_model("a", &res);
+        assert_eq!(r.model_chain, vec!["b"]);
+    }
+
+    #[test]
+    fn test_alias_no_glob() {
+        // Aliases are exact match only; glob patterns should not match
+        let res = ModelResolution {
+            aliases: vec![ModelAlias {
+                from: "gpt-*".to_string(),
+                to: "gpt-4".to_string(),
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("gpt-5", &res);
+        // Should NOT match — "gpt-*" is literal, not a glob
+        assert_eq!(r.model_chain, vec!["gpt-5"]);
+        assert!(r.resolution_steps.is_empty());
+    }
+
+    #[test]
+    fn test_rewrite_glob() {
+        let res = ModelResolution {
+            rewrites: vec![ModelRewrite {
+                pattern: "claude-*-preview".to_string(),
+                to: "claude-3.5-sonnet".to_string(),
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("claude-next-preview", &res);
+        assert_eq!(r.model_chain, vec!["claude-3.5-sonnet"]);
+    }
+
+    #[test]
+    fn test_rewrite_first_match_wins() {
+        let res = ModelResolution {
+            rewrites: vec![
+                ModelRewrite {
+                    pattern: "gpt-*".to_string(),
+                    to: "gpt-4o".to_string(),
+                },
+                ModelRewrite {
+                    pattern: "gpt-*".to_string(),
+                    to: "gpt-4".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let r = resolve_model("gpt-latest", &res);
+        assert_eq!(r.model_chain, vec!["gpt-4o"]);
+    }
+
+    #[test]
+    fn test_rewrite_no_match() {
+        let res = ModelResolution {
+            rewrites: vec![ModelRewrite {
+                pattern: "claude-*".to_string(),
+                to: "claude-3.5-sonnet".to_string(),
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("gpt-4", &res);
+        assert_eq!(r.model_chain, vec!["gpt-4"]);
+    }
+
+    #[test]
+    fn test_fallback_chain() {
+        let res = ModelResolution {
+            fallbacks: vec![ModelFallback {
+                pattern: "gpt-4".to_string(),
+                to: vec!["gpt-4-turbo".to_string(), "gpt-3.5-turbo".to_string()],
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("gpt-4", &res);
+        assert_eq!(r.model_chain, vec!["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"]);
+    }
+
+    #[test]
+    fn test_fallback_no_duplicate_primary() {
+        let res = ModelResolution {
+            fallbacks: vec![ModelFallback {
+                pattern: "gpt-4".to_string(),
+                to: vec!["gpt-4".to_string(), "gpt-3.5-turbo".to_string()],
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("gpt-4", &res);
+        // Primary should not be duplicated in chain
+        assert_eq!(r.model_chain, vec!["gpt-4", "gpt-3.5-turbo"]);
+    }
+
+    #[test]
+    fn test_provider_pin() {
+        let res = ModelResolution {
+            provider_pins: vec![ProviderPin {
+                pattern: "claude-*".to_string(),
+                providers: vec!["claude".to_string()],
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("claude-3-opus", &res);
+        assert_eq!(r.pinned_providers, Some(vec!["claude".to_string()]));
+    }
+
+    #[test]
+    fn test_alias_then_fallback() {
+        let res = ModelResolution {
+            aliases: vec![ModelAlias {
+                from: "smart".to_string(),
+                to: "gpt-4".to_string(),
+            }],
+            fallbacks: vec![ModelFallback {
+                pattern: "gpt-4".to_string(),
+                to: vec!["gpt-3.5-turbo".to_string()],
+            }],
+            ..Default::default()
+        };
+        let r = resolve_model("smart", &res);
+        // alias resolves to gpt-4, then fallback chain adds gpt-3.5-turbo
+        assert_eq!(r.model_chain, vec!["gpt-4", "gpt-3.5-turbo"]);
+        assert_eq!(r.resolution_steps.len(), 2);
+    }
+
+    #[test]
+    fn test_full_pipeline() {
+        let res = ModelResolution {
+            aliases: vec![ModelAlias {
+                from: "latest".to_string(),
+                to: "gpt-4o".to_string(),
+            }],
+            rewrites: vec![], // no rewrites
+            fallbacks: vec![ModelFallback {
+                pattern: "gpt-4o".to_string(),
+                to: vec!["gpt-4-turbo".to_string()],
+            }],
+            provider_pins: vec![ProviderPin {
+                pattern: "gpt-*".to_string(),
+                providers: vec!["openai".to_string()],
+            }],
+        };
+        let r = resolve_model("latest", &res);
+        assert_eq!(r.model_chain, vec!["gpt-4o", "gpt-4-turbo"]);
+        assert_eq!(r.pinned_providers, Some(vec!["openai".to_string()]));
+        assert_eq!(r.resolution_steps.len(), 3); // alias + fallback + pin
+    }
+}

--- a/crates/core/src/routing/planner.rs
+++ b/crates/core/src/routing/planner.rs
@@ -1,0 +1,720 @@
+use super::config::{ProviderStrategy, RouteProfile};
+use super::match_engine;
+use super::model_resolver;
+use super::types::*;
+use crate::glob::glob_match;
+use crate::provider::Format;
+use crate::routing::config::RoutingConfig;
+use std::collections::HashMap;
+
+// ─── Inventory snapshot ────────────────────────────────────────────────────
+
+/// Point-in-time snapshot of available providers and credentials.
+#[derive(Debug, Clone, Default)]
+pub struct InventorySnapshot {
+    pub providers: Vec<ProviderEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderEntry {
+    pub format: Format,
+    pub name: String,
+    pub credentials: Vec<CredentialEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CredentialEntry {
+    pub id: String,
+    pub name: String,
+    pub models: Vec<String>,
+    pub excluded_models: Vec<String>,
+    pub region: Option<String>,
+    pub weight: u32,
+    pub disabled: bool,
+}
+
+// ─── Health snapshot ───────────────────────────────────────────────────────
+
+/// Point-in-time snapshot of health state.
+#[derive(Debug, Clone, Default)]
+pub struct HealthSnapshot {
+    pub credentials: HashMap<String, CredentialHealth>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CredentialHealth {
+    pub circuit_open: bool,
+    pub ejected: bool,
+    pub inflight: u64,
+    pub ewma_latency_ms: f64,
+    pub ewma_cost_micro_usd: f64,
+    pub cooldown_active: bool,
+}
+
+impl Default for CredentialHealth {
+    fn default() -> Self {
+        Self {
+            circuit_open: false,
+            ejected: false,
+            inflight: 0,
+            ewma_latency_ms: 0.0,
+            ewma_cost_micro_usd: 0.0,
+            cooldown_active: false,
+        }
+    }
+}
+
+// ─── Planner ───────────────────────────────────────────────────────────────
+
+pub struct RoutePlanner;
+
+impl RoutePlanner {
+    /// Build a deterministic route plan from immutable inputs.
+    /// Pure function — no side effects, no I/O.
+    pub fn plan(
+        features: &RouteRequestFeatures,
+        config: &RoutingConfig,
+        inventory: &InventorySnapshot,
+        health: &HealthSnapshot,
+    ) -> RoutePlan {
+        // 1. Resolve profile via match engine
+        let (profile_name, profile) = match_engine::resolve_profile(features, config);
+        let matched_rule =
+            match_engine::match_rule(features, &config.rules).map(|r| r.name.clone());
+
+        // 2. Resolve model chain
+        let resolved =
+            model_resolver::resolve_model(&features.requested_model, &config.model_resolution);
+
+        let mut trace = RouteTrace {
+            matched_rule: matched_rule.clone(),
+            resolved_profile: profile_name.to_string(),
+            model_resolution_steps: resolved.resolution_steps,
+            ..Default::default()
+        };
+
+        // 3. For each model in chain, find eligible candidates
+        let mut all_candidates = Vec::new();
+        let mut all_rejections = Vec::new();
+
+        for model in &resolved.model_chain {
+            collect_candidates(
+                model,
+                &resolved.pinned_providers,
+                features,
+                inventory,
+                health,
+                &mut all_candidates,
+                &mut all_rejections,
+            );
+        }
+
+        // Record in trace
+        trace.candidates = all_candidates
+            .iter()
+            .map(|c| RouteCandidate {
+                provider: c.provider_name.clone(),
+                credential_id: c.credential_id.clone(),
+                credential_name: c.credential_name.clone(),
+                model: c.model.clone(),
+            })
+            .collect();
+        trace.rejections = all_rejections;
+
+        // 4. Score and rank candidates
+        let mut scored = score_candidates(&all_candidates, profile, health);
+        // Stable sort to preserve deterministic ordering
+        scored.sort_by(|a, b| {
+            b.score
+                .weight
+                .partial_cmp(&a.score.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Assign ranks
+        for (i, entry) in scored.iter_mut().enumerate() {
+            entry.rank = (i + 1) as u32;
+        }
+
+        trace.scoring = scored
+            .iter()
+            .map(|s| RouteScoringEntry {
+                candidate: format!("{}/{}", s.provider_name, s.credential_name),
+                score: s.score.clone(),
+                rank: s.rank,
+            })
+            .collect();
+
+        // 5. Build attempt list
+        let attempts: Vec<RouteAttemptPlan> = scored
+            .iter()
+            .map(|s| RouteAttemptPlan {
+                model: s.model.clone(),
+                provider: s.format,
+                credential_id: s.credential_id.clone(),
+                credential_name: s.credential_name.clone(),
+                rank: s.rank,
+                score: s.score.clone(),
+            })
+            .collect();
+
+        RoutePlan {
+            profile: profile_name.to_string(),
+            model_chain: resolved.model_chain,
+            attempts,
+            trace,
+        }
+    }
+}
+
+// ─── Internal candidate ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct CandidateInfo {
+    format: Format,
+    provider_name: String,
+    credential_id: String,
+    credential_name: String,
+    model: String,
+    weight: u32,
+    _region: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ScoredCandidate {
+    format: Format,
+    provider_name: String,
+    credential_id: String,
+    credential_name: String,
+    model: String,
+    score: RouteScore,
+    rank: u32,
+}
+
+fn collect_candidates(
+    model: &str,
+    pinned_providers: &Option<Vec<String>>,
+    features: &RouteRequestFeatures,
+    inventory: &InventorySnapshot,
+    health: &HealthSnapshot,
+    candidates: &mut Vec<CandidateInfo>,
+    rejections: &mut Vec<RouteRejection>,
+) {
+    for provider in &inventory.providers {
+        // Check provider pin
+        if pinned_providers
+            .as_ref()
+            .is_some_and(|pins| !pins.iter().any(|p| glob_match(p, &provider.name)))
+        {
+            rejections.push(RouteRejection {
+                candidate: provider.name.clone(),
+                reason: RejectReason::ProviderPinExcluded,
+            });
+            continue;
+        }
+
+        for cred in &provider.credentials {
+            let cand_label = format!("{}/{}", provider.name, cred.name);
+
+            // Disabled
+            if cred.disabled {
+                rejections.push(RouteRejection {
+                    candidate: cand_label,
+                    reason: RejectReason::CredentialDisabled,
+                });
+                continue;
+            }
+
+            // Model support
+            let supports =
+                cred.models.is_empty() || cred.models.iter().any(|m| glob_match(m, model));
+            let excluded = cred.excluded_models.iter().any(|m| glob_match(m, model));
+            if !supports || excluded {
+                rejections.push(RouteRejection {
+                    candidate: cand_label,
+                    reason: RejectReason::ModelNotSupported,
+                });
+                continue;
+            }
+
+            // Region mismatch (if request and credential both specify region)
+            if let (Some(req_region), Some(cred_region)) = (&features.region, &cred.region)
+                && !glob_match(cred_region, req_region)
+                && !glob_match(req_region, cred_region)
+            {
+                rejections.push(RouteRejection {
+                    candidate: cand_label,
+                    reason: RejectReason::RegionMismatch,
+                });
+                continue;
+            }
+
+            // Health checks
+            if let Some(ch) = health.credentials.get(&cred.id) {
+                if ch.circuit_open {
+                    rejections.push(RouteRejection {
+                        candidate: cand_label,
+                        reason: RejectReason::CircuitBreakerOpen,
+                    });
+                    continue;
+                }
+                if ch.ejected {
+                    rejections.push(RouteRejection {
+                        candidate: cand_label,
+                        reason: RejectReason::OutlierEjected,
+                    });
+                    continue;
+                }
+                if ch.cooldown_active {
+                    rejections.push(RouteRejection {
+                        candidate: cand_label,
+                        reason: RejectReason::CooldownActive,
+                    });
+                    continue;
+                }
+            }
+
+            candidates.push(CandidateInfo {
+                format: provider.format,
+                provider_name: provider.name.clone(),
+                credential_id: cred.id.clone(),
+                credential_name: cred.name.clone(),
+                model: model.to_string(),
+                weight: cred.weight,
+                _region: cred.region.clone(),
+            });
+        }
+    }
+}
+
+fn score_candidates(
+    candidates: &[CandidateInfo],
+    profile: &RouteProfile,
+    health: &HealthSnapshot,
+) -> Vec<ScoredCandidate> {
+    candidates
+        .iter()
+        .map(|c| {
+            let ch = health.credentials.get(&c.credential_id);
+            let weight = compute_weight(c, profile, ch);
+            let latency_ms = ch.map(|h| h.ewma_latency_ms);
+            let inflight = ch.map(|h| h.inflight);
+            let estimated_cost = ch.map(|h| h.ewma_cost_micro_usd);
+
+            ScoredCandidate {
+                format: c.format,
+                provider_name: c.provider_name.clone(),
+                credential_id: c.credential_id.clone(),
+                credential_name: c.credential_name.clone(),
+                model: c.model.clone(),
+                score: RouteScore {
+                    weight,
+                    latency_ms,
+                    inflight,
+                    estimated_cost,
+                    health_penalty: 0.0,
+                },
+                rank: 0,
+            }
+        })
+        .collect()
+}
+
+fn compute_weight(
+    candidate: &CandidateInfo,
+    profile: &RouteProfile,
+    health: Option<&CredentialHealth>,
+) -> f64 {
+    let base = candidate.weight as f64;
+    match profile.provider_policy.strategy {
+        ProviderStrategy::WeightedRoundRobin => {
+            // Use configured weight, fall back to credential weight
+            let w = profile
+                .provider_policy
+                .weights
+                .get(&candidate.provider_name)
+                .copied()
+                .unwrap_or(candidate.weight);
+            w as f64
+        }
+        ProviderStrategy::EwmaLatency => {
+            if let Some(h) = health.filter(|h| h.ewma_latency_ms > 0.0) {
+                return 1000.0 / h.ewma_latency_ms;
+            }
+            base
+        }
+        ProviderStrategy::LowestEstimatedCost => {
+            if let Some(h) = health.filter(|h| h.ewma_cost_micro_usd > 0.0) {
+                return 1_000_000.0 / h.ewma_cost_micro_usd;
+            }
+            base
+        }
+        ProviderStrategy::OrderedFallback => {
+            // Weight by position in order list (first = highest weight)
+            let order = &profile.provider_policy.order;
+            if order.is_empty() {
+                return base;
+            }
+            match order.iter().position(|p| p == &candidate.provider_name) {
+                Some(pos) => (order.len() - pos) as f64 * 1000.0,
+                None => 0.0, // Not in order list
+            }
+        }
+        ProviderStrategy::StickyHash => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::config::RoutingConfig;
+    use crate::routing::types::RouteEndpoint;
+    use std::collections::BTreeMap;
+
+    fn test_features(model: &str) -> RouteRequestFeatures {
+        RouteRequestFeatures {
+            requested_model: model.to_string(),
+            endpoint: RouteEndpoint::ChatCompletions,
+            source_format: Format::OpenAI,
+            tenant_id: None,
+            api_key_id: None,
+            region: None,
+            stream: false,
+            headers: BTreeMap::new(),
+        }
+    }
+
+    fn test_inventory() -> InventorySnapshot {
+        InventorySnapshot {
+            providers: vec![
+                ProviderEntry {
+                    format: Format::OpenAI,
+                    name: "openai".to_string(),
+                    credentials: vec![CredentialEntry {
+                        id: "cred-openai-1".to_string(),
+                        name: "prod-openai".to_string(),
+                        models: vec!["gpt-4".to_string(), "gpt-3.5-turbo".to_string()],
+                        excluded_models: vec![],
+                        region: None,
+                        weight: 100,
+                        disabled: false,
+                    }],
+                },
+                ProviderEntry {
+                    format: Format::Claude,
+                    name: "claude".to_string(),
+                    credentials: vec![CredentialEntry {
+                        id: "cred-claude-1".to_string(),
+                        name: "prod-claude".to_string(),
+                        models: vec!["claude-3-opus".to_string()],
+                        excluded_models: vec![],
+                        region: None,
+                        weight: 100,
+                        disabled: false,
+                    }],
+                },
+            ],
+        }
+    }
+
+    fn healthy() -> HealthSnapshot {
+        HealthSnapshot::default()
+    }
+
+    #[test]
+    fn test_plan_basic() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let inventory = test_inventory();
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert_eq!(plan.profile, "balanced");
+        assert_eq!(plan.model_chain, vec!["gpt-4"]);
+        assert!(!plan.attempts.is_empty());
+        assert_eq!(plan.attempts[0].model, "gpt-4");
+    }
+
+    #[test]
+    fn test_plan_determinism() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let inventory = test_inventory();
+        let health = healthy();
+
+        let plan1 = RoutePlanner::plan(&features, &config, &inventory, &health);
+        for _ in 0..100 {
+            let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+            assert_eq!(plan.attempts.len(), plan1.attempts.len());
+            for (a, b) in plan.attempts.iter().zip(plan1.attempts.iter()) {
+                assert_eq!(a.credential_id, b.credential_id);
+                assert_eq!(a.model, b.model);
+                assert_eq!(a.rank, b.rank);
+            }
+        }
+    }
+
+    #[test]
+    fn test_plan_empty_inventory() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let inventory = InventorySnapshot::default();
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert!(plan.attempts.is_empty());
+        assert!(plan.trace.candidates.is_empty());
+    }
+
+    #[test]
+    fn test_plan_all_credentials_unhealthy() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let inventory = test_inventory();
+        let mut health = HealthSnapshot::default();
+        health.credentials.insert(
+            "cred-openai-1".to_string(),
+            CredentialHealth {
+                circuit_open: true,
+                ..Default::default()
+            },
+        );
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert!(plan.attempts.is_empty());
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::CircuitBreakerOpen)
+        );
+    }
+
+    #[test]
+    fn test_plan_provider_pin_excludes() {
+        let features = test_features("gpt-4");
+        let mut config = RoutingConfig::default();
+        config
+            .model_resolution
+            .provider_pins
+            .push(crate::routing::config::ProviderPin {
+                pattern: "gpt-*".to_string(),
+                providers: vec!["openai".to_string()],
+            });
+        let inventory = test_inventory();
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        // Claude should be excluded
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::ProviderPinExcluded)
+        );
+        assert!(plan.attempts.iter().all(|a| a.provider == Format::OpenAI));
+    }
+
+    #[test]
+    fn test_plan_disabled_credential() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let mut inventory = test_inventory();
+        inventory.providers[0].credentials[0].disabled = true;
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::CredentialDisabled)
+        );
+    }
+
+    #[test]
+    fn test_plan_model_not_supported() {
+        let features = test_features("unknown-model");
+        let config = RoutingConfig::default();
+        let inventory = test_inventory();
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        // All credentials should reject with ModelNotSupported
+        assert!(plan.attempts.is_empty());
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::ModelNotSupported)
+        );
+    }
+
+    #[test]
+    fn test_plan_region_mismatch() {
+        let mut features = test_features("gpt-4");
+        features.region = Some("eu-west-1".to_string());
+        let config = RoutingConfig::default();
+        let mut inventory = test_inventory();
+        inventory.providers[0].credentials[0].region = Some("us-east-1".to_string());
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::RegionMismatch)
+        );
+    }
+
+    #[test]
+    fn test_plan_outlier_ejected() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let inventory = test_inventory();
+        let mut health = HealthSnapshot::default();
+        health.credentials.insert(
+            "cred-openai-1".to_string(),
+            CredentialHealth {
+                ejected: true,
+                ..Default::default()
+            },
+        );
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::OutlierEjected)
+        );
+    }
+
+    #[test]
+    fn test_plan_cooldown_active() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig::default();
+        let inventory = test_inventory();
+        let mut health = HealthSnapshot::default();
+        health.credentials.insert(
+            "cred-openai-1".to_string(),
+            CredentialHealth {
+                cooldown_active: true,
+                ..Default::default()
+            },
+        );
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert!(
+            plan.trace
+                .rejections
+                .iter()
+                .any(|r| r.reason == RejectReason::CooldownActive)
+        );
+    }
+
+    #[test]
+    fn test_plan_latency_scoring() {
+        let features = test_features("gpt-4");
+        let config = RoutingConfig {
+            default_profile: "lowest-latency".to_string(),
+            ..Default::default()
+        };
+
+        let inventory = InventorySnapshot {
+            providers: vec![ProviderEntry {
+                format: Format::OpenAI,
+                name: "openai".to_string(),
+                credentials: vec![
+                    CredentialEntry {
+                        id: "fast".to_string(),
+                        name: "fast".to_string(),
+                        models: vec!["gpt-4".to_string()],
+                        excluded_models: vec![],
+                        region: None,
+                        weight: 100,
+                        disabled: false,
+                    },
+                    CredentialEntry {
+                        id: "slow".to_string(),
+                        name: "slow".to_string(),
+                        models: vec!["gpt-4".to_string()],
+                        excluded_models: vec![],
+                        region: None,
+                        weight: 100,
+                        disabled: false,
+                    },
+                ],
+            }],
+        };
+
+        let mut health = HealthSnapshot::default();
+        health.credentials.insert(
+            "fast".to_string(),
+            CredentialHealth {
+                ewma_latency_ms: 50.0,
+                ..Default::default()
+            },
+        );
+        health.credentials.insert(
+            "slow".to_string(),
+            CredentialHealth {
+                ewma_latency_ms: 500.0,
+                ..Default::default()
+            },
+        );
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert_eq!(plan.attempts.len(), 2);
+        // Fast should rank higher (lower latency = higher weight)
+        assert_eq!(plan.attempts[0].credential_id, "fast");
+        assert_eq!(plan.attempts[1].credential_id, "slow");
+    }
+
+    #[test]
+    fn test_plan_with_fallback_chain() {
+        let features = test_features("gpt-4");
+        let mut config = RoutingConfig::default();
+        config
+            .model_resolution
+            .fallbacks
+            .push(crate::routing::config::ModelFallback {
+                pattern: "gpt-4".to_string(),
+                to: vec!["gpt-3.5-turbo".to_string()],
+            });
+
+        let inventory = test_inventory();
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert_eq!(plan.model_chain, vec!["gpt-4", "gpt-3.5-turbo"]);
+        // Should have candidates for both models
+        assert!(!plan.attempts.is_empty());
+    }
+
+    #[test]
+    fn test_plan_empty_models_means_all() {
+        let features = test_features("anything-goes");
+        let config = RoutingConfig::default();
+        let inventory = InventorySnapshot {
+            providers: vec![ProviderEntry {
+                format: Format::OpenAI,
+                name: "openai".to_string(),
+                credentials: vec![CredentialEntry {
+                    id: "cred-1".to_string(),
+                    name: "prod".to_string(),
+                    models: vec![], // empty = supports all models
+                    excluded_models: vec![],
+                    region: None,
+                    weight: 100,
+                    disabled: false,
+                }],
+            }],
+        };
+        let health = healthy();
+
+        let plan = RoutePlanner::plan(&features, &config, &inventory, &health);
+        assert_eq!(plan.attempts.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `match_engine.rs`: specificity-based rule matching with support for model, tenant, endpoint, region, stream, and header conditions
- Add `model_resolver.rs`: alias (exact match), rewrite (glob), fallback chain, and provider pin resolution
- Add `planner.rs`: deterministic pure route planner with inventory/health snapshots, candidate filtering, rejection tracking, and strategy-based scoring (WeightedRR, EwmaLatency, LowestCost, OrderedFallback, StickyHash)
- Add `explain.rs`: convert RoutePlan to structured RouteExplanation for API responses
- 45 new unit tests covering all components

Closes #174

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo test --workspace` — 420 tests pass (45 new)
- [x] No frontend changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)