### PR TITLE
feat: add route preview/explain API and rebuild dashboard routing page

### DIFF
--- a/crates/server/src/handler/dashboard/routing.rs
+++ b/crates/server/src/handler/dashboard/routing.rs
@@ -3,7 +3,12 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use prism_core::routing::config::{ModelResolution, RouteProfile, RouteRule};
+use prism_core::routing::config::{
+    CredentialPolicy, ModelResolution, ProviderPolicy, ProviderStrategy, RouteProfile, RouteRule,
+};
+use prism_core::routing::explain::explain;
+use prism_core::routing::planner::RoutePlanner;
+use prism_core::routing::types::RouteRequestFeatures;
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
@@ -28,6 +33,14 @@ pub async fn update_routing(
     State(state): State<AppState>,
     Json(body): Json<UpdateRoutingRequest>,
 ) -> impl IntoResponse {
+    // Validate before applying
+    if let Err(errors) = validate_routing_update(&body) {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": "validation_failed", "details": errors})),
+        );
+    }
+
     match super::providers::update_config_file_public(&state, move |config| {
         if let Some(dp) = body.default_profile {
             config.routing.default_profile = dp;
@@ -53,4 +66,173 @@ pub async fn update_routing(
             Json(json!({"error": "write_failed", "message": e})),
         ),
     }
+}
+
+/// POST /api/dashboard/routing/preview
+pub async fn preview_route(
+    State(state): State<AppState>,
+    Json(req): Json<PreviewRequest>,
+) -> impl IntoResponse {
+    let features = req.into_features();
+    let config = state.config.load();
+    let inventory = state.catalog.snapshot();
+    let health = state.health_manager.snapshot();
+
+    let plan = RoutePlanner::plan(&features, &config.routing, &inventory, &health);
+    let mut explanation = explain(&plan);
+    // Preview omits detailed scoring
+    explanation.scoring.clear();
+
+    (StatusCode::OK, Json(json!(explanation)))
+}
+
+/// POST /api/dashboard/routing/explain
+pub async fn explain_route(
+    State(state): State<AppState>,
+    Json(req): Json<PreviewRequest>,
+) -> impl IntoResponse {
+    let features = req.into_features();
+    let config = state.config.load();
+    let inventory = state.catalog.snapshot();
+    let health = state.health_manager.snapshot();
+
+    let plan = RoutePlanner::plan(&features, &config.routing, &inventory, &health);
+    let explanation = explain(&plan);
+
+    (StatusCode::OK, Json(json!(explanation)))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PreviewRequest {
+    pub model: String,
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+    #[serde(default = "default_source_format")]
+    pub source_format: String,
+    pub tenant_id: Option<String>,
+    pub api_key_id: Option<String>,
+    pub region: Option<String>,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub headers: std::collections::BTreeMap<String, String>,
+}
+
+fn default_endpoint() -> String {
+    "chat-completions".to_string()
+}
+
+fn default_source_format() -> String {
+    "openai".to_string()
+}
+
+impl PreviewRequest {
+    fn into_features(self) -> RouteRequestFeatures {
+        use prism_core::provider::Format;
+        use prism_core::routing::types::RouteEndpoint;
+
+        let endpoint = match self.endpoint.as_str() {
+            "messages" => RouteEndpoint::Messages,
+            "responses" => RouteEndpoint::Responses,
+            _ => RouteEndpoint::ChatCompletions,
+        };
+
+        let source_format = match self.source_format.as_str() {
+            "claude" => Format::Claude,
+            "gemini" => Format::Gemini,
+            "openai-compat" | "openai_compat" => Format::OpenAICompat,
+            _ => Format::OpenAI,
+        };
+
+        RouteRequestFeatures {
+            requested_model: self.model,
+            endpoint,
+            source_format,
+            tenant_id: self.tenant_id,
+            api_key_id: self.api_key_id,
+            region: self.region,
+            stream: self.stream,
+            headers: self.headers,
+        }
+    }
+}
+
+/// Validate a routing update request. Returns Ok(()) if valid, Err(details) if invalid.
+fn validate_routing_update(body: &UpdateRoutingRequest) -> Result<(), Vec<String>> {
+    let mut errors = Vec::new();
+
+    // Validate profiles
+    if let Some(ref profiles) = body.profiles {
+        if profiles.is_empty() {
+            errors.push("profiles map must not be empty".to_string());
+        }
+
+        for (name, profile) in profiles {
+            validate_profile(name, profile, &mut errors);
+        }
+    }
+
+    // Validate rules reference existing profiles
+    if let (Some(rules), Some(profiles)) = (&body.rules, &body.profiles) {
+        for rule in rules {
+            if !profiles.contains_key(&rule.use_profile) {
+                errors.push(format!(
+                    "rule '{}' references non-existent profile '{}'",
+                    rule.name, rule.use_profile
+                ));
+            }
+        }
+    }
+
+    // Validate default_profile exists in profiles
+    if let (Some(dp), Some(profiles)) = (&body.default_profile, &body.profiles)
+        && !profiles.contains_key(dp.as_str())
+    {
+        errors.push(format!(
+            "default-profile '{}' does not exist in profiles",
+            dp
+        ));
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+fn validate_profile(name: &str, profile: &RouteProfile, errors: &mut Vec<String>) {
+    validate_provider_policy(name, &profile.provider_policy, errors);
+    validate_credential_policy(name, &profile.credential_policy, errors);
+}
+
+fn validate_provider_policy(profile_name: &str, policy: &ProviderPolicy, errors: &mut Vec<String>) {
+    match policy.strategy {
+        ProviderStrategy::OrderedFallback => {
+            if policy.order.is_empty() {
+                errors.push(format!(
+                    "profile '{}': ordered-fallback strategy requires non-empty 'order' list",
+                    profile_name
+                ));
+            }
+        }
+        ProviderStrategy::WeightedRoundRobin => {
+            if policy.weights.is_empty() {
+                errors.push(format!(
+                    "profile '{}': weighted-round-robin strategy requires non-empty 'weights' map",
+                    profile_name
+                ));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn validate_credential_policy(
+    _profile_name: &str,
+    _policy: &CredentialPolicy,
+    _errors: &mut Vec<String>,
+) {
+    // No additional validation needed for credential policies currently
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -156,6 +156,14 @@ pub fn build_router(state: AppState) -> Router {
             axum::routing::get(handler::dashboard::routing::get_routing)
                 .patch(handler::dashboard::routing::update_routing),
         )
+        .route(
+            "/api/dashboard/routing/preview",
+            axum::routing::post(handler::dashboard::routing::preview_route),
+        )
+        .route(
+            "/api/dashboard/routing/explain",
+            axum::routing::post(handler::dashboard::routing::explain_route),
+        )
         // Config operations
         .route(
             "/api/dashboard/config/validate",

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -1111,3 +1111,228 @@ async fn test_multiple_provider_types() {
     assert!(ids.contains(&"claude-0"));
     assert!(ids.contains(&"gemini-0"));
 }
+
+// ===========================================================================
+// Routing preview/explain tests
+// ===========================================================================
+
+#[tokio::test]
+async fn test_preview_route_empty_inventory() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_post(
+        "/api/dashboard/routing/preview",
+        &token,
+        json!({"model": "gpt-4"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "preview failed: {body:?}");
+    assert_eq!(body["profile"], "balanced");
+    // No credentials configured, so no selected route
+    assert!(body["selected"].is_null());
+    assert!(body["alternates"].as_array().unwrap().is_empty());
+    // Preview should not include scoring details
+    assert!(body["scoring"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_explain_route_empty_inventory() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_post(
+        "/api/dashboard/routing/explain",
+        &token,
+        json!({"model": "gpt-4"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "explain failed: {body:?}");
+    assert_eq!(body["profile"], "balanced");
+    assert!(body["selected"].is_null());
+}
+
+#[tokio::test]
+async fn test_preview_route_with_providers() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create an OpenAI provider to populate catalog
+    let req = authed_post(
+        "/api/dashboard/providers",
+        &token,
+        json!({
+            "provider_type": "openai",
+            "api_key": "sk-test-preview-1234567890abcdef",
+            "name": "Preview Test OpenAI"
+        }),
+    );
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Reload config and update catalog
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.router.update_from_config(&new_config);
+    harness
+        .state
+        .catalog
+        .update_from_credentials(&harness.state.router.credential_map());
+    harness.state.config.store(Arc::new(new_config));
+
+    // Preview should now find the provider
+    let req = authed_post(
+        "/api/dashboard/routing/preview",
+        &token,
+        json!({"model": "gpt-4", "endpoint": "chat-completions"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "preview failed: {body:?}");
+    assert_eq!(body["profile"], "balanced");
+    // Model chain should contain the requested model
+    assert!(
+        body["model_chain"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|m| m == "gpt-4")
+    );
+}
+
+#[tokio::test]
+async fn test_preview_route_invalid_body() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Missing required 'model' field
+    let req = authed_post(
+        "/api/dashboard/routing/preview",
+        &token,
+        json!({"endpoint": "chat-completions"}),
+    );
+    let (status, _body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn test_explain_includes_scoring() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Create a provider
+    let req = authed_post(
+        "/api/dashboard/providers",
+        &token,
+        json!({
+            "provider_type": "openai",
+            "api_key": "sk-test-explain-1234567890abcdef",
+            "name": "Explain Test OpenAI"
+        }),
+    );
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Reload and update catalog
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.router.update_from_config(&new_config);
+    harness
+        .state
+        .catalog
+        .update_from_credentials(&harness.state.router.credential_map());
+    harness.state.config.store(Arc::new(new_config));
+
+    // Explain should include scoring (not cleared like preview)
+    let req = authed_post(
+        "/api/dashboard/routing/explain",
+        &token,
+        json!({"model": "gpt-4"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK, "explain failed: {body:?}");
+    // scoring field should be present (may be empty if no candidates scored, but present)
+    assert!(body["scoring"].is_array());
+}
+
+#[tokio::test]
+async fn test_update_routing_validation_empty_profiles() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_patch("/api/dashboard/routing", &token, json!({"profiles": {}}));
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["error"], "validation_failed");
+    let details = body["details"].as_array().unwrap();
+    assert!(details.iter().any(|d| {
+        d.as_str()
+            .unwrap()
+            .contains("profiles map must not be empty")
+    }));
+}
+
+#[tokio::test]
+async fn test_update_routing_validation_rule_references_nonexistent_profile() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let req = authed_patch(
+        "/api/dashboard/routing",
+        &token,
+        json!({
+            "profiles": {
+                "balanced": {
+                    "provider-policy": {"strategy": "weighted-round-robin", "weights": {"openai": 100}},
+                    "credential-policy": {"strategy": "priority-weighted-rr"},
+                    "health": {
+                        "circuit-breaker": {"enabled": true, "failure-threshold": 5, "cooldown-seconds": 30},
+                        "outlier-detection": {"consecutive-5xx": 5, "consecutive-local-failures": 3, "base-eject-seconds": 10, "max-eject-seconds": 300}
+                    },
+                    "failover": {"credential-attempts": 2, "provider-attempts": 2, "model-attempts": 2, "retry-budget": {"ratio": 0.2, "min-retries-per-second": 1}, "retry-on": ["429", "5xx"]}
+                }
+            },
+            "rules": [
+                {"name": "test-rule", "match": {"models": ["gpt-*"]}, "use-profile": "nonexistent"}
+            ]
+        }),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["error"], "validation_failed");
+    let details = body["details"].as_array().unwrap();
+    assert!(
+        details
+            .iter()
+            .any(|d| d.as_str().unwrap().contains("nonexistent"))
+    );
+}
+
+#[tokio::test]
+async fn test_update_routing_then_preview_reflects_change() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    // Switch to stable profile
+    let req = authed_patch(
+        "/api/dashboard/routing",
+        &token,
+        json!({"default-profile": "stable"}),
+    );
+    let (status, _) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Reload config
+    let config_path = harness.state.config_path.lock().unwrap().clone();
+    let new_config = Config::load(&config_path).expect("failed to reload config");
+    harness.state.config.store(Arc::new(new_config));
+
+    // Preview should reflect the new profile
+    let req = authed_post(
+        "/api/dashboard/routing/preview",
+        &token,
+        json!({"model": "gpt-4"}),
+    );
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["profile"], "stable");
+}

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1656,3 +1656,201 @@
     display: none;
   }
 }
+
+/* ── Routing Page ─────────────────────────────────────────────── */
+
+.strategy-option-algo {
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  margin-top: 0.25rem;
+}
+
+/* Data table */
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.data-table th {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Form inputs */
+
+.form-input,
+.form-select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.form-input:focus,
+.form-select:focus {
+  border-color: var(--color-primary);
+}
+
+.form-input--sm,
+.form-select--sm {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+}
+
+/* Icon buttons */
+
+.btn-icon {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  color: var(--color-text-secondary);
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.btn-icon:hover {
+  color: var(--color-primary);
+  background: var(--color-bg-hover);
+}
+
+.btn-icon--danger:hover {
+  color: var(--color-error);
+}
+
+/* Tabs */
+
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab:hover {
+  color: var(--color-text);
+}
+
+.tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+/* Route Preview */
+
+.preview-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.preview-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.preview-result {
+  min-height: 200px;
+}
+
+.preview-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.preview-section h4 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+}
+
+.preview-section p {
+  margin: 0.25rem 0;
+  font-size: 0.85rem;
+}
+
+.preview-route-card {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.preview-route-card--selected {
+  border-color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 5%, transparent);
+}
+
+.preview-provider {
+  font-weight: 600;
+}
+
+.preview-credential {
+  color: var(--color-text-secondary);
+}
+
+.preview-model {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.preview-score {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+}
+
+.preview-rejection {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.25rem 0;
+  font-size: 0.8rem;
+}
+
+.preview-reason {
+  color: var(--color-error);
+  font-size: 0.75rem;
+  text-transform: capitalize;
+}
+
+@media (max-width: 768px) {
+  .preview-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/components/routing/AdvancedEditor.tsx
+++ b/web/src/components/routing/AdvancedEditor.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import type { RouteProfile } from '../../types';
+
+interface AdvancedEditorProps {
+  profileName: string;
+  profile: RouteProfile;
+}
+
+type Tab = 'provider' | 'credential' | 'health' | 'failover';
+
+const TAB_LABELS: Record<Tab, string> = {
+  provider: 'Provider Policy',
+  credential: 'Credential Policy',
+  health: 'Health',
+  failover: 'Failover',
+};
+
+export default function AdvancedEditor({ profileName, profile }: AdvancedEditorProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('provider');
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3>Advanced Policy: {profileName}</h3>
+      </div>
+      <div className="card-body">
+        <div className="tabs">
+          {(Object.keys(TAB_LABELS) as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              className={`tab ${activeTab === tab ? 'tab--active' : ''}`}
+              onClick={() => setActiveTab(tab)}
+            >
+              {TAB_LABELS[tab]}
+            </button>
+          ))}
+        </div>
+
+        <div className="tab-content" style={{ marginTop: '1rem' }}>
+          {activeTab === 'provider' && (
+            <div className="settings-form">
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Strategy</label>
+                  <code>{profile['provider-policy'].strategy}</code>
+                </div>
+              </div>
+              {profile['provider-policy'].weights && Object.keys(profile['provider-policy'].weights).length > 0 && (
+                <div className="form-row">
+                  <div className="form-group">
+                    <label>Weights</label>
+                    <code>
+                      {Object.entries(profile['provider-policy'].weights)
+                        .map(([k, v]) => `${k}=${v}`)
+                        .join(', ')}
+                    </code>
+                  </div>
+                </div>
+              )}
+              {profile['provider-policy'].order && profile['provider-policy'].order.length > 0 && (
+                <div className="form-row">
+                  <div className="form-group">
+                    <label>Order</label>
+                    <code>{profile['provider-policy'].order.join(' → ')}</code>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'credential' && (
+            <div className="settings-form">
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Strategy</label>
+                  <code>{profile['credential-policy'].strategy}</code>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'health' && (
+            <div className="settings-form">
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Circuit Breaker</label>
+                  <code>{profile.health['circuit-breaker'].enabled ? 'Enabled' : 'Disabled'}</code>
+                </div>
+                <div className="form-group">
+                  <label>Failure Threshold</label>
+                  <code>{profile.health['circuit-breaker']['failure-threshold']}</code>
+                </div>
+                <div className="form-group">
+                  <label>Cooldown</label>
+                  <code>{profile.health['circuit-breaker']['cooldown-seconds']}s</code>
+                </div>
+              </div>
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Consecutive 5xx</label>
+                  <code>{profile.health['outlier-detection']['consecutive-5xx']}</code>
+                </div>
+                <div className="form-group">
+                  <label>Base Eject</label>
+                  <code>{profile.health['outlier-detection']['base-eject-seconds']}s</code>
+                </div>
+                <div className="form-group">
+                  <label>Max Eject</label>
+                  <code>{profile.health['outlier-detection']['max-eject-seconds']}s</code>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'failover' && (
+            <div className="settings-form">
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Credential Attempts</label>
+                  <code>{profile.failover['credential-attempts']}</code>
+                </div>
+                <div className="form-group">
+                  <label>Provider Attempts</label>
+                  <code>{profile.failover['provider-attempts']}</code>
+                </div>
+                <div className="form-group">
+                  <label>Model Attempts</label>
+                  <code>{profile.failover['model-attempts']}</code>
+                </div>
+              </div>
+              <div className="form-row">
+                <div className="form-group">
+                  <label>Retry Budget Ratio</label>
+                  <code>{profile.failover['retry-budget'].ratio}</code>
+                </div>
+                <div className="form-group">
+                  <label>Retry On</label>
+                  <code>{profile.failover['retry-on'].join(', ')}</code>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/routing/PresetCards.tsx
+++ b/web/src/components/routing/PresetCards.tsx
@@ -1,0 +1,76 @@
+import { GitBranch, Shield, Zap, DollarSign } from 'lucide-react';
+
+const PRESETS = [
+  {
+    key: 'balanced',
+    label: 'Balanced',
+    intent: 'Distribute requests evenly across providers and credentials',
+    algorithm: 'weighted-round-robin',
+    icon: GitBranch,
+  },
+  {
+    key: 'stable',
+    label: 'Stable',
+    intent: 'Always use the same provider, failover only when unhealthy',
+    algorithm: 'ordered-fallback',
+    icon: Shield,
+  },
+  {
+    key: 'lowest-latency',
+    label: 'Lowest Latency',
+    intent: 'Route to the fastest responding provider',
+    algorithm: 'ewma-latency',
+    icon: Zap,
+  },
+  {
+    key: 'lowest-cost',
+    label: 'Lowest Cost',
+    intent: 'Route to the cheapest available provider',
+    algorithm: 'lowest-estimated-cost',
+    icon: DollarSign,
+  },
+];
+
+interface PresetCardsProps {
+  selectedProfile: string;
+  onSelect: (profile: string) => void;
+}
+
+export default function PresetCards({ selectedProfile, onSelect }: PresetCardsProps) {
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3>Routing Mode</h3>
+      </div>
+      <div className="card-body">
+        <div className="strategy-grid">
+          {PRESETS.map((p) => {
+            const Icon = p.icon;
+            return (
+              <label
+                key={p.key}
+                className={`strategy-option ${selectedProfile === p.key ? 'strategy-option--selected' : ''}`}
+              >
+                <input
+                  type="radio"
+                  name="profile"
+                  value={p.key}
+                  checked={selectedProfile === p.key}
+                  onChange={() => onSelect(p.key)}
+                />
+                <div className="strategy-option-content">
+                  <div className="strategy-option-header">
+                    <Icon size={18} />
+                    <span className="strategy-option-label">{p.label}</span>
+                  </div>
+                  <p className="strategy-option-desc">{p.intent}</p>
+                  <p className="strategy-option-algo">{p.algorithm}</p>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/routing/RoutePreview.tsx
+++ b/web/src/components/routing/RoutePreview.tsx
@@ -1,0 +1,194 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Search, CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
+import { routingApi } from '../../services/api';
+import type { PreviewRequest, RouteExplanation } from '../../types';
+
+export default function RoutePreview() {
+  const [model, setModel] = useState('');
+  const [endpoint, setEndpoint] = useState('chat-completions');
+  const [tenant, setTenant] = useState('');
+  const [region, setRegion] = useState('');
+  const [stream, setStream] = useState(false);
+  const [result, setResult] = useState<RouteExplanation | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const doPreview = useCallback(async () => {
+    if (!model.trim()) {
+      setResult(null);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const req: PreviewRequest = {
+        model: model.trim(),
+        endpoint,
+        stream,
+      };
+      if (tenant.trim()) req.tenant_id = tenant.trim();
+      if (region.trim()) req.region = region.trim();
+
+      const res = await routingApi.preview(req);
+      setResult(res.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Preview failed');
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [model, endpoint, tenant, region, stream]);
+
+  // Auto-preview with debounce
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!model.trim()) return;
+    debounceRef.current = setTimeout(doPreview, 500);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [model, endpoint, tenant, region, stream, doPreview]);
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3>Route Preview</h3>
+      </div>
+      <div className="card-body">
+        <div className="preview-layout">
+          {/* Input form */}
+          <div className="preview-form">
+            <div className="form-group">
+              <label>Model</label>
+              <input
+                className="form-input"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="gpt-4, claude-sonnet-4-5, etc."
+              />
+            </div>
+            <div className="form-group">
+              <label>Endpoint</label>
+              <select
+                className="form-select"
+                value={endpoint}
+                onChange={(e) => setEndpoint(e.target.value)}
+              >
+                <option value="chat-completions">Chat Completions</option>
+                <option value="messages">Messages</option>
+                <option value="responses">Responses</option>
+              </select>
+            </div>
+            <div className="form-row">
+              <div className="form-group">
+                <label>Tenant</label>
+                <input
+                  className="form-input"
+                  value={tenant}
+                  onChange={(e) => setTenant(e.target.value)}
+                  placeholder="(optional)"
+                />
+              </div>
+              <div className="form-group">
+                <label>Region</label>
+                <input
+                  className="form-input"
+                  value={region}
+                  onChange={(e) => setRegion(e.target.value)}
+                  placeholder="(optional)"
+                />
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={stream}
+                  onChange={(e) => setStream(e.target.checked)}
+                />
+                Stream
+              </label>
+            </div>
+            <button className="btn btn-primary" onClick={doPreview} disabled={loading || !model.trim()}>
+              <Search size={14} />
+              {loading ? 'Loading...' : 'Preview'}
+            </button>
+          </div>
+
+          {/* Result panel */}
+          <div className="preview-result">
+            {error && (
+              <div className="alert alert-error">{error}</div>
+            )}
+            {!result && !error && (
+              <p style={{ color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>
+                Enter a model name to preview the routing decision.
+              </p>
+            )}
+            {result && (
+              <div className="preview-details">
+                <div className="preview-section">
+                  <h4>Profile: <code>{result.profile}</code></h4>
+                  {result.matched_rule && (
+                    <p>Matched rule: <code>{result.matched_rule}</code></p>
+                  )}
+                  {result.model_chain.length > 0 && (
+                    <p>Model chain: <code>{result.model_chain.join(' → ')}</code></p>
+                  )}
+                </div>
+
+                {result.selected && (
+                  <div className="preview-section">
+                    <h4><CheckCircle size={14} style={{ color: 'var(--color-success)' }} /> Selected</h4>
+                    <div className="preview-route-card preview-route-card--selected">
+                      <span className="preview-provider">{result.selected.provider}</span>
+                      <span className="preview-credential">{result.selected.credential_name}</span>
+                      <span className="preview-model">{result.selected.model}</span>
+                      <span className="preview-score">weight: {result.selected.score.weight}</span>
+                      {result.selected.score.latency_ms != null && (
+                        <span className="preview-score">latency: {result.selected.score.latency_ms.toFixed(1)}ms</span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {!result.selected && (
+                  <div className="preview-section">
+                    <h4><AlertTriangle size={14} style={{ color: 'var(--color-warning)' }} /> No route selected</h4>
+                    <p style={{ color: 'var(--color-text-secondary)' }}>No matching credentials found for this request.</p>
+                  </div>
+                )}
+
+                {result.alternates.length > 0 && (
+                  <div className="preview-section">
+                    <h4>Alternates ({result.alternates.length})</h4>
+                    {result.alternates.map((alt, i) => (
+                      <div key={i} className="preview-route-card">
+                        <span className="preview-provider">{alt.provider}</span>
+                        <span className="preview-credential">{alt.credential_name}</span>
+                        <span className="preview-model">{alt.model}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {result.rejections.length > 0 && (
+                  <div className="preview-section">
+                    <h4><XCircle size={14} style={{ color: 'var(--color-error)' }} /> Rejected ({result.rejections.length})</h4>
+                    {result.rejections.map((rej, i) => (
+                      <div key={i} className="preview-rejection">
+                        <code>{rej.candidate}</code>
+                        <span className="preview-reason">{rej.reason.replace(/_/g, ' ')}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/routing/RuleTable.tsx
+++ b/web/src/components/routing/RuleTable.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react';
+import { Plus, Trash2, Edit2, Check, X } from 'lucide-react';
+import type { RouteRule } from '../../types';
+
+interface RuleTableProps {
+  rules: RouteRule[];
+  profileNames: string[];
+  onChange: (rules: RouteRule[]) => void;
+}
+
+interface EditingRule {
+  name: string;
+  models: string;
+  tenants: string;
+  useProfile: string;
+}
+
+function ruleToEditing(rule: RouteRule): EditingRule {
+  return {
+    name: rule.name,
+    models: (rule.match.models ?? []).join(', '),
+    tenants: (rule.match.tenants ?? []).join(', '),
+    useProfile: rule['use-profile'],
+  };
+}
+
+function editingToRule(editing: EditingRule, priority: number): RouteRule {
+  return {
+    name: editing.name,
+    priority,
+    match: {
+      models: editing.models ? editing.models.split(',').map((s) => s.trim()).filter(Boolean) : undefined,
+      tenants: editing.tenants ? editing.tenants.split(',').map((s) => s.trim()).filter(Boolean) : undefined,
+    },
+    'use-profile': editing.useProfile,
+  };
+}
+
+export default function RuleTable({ rules, profileNames, onChange }: RuleTableProps) {
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [editingRule, setEditingRule] = useState<EditingRule | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [newRule, setNewRule] = useState<EditingRule>({
+    name: '',
+    models: '',
+    tenants: '',
+    useProfile: profileNames[0] ?? 'balanced',
+  });
+
+  const startEdit = (idx: number) => {
+    setEditingIdx(idx);
+    setEditingRule(ruleToEditing(rules[idx]));
+  };
+
+  const cancelEdit = () => {
+    setEditingIdx(null);
+    setEditingRule(null);
+  };
+
+  const saveEdit = () => {
+    if (editingIdx === null || !editingRule) return;
+    const updated = [...rules];
+    updated[editingIdx] = editingToRule(editingRule, editingIdx);
+    onChange(updated);
+    cancelEdit();
+  };
+
+  const deleteRule = (idx: number) => {
+    onChange(rules.filter((_, i) => i !== idx));
+  };
+
+  const addRule = () => {
+    if (!newRule.name.trim()) return;
+    onChange([...rules, editingToRule(newRule, rules.length)]);
+    setNewRule({ name: '', models: '', tenants: '', useProfile: profileNames[0] ?? 'balanced' });
+    setAdding(false);
+  };
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h3>Rules</h3>
+        <button className="btn btn-sm btn-secondary" onClick={() => setAdding(!adding)}>
+          <Plus size={14} /> Add Rule
+        </button>
+      </div>
+      <div className="card-body">
+        {rules.length === 0 && !adding && (
+          <p style={{ color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>
+            No rules configured. All requests use the default profile.
+          </p>
+        )}
+        {(rules.length > 0 || adding) && (
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Model Match</th>
+                <th>Tenant Match</th>
+                <th>Profile</th>
+                <th style={{ width: '80px' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rules.map((rule, idx) => (
+                <tr key={idx}>
+                  {editingIdx === idx && editingRule ? (
+                    <>
+                      <td>
+                        <input
+                          className="form-input form-input--sm"
+                          value={editingRule.name}
+                          onChange={(e) => setEditingRule({ ...editingRule, name: e.target.value })}
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="form-input form-input--sm"
+                          value={editingRule.models}
+                          onChange={(e) => setEditingRule({ ...editingRule, models: e.target.value })}
+                          placeholder="gpt-*, claude-*"
+                        />
+                      </td>
+                      <td>
+                        <input
+                          className="form-input form-input--sm"
+                          value={editingRule.tenants}
+                          onChange={(e) => setEditingRule({ ...editingRule, tenants: e.target.value })}
+                          placeholder="tenant-a, tenant-b"
+                        />
+                      </td>
+                      <td>
+                        <select
+                          className="form-select form-select--sm"
+                          value={editingRule.useProfile}
+                          onChange={(e) => setEditingRule({ ...editingRule, useProfile: e.target.value })}
+                        >
+                          {profileNames.map((p) => (
+                            <option key={p} value={p}>{p}</option>
+                          ))}
+                        </select>
+                      </td>
+                      <td>
+                        <button className="btn-icon" onClick={saveEdit} title="Save"><Check size={14} /></button>
+                        <button className="btn-icon" onClick={cancelEdit} title="Cancel"><X size={14} /></button>
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td><code>{rule.name}</code></td>
+                      <td><code>{(rule.match.models ?? []).join(', ') || '—'}</code></td>
+                      <td><code>{(rule.match.tenants ?? []).join(', ') || '—'}</code></td>
+                      <td><code>{rule['use-profile']}</code></td>
+                      <td>
+                        <button className="btn-icon" onClick={() => startEdit(idx)} title="Edit"><Edit2 size={14} /></button>
+                        <button className="btn-icon btn-icon--danger" onClick={() => deleteRule(idx)} title="Delete"><Trash2 size={14} /></button>
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+              {adding && (
+                <tr>
+                  <td>
+                    <input
+                      className="form-input form-input--sm"
+                      value={newRule.name}
+                      onChange={(e) => setNewRule({ ...newRule, name: e.target.value })}
+                      placeholder="rule-name"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="form-input form-input--sm"
+                      value={newRule.models}
+                      onChange={(e) => setNewRule({ ...newRule, models: e.target.value })}
+                      placeholder="gpt-*, claude-*"
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="form-input form-input--sm"
+                      value={newRule.tenants}
+                      onChange={(e) => setNewRule({ ...newRule, tenants: e.target.value })}
+                      placeholder="tenant-a, tenant-b"
+                    />
+                  </td>
+                  <td>
+                    <select
+                      className="form-select form-select--sm"
+                      value={newRule.useProfile}
+                      onChange={(e) => setNewRule({ ...newRule, useProfile: e.target.value })}
+                    >
+                      {profileNames.map((p) => (
+                        <option key={p} value={p}>{p}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <button className="btn-icon" onClick={addRule} title="Add"><Check size={14} /></button>
+                    <button className="btn-icon" onClick={() => setAdding(false)} title="Cancel"><X size={14} /></button>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Routing.tsx
+++ b/web/src/pages/Routing.tsx
@@ -1,30 +1,11 @@
 import { useEffect, useState } from 'react';
 import { routingApi } from '../services/api';
-import type { RoutingConfig } from '../types';
-import { GitBranch, Save, RotateCcw } from 'lucide-react';
-
-const PRESETS = [
-  {
-    key: 'balanced',
-    label: 'Balanced',
-    description: 'Distribute requests evenly across providers and credentials.',
-  },
-  {
-    key: 'stable',
-    label: 'Stable',
-    description: 'Always use the same provider, failover only when unhealthy.',
-  },
-  {
-    key: 'lowest-latency',
-    label: 'Lowest Latency',
-    description: 'Route to the fastest responding provider.',
-  },
-  {
-    key: 'lowest-cost',
-    label: 'Lowest Cost',
-    description: 'Route to the cheapest available provider.',
-  },
-];
+import type { RoutingConfig, RouteRule } from '../types';
+import { Save, RotateCcw } from 'lucide-react';
+import PresetCards from '../components/routing/PresetCards';
+import RuleTable from '../components/routing/RuleTable';
+import AdvancedEditor from '../components/routing/AdvancedEditor';
+import RoutePreview from '../components/routing/RoutePreview';
 
 export default function Routing() {
   const [config, setConfig] = useState<RoutingConfig | null>(null);
@@ -34,10 +15,14 @@ export default function Routing() {
   const [error, setError] = useState('');
 
   const [selectedProfile, setSelectedProfile] = useState('balanced');
+  const [rules, setRules] = useState<RouteRule[]>([]);
+  const [dirty, setDirty] = useState(false);
 
   const loadConfig = (data: RoutingConfig) => {
     setConfig(data);
     setSelectedProfile(data['default-profile']);
+    setRules(data.rules ?? []);
+    setDirty(false);
   };
 
   const fetchConfig = async () => {
@@ -55,20 +40,43 @@ export default function Routing() {
     fetchConfig();
   }, []);
 
+  const handleProfileSelect = (profile: string) => {
+    setSelectedProfile(profile);
+    setDirty(true);
+  };
+
+  const handleRulesChange = (newRules: RouteRule[]) => {
+    setRules(newRules);
+    setDirty(true);
+  };
+
   const handleSave = async () => {
     setSaving(true);
     setError('');
     setSaved(false);
 
     try {
-      await routingApi.update({ 'default-profile': selectedProfile });
+      await routingApi.update({
+        'default-profile': selectedProfile,
+        rules,
+      });
       if (config) {
-        loadConfig({ ...config, 'default-profile': selectedProfile });
+        loadConfig({ ...config, 'default-profile': selectedProfile, rules });
       }
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update routing config');
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { details?: string[] } } };
+        const details = axiosErr.response?.data?.details;
+        if (details && details.length > 0) {
+          setError(details.join('; '));
+        } else {
+          setError('Failed to update routing config');
+        }
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to update routing config');
+      }
     } finally {
       setSaving(false);
     }
@@ -91,22 +99,25 @@ export default function Routing() {
     );
   }
 
+  const profileNames = config ? Object.keys(config.profiles) : [];
+  const activeProfile = config?.profiles[selectedProfile];
+
   return (
     <div className="page">
       <div className="page-header">
         <div>
           <h2>Routing</h2>
-          <p className="page-subtitle">Configure request routing profile</p>
+          <p className="page-subtitle">Configure request routing profile, rules, and preview decisions</p>
         </div>
         <div className="page-header-actions">
-          <button className="btn btn-secondary" onClick={handleReset}>
+          <button className="btn btn-secondary" onClick={handleReset} disabled={!dirty}>
             <RotateCcw size={16} />
             Reset
           </button>
           <button
             className="btn btn-primary"
             onClick={handleSave}
-            disabled={saving}
+            disabled={saving || !dirty}
           >
             <Save size={16} />
             {saving ? 'Saving...' : saved ? 'Saved!' : 'Save Changes'}
@@ -117,74 +128,19 @@ export default function Routing() {
       {error && <div className="alert alert-error" style={{ marginBottom: '1.5rem' }}>{error}</div>}
       {saved && <div className="alert alert-success" style={{ marginBottom: '1.5rem' }}>Routing configuration updated successfully.</div>}
 
-      {/* Profile Selection */}
-      <div className="card">
-        <div className="card-header">
-          <h3>Routing Profile</h3>
-        </div>
-        <div className="card-body">
-          <div className="strategy-grid">
-            {PRESETS.map((p) => (
-              <label
-                key={p.key}
-                className={`strategy-option ${selectedProfile === p.key ? 'strategy-option--selected' : ''}`}
-              >
-                <input
-                  type="radio"
-                  name="profile"
-                  value={p.key}
-                  checked={selectedProfile === p.key}
-                  onChange={() => setSelectedProfile(p.key)}
-                />
-                <div className="strategy-option-content">
-                  <div className="strategy-option-header">
-                    <GitBranch size={18} />
-                    <span className="strategy-option-label">{p.label}</span>
-                  </div>
-                  <p className="strategy-option-desc">{p.description}</p>
-                </div>
-              </label>
-            ))}
-          </div>
-        </div>
-      </div>
+      {/* Section 1: Preset Cards */}
+      <PresetCards selectedProfile={selectedProfile} onSelect={handleProfileSelect} />
 
-      {/* Current Profile Details */}
-      {config && config.profiles[selectedProfile] && (
-        <div className="card">
-          <div className="card-header">
-            <h3>Profile Details: {selectedProfile}</h3>
-          </div>
-          <div className="card-body">
-            <div className="settings-form">
-              <div className="form-row">
-                <div className="form-group">
-                  <label>Provider Strategy</label>
-                  <code>{config.profiles[selectedProfile]['provider-policy'].strategy}</code>
-                </div>
-                <div className="form-group">
-                  <label>Credential Strategy</label>
-                  <code>{config.profiles[selectedProfile]['credential-policy'].strategy}</code>
-                </div>
-              </div>
-              <div className="form-row">
-                <div className="form-group">
-                  <label>Credential Attempts</label>
-                  <code>{config.profiles[selectedProfile].failover['credential-attempts']}</code>
-                </div>
-                <div className="form-group">
-                  <label>Provider Attempts</label>
-                  <code>{config.profiles[selectedProfile].failover['provider-attempts']}</code>
-                </div>
-                <div className="form-group">
-                  <label>Model Attempts</label>
-                  <code>{config.profiles[selectedProfile].failover['model-attempts']}</code>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+      {/* Section 2: Rules */}
+      <RuleTable rules={rules} profileNames={profileNames} onChange={handleRulesChange} />
+
+      {/* Section 3: Advanced Policy */}
+      {activeProfile && (
+        <AdvancedEditor profileName={selectedProfile} profile={activeProfile} />
       )}
+
+      {/* Section 4: Route Preview */}
+      <RoutePreview />
     </div>
   );
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -10,6 +10,8 @@ import type {
   AuthKeyUpdateRequest,
   RoutingConfig,
   RoutingUpdateRequest,
+  PreviewRequest,
+  RouteExplanation,
   RequestLog,
   PaginatedResponse,
   RequestLogFilter,
@@ -177,6 +179,18 @@ export const routingApi = {
 
   update: (data: RoutingUpdateRequest) =>
     api.patch('/routing', data),
+
+  preview: (data: PreviewRequest) =>
+    api.post('/routing/preview', data).then((res) => ({
+      ...res,
+      data: res.data as RouteExplanation,
+    })) as Promise<{ data: RouteExplanation } & Record<string, unknown>>,
+
+  explain: (data: PreviewRequest) =>
+    api.post('/routing/explain', data).then((res) => ({
+      ...res,
+      data: res.data as RouteExplanation,
+    })) as Promise<{ data: RouteExplanation } & Record<string, unknown>>,
 };
 
 // ── Logs ──

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -207,6 +207,67 @@ export interface RoutingUpdateRequest {
   'model-resolution'?: ModelResolution;
 }
 
+// ── Route Preview/Explain ──
+
+export interface PreviewRequest {
+  model: string;
+  endpoint?: string;
+  source_format?: string;
+  tenant_id?: string;
+  api_key_id?: string;
+  region?: string;
+  stream?: boolean;
+  headers?: Record<string, string>;
+}
+
+export interface RouteScore {
+  weight: number;
+  latency_ms?: number;
+  inflight?: number;
+  estimated_cost?: number;
+  health_penalty: number;
+}
+
+export interface SelectedRoute {
+  provider: string;
+  credential_name: string;
+  model: string;
+  score: RouteScore;
+}
+
+export interface RouteRejection {
+  candidate: string;
+  reason: string;
+}
+
+export interface ModelResolutionStep {
+  step: string;
+  from?: string;
+  to?: string;
+  rule?: string;
+  primary?: string;
+  fallbacks?: string[];
+  model?: string;
+  providers?: string[];
+}
+
+export interface RouteScoringEntry {
+  candidate: string;
+  score: RouteScore;
+  rank: number;
+}
+
+export interface RouteExplanation {
+  profile: string;
+  matched_rule: string | null;
+  model_chain: string[];
+  selected: SelectedRoute | null;
+  alternates: SelectedRoute[];
+  rejections: RouteRejection[];
+  model_resolution: ModelResolutionStep[];
+  scoring: RouteScoringEntry[];
+}
+
 // ── Metrics (real-time WebSocket snapshot) ──
 
 export interface MetricsSnapshot {


### PR DESCRIPTION
## Summary

Implements **SPEC-052: Preview API & Dashboard UX** (closes #177).

- **Preview/Explain API**: `POST /api/dashboard/routing/preview` and `/explain` endpoints using the same `RoutePlanner` as production dispatch — no preview/production divergence
- **Routing validation**: PATCH `/api/dashboard/routing` now validates empty profiles, nonexistent profile references, and strategy-specific requirements (ordered-fallback needs `order`, weighted-rr needs `weights`)
- **Dashboard routing page**: Rebuilt with 4 sections — PresetCards (routing mode selection), RuleTable (inline CRUD), AdvancedEditor (4-tab policy viewer), RoutePreview (live debounced preview)
- **Frontend types**: Added `PreviewRequest`, `RouteExplanation`, `SelectedRoute`, `RouteRejection`, `RouteScoringEntry` types and API client methods

## Test plan

- [x] 8 new integration tests (preview empty/with providers/invalid body, explain empty/scoring, validation empty profiles/nonexistent profile, config-then-preview)
- [x] All 453 tests pass (`cargo test --workspace`)
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --check` passes
- [x] TypeScript `npx tsc --noEmit` passes
- [ ] CI pipeline passes
- [ ] Manual verification of dashboard routing page

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)