### PR TITLE
test: add Playwright E2E browser tests for dashboard

### DIFF
--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+
+// Vite dev server serves the SPA and proxies /api/dashboard to Prism backend
+const FRONTEND = process.env.PRISM_FRONTEND_URL || 'http://localhost:3000';
+// Prism backend for direct API calls
+const BACKEND = process.env.PRISM_BASE_URL || 'http://localhost:8317';
+const USERNAME = 'admin';
+const PASSWORD = 'test123';
+
+async function login(page: import('@playwright/test').Page) {
+  await page.goto(FRONTEND);
+  await page.waitForSelector('#username', { timeout: 10000 });
+  await page.fill('#username', USERNAME);
+  await page.fill('#password', PASSWORD);
+  await page.click('button[type="submit"]');
+  // Wait for navigation away from login
+  await page.waitForFunction(() => !document.querySelector('#username'), { timeout: 15000 });
+}
+
+test.describe('Dashboard Login', () => {
+  test('shows login page', async ({ page }) => {
+    await page.goto(FRONTEND);
+    await expect(page.locator('h1')).toContainText('Prism', { timeout: 10000 });
+    await expect(page.locator('#username')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+  });
+
+  test('rejects wrong credentials', async ({ page }) => {
+    await page.goto(FRONTEND);
+    await page.waitForSelector('#username', { timeout: 10000 });
+    await page.fill('#username', 'admin');
+    await page.fill('#password', 'wrongpassword');
+    await page.click('button[type="submit"]');
+    await expect(page.locator('.login-error')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('successful login navigates to dashboard', async ({ page }) => {
+    await login(page);
+    await expect(page.locator('body')).toContainText(/Total Requests|Overview|Dashboard/i, { timeout: 15000 });
+  });
+});
+
+test.describe('Dashboard Pages', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('overview page shows metric cards', async ({ page }) => {
+    await expect(page.locator('.metric-card').first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('providers page lists providers', async ({ page }) => {
+    await page.getByRole('link', { name: /providers/i }).click();
+    await expect(page.locator('body')).toContainText(/bailian/i, { timeout: 15000 });
+  });
+
+  test('request logs page shows entries', async ({ page }) => {
+    await page.getByRole('link', { name: /request/i }).click();
+    await expect(page.locator('body')).toContainText(/qwen|Request Logs/i, { timeout: 15000 });
+  });
+
+  test('routing page loads', async ({ page }) => {
+    await page.getByRole('link', { name: /routing/i }).click();
+    await expect(page.locator('body')).toContainText(/routing|profile/i, { timeout: 15000 });
+  });
+
+  test('system page shows health info', async ({ page }) => {
+    await page.getByRole('link', { name: /system/i }).click();
+    await expect(page.locator('body')).toContainText(/uptime|version|system/i, { timeout: 15000 });
+  });
+});
+
+test.describe('API E2E', () => {
+  test('non-streaming chat completion', async ({ request }) => {
+    const resp = await request.post(`${BACKEND}/v1/chat/completions`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        model: 'qwen3-coder-plus',
+        messages: [{ role: 'user', content: 'Say pong' }],
+        max_tokens: 10,
+      },
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.choices).toBeDefined();
+    expect(body.choices[0].message.content).toBeTruthy();
+  });
+
+  test('streaming chat completion', async ({ request }) => {
+    const resp = await request.post(`${BACKEND}/v1/chat/completions`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        model: 'qwen3-coder-plus',
+        messages: [{ role: 'user', content: 'Say pong' }],
+        max_tokens: 10,
+        stream: true,
+      },
+    });
+    expect(resp.status()).toBe(200);
+    const text = await resp.text();
+    expect(text).toContain('data:');
+    expect(text).toContain('[DONE]');
+  });
+
+  test('models endpoint', async ({ request }) => {
+    const resp = await request.get(`${BACKEND}/v1/models`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.data.some((m: any) => m.id === 'qwen3-coder-plus')).toBe(true);
+  });
+
+  test('health endpoint', async ({ request }) => {
+    const resp = await request.get(`${BACKEND}/health`);
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.status).toBe('ok');
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^5.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1178,6 +1179,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3286,6 +3303,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "lint": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.7.0",
@@ -21,6 +22,7 @@
     "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  retries: 0,
+  use: {
+    baseURL: process.env.PRISM_BASE_URL || 'http://127.0.0.1:8317',
+    headless: true,
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],
+    exclude: ['e2e/**', 'node_modules/**'],
   },
 });


### PR DESCRIPTION
## Summary

- Add Playwright E2E tests covering dashboard login, page navigation, and API endpoints
- 12 test cases: login flow (3), dashboard pages (5), API E2E (4)
- Add `@playwright/test` dependency and `test:e2e` npm script
- Exclude `e2e/` from vitest to prevent test runner conflicts

Closes #198

## Test plan

- [x] All 12 Playwright tests pass locally against real Prism backend + Vite dev server
- [ ] CI passes (lint, unit tests)
- [ ] E2E tests require running Prism backend and Vite dev server (manual or CI with services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)