### PR TITLE
fix: stop deduplicating providers by api_key

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -283,14 +283,11 @@ fn resolve_provider_secrets(entries: &mut [ProviderKeyEntry]) -> Result<(), anyh
     Ok(())
 }
 
-/// Remove entries with empty api_key (unless they have a credential_source), deduplicate, normalize base_url.
+/// Remove entries with empty api_key (unless they have a credential_source),
+/// then normalize base_url and header casing.
 fn sanitize_entries(entries: &mut Vec<ProviderKeyEntry>) {
     // Remove entries with empty API keys that don't have a credential_source
     entries.retain(|e| !e.api_key.is_empty() || e.credential_source.is_some());
-
-    // Deduplicate by api_key
-    let mut seen = std::collections::HashSet::new();
-    entries.retain(|e| seen.insert(e.api_key.clone()));
 
     // Normalize entries
     for entry in entries.iter_mut() {
@@ -688,15 +685,18 @@ mod tests {
         e1.base_url = Some("https://api.example.com/".into());
         e1.headers = HashMap::from([("X-Custom".into(), "val".into())]);
         let e2 = make_test_entry("p2", "");
-        let e3 = make_test_entry("p3", "key1"); // duplicate key
+        let mut e3 = make_test_entry("p3", "key1");
+        e3.format = crate::provider::Format::Claude;
         let mut entries = vec![e1, e2, e3];
         sanitize_entries(&mut entries);
-        assert_eq!(entries.len(), 1);
+        assert_eq!(entries.len(), 2);
         assert_eq!(
             entries[0].base_url.as_deref(),
             Some("https://api.example.com")
         );
         assert!(entries[0].headers.contains_key("x-custom"));
+        assert_eq!(entries[1].name, "p3");
+        assert_eq!(entries[1].format, crate::provider::Format::Claude);
     }
 
     #[test]

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -1118,6 +1118,52 @@ async fn test_multiple_provider_types() {
     assert!(names.contains(&"Gemini Prod"));
 }
 
+#[tokio::test]
+async fn test_providers_with_same_api_key_across_formats() {
+    let harness = create_test_harness();
+    let token = login_and_get_token(&harness).await;
+
+    let shared_key = "sk-sp-shared-test-1234567890abcdef";
+    let providers = vec![
+        json!({
+            "format": "openai",
+            "api_key": shared_key,
+            "name": "Bailian OpenAI",
+            "base_url": "https://coding.dashscope.aliyuncs.com"
+        }),
+        json!({
+            "format": "claude",
+            "api_key": shared_key,
+            "name": "Bailian Claude",
+            "base_url": "https://coding.dashscope.aliyuncs.com/apps/anthropic"
+        }),
+    ];
+
+    for p in &providers {
+        let req = authed_post("/api/dashboard/providers", &token, p.clone());
+        let (status, body) = send_request(&harness, req).await;
+        assert_eq!(status, StatusCode::CREATED, "create failed: {body:?}");
+
+        let config_path = harness.state.config_path.lock().unwrap().clone();
+        let new_config = Config::load(&config_path).expect("failed to reload config");
+        harness.state.config.store(Arc::new(new_config));
+    }
+
+    let req = authed_get("/api/dashboard/providers", &token);
+    let (status, body) = send_request(&harness, req).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let all_providers = body["providers"].as_array().unwrap();
+    assert_eq!(all_providers.len(), 2, "providers: {all_providers:?}");
+
+    let names: Vec<&str> = all_providers
+        .iter()
+        .map(|p| p["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"Bailian OpenAI"));
+    assert!(names.contains(&"Bailian Claude"));
+}
+
 // ===========================================================================
 // Routing preview/explain tests
 // ===========================================================================

--- a/docs/reference/types/config.md
+++ b/docs/reference/types/config.md
@@ -130,8 +130,7 @@ pub struct Config {
 
 ### Sanitization (on load)
 
-- Entries with empty `api_key` are removed.
-- Duplicate entries (by `api_key`) are deduplicated.
+- Entries with empty `api_key` (and no `credential_source`) are removed.
 - Trailing slashes are stripped from `base_url`.
 - Header keys are normalized to lowercase.
 - `auth_key_store` is built from `auth_keys` for O(1) lookups.

--- a/web/src/__tests__/pages/Providers.test.tsx
+++ b/web/src/__tests__/pages/Providers.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockProvidersApi = vi.hoisted(() => ({
+  list: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  fetchModels: vi.fn(),
+  healthCheck: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+  providersApi: mockProvidersApi,
+}));
+
+const { default: Providers } = await import('../../pages/Providers');
+
+describe('Providers page', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows success feedback after creating a Claude provider', async () => {
+    const user = userEvent.setup();
+    mockProvidersApi.list
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            name: 'claude-prod',
+            format: 'claude',
+            api_key_masked: 'sk-a****test',
+            base_url: 'https://api.anthropic.com',
+            models_count: 0,
+            disabled: false,
+          },
+        ],
+      });
+    mockProvidersApi.create.mockResolvedValueOnce({
+      data: { message: 'Provider created successfully' },
+    });
+
+    render(<Providers />);
+
+    await screen.findByText('No providers configured');
+    await user.click(screen.getByRole('button', { name: /add first provider/i }));
+    await user.type(
+      screen.getByPlaceholderText('e.g., deepseek, openai-prod'),
+      'claude-prod'
+    );
+    const [formatSelect] = screen.getAllByRole('combobox');
+    await user.selectOptions(formatSelect, 'claude');
+    await user.type(screen.getByPlaceholderText('sk-...'), 'sk-ant-test-123');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => {
+      expect(mockProvidersApi.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'claude-prod',
+          format: 'claude',
+        })
+      );
+    });
+    expect(
+      await screen.findByText('Provider "claude-prod" created successfully.')
+    ).toBeInTheDocument();
+    expect(await screen.findByText('claude-prod')).toBeInTheDocument();
+  });
+
+  it('shows a warning when creation succeeds but the list refresh fails', async () => {
+    const user = userEvent.setup();
+    mockProvidersApi.list
+      .mockResolvedValueOnce({ data: [] })
+      .mockRejectedValueOnce({
+        response: { data: { message: 'refresh failed' } },
+        message: 'Request failed',
+      });
+    mockProvidersApi.create.mockResolvedValueOnce({
+      data: { message: 'Provider created successfully' },
+    });
+
+    render(<Providers />);
+
+    await screen.findByText('No providers configured');
+    await user.click(screen.getByRole('button', { name: /add first provider/i }));
+    await user.type(
+      screen.getByPlaceholderText('e.g., deepseek, openai-prod'),
+      'claude-prod'
+    );
+    const [formatSelect] = screen.getAllByRole('combobox');
+    await user.selectOptions(formatSelect, 'claude');
+    await user.type(screen.getByPlaceholderText('sk-...'), 'sk-ant-test-123');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(
+      await screen.findByText(
+        'Provider "claude-prod" created successfully, but refreshing the list failed: refresh failed'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -38,6 +38,11 @@ interface FormState {
   region: string;
 }
 
+interface NoticeState {
+  type: 'success' | 'error' | 'warning';
+  message: string;
+}
+
 const emptyForm: FormState = {
   name: '',
   format: 'openai',
@@ -61,24 +66,51 @@ export default function Providers() {
   const [editName, setEditName] = useState<string | null>(null);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [error, setError] = useState('');
+  const [notice, setNotice] = useState<NoticeState | null>(null);
   const [saving, setSaving] = useState(false);
   const [fetchingModels, setFetchingModels] = useState(false);
   const [healthChecking, setHealthChecking] = useState<string | null>(null);
   const [healthResults, setHealthResults] = useState<Record<string, { status: string; latency_ms?: number; message?: string }>>({});
 
-  const fetchProviders = async () => {
+  const extractErrorMessage = (err: unknown, fallback: string) => {
+    if (typeof err === 'object' && err !== null) {
+      const maybeError = err as {
+        message?: unknown;
+        response?: { data?: { message?: unknown } };
+      };
+      const apiMessage = maybeError.response?.data?.message;
+      if (typeof apiMessage === 'string' && apiMessage.trim()) {
+        return apiMessage;
+      }
+      if (typeof maybeError.message === 'string' && maybeError.message.trim()) {
+        return maybeError.message;
+      }
+    }
+    return fallback;
+  };
+
+  const fetchProviders = async (options?: { surfaceError?: boolean }) => {
+    const surfaceError = options?.surfaceError ?? true;
     try {
       const response = await providersApi.list();
       setProviders(response.data);
+      return response.data;
     } catch (err) {
       console.error('Failed to fetch providers:', err);
+      if (surfaceError) {
+        setNotice({
+          type: 'error',
+          message: extractErrorMessage(err, 'Failed to fetch providers'),
+        });
+      }
+      throw err;
     } finally {
       setIsLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchProviders();
+    void fetchProviders();
   }, []);
 
   const openCreate = () => {
@@ -116,7 +148,8 @@ export default function Providers() {
   };
 
   const handleSubmit = async () => {
-    if (!form.name.trim()) {
+    const providerName = form.name.trim();
+    if (!providerName) {
       setError('Name is required');
       return;
     }
@@ -160,7 +193,7 @@ export default function Providers() {
         });
       } else {
         const data: ProviderCreateRequest = {
-          name: form.name,
+          name: providerName,
           format: form.format,
           base_url: form.base_url || undefined,
           proxy_url: form.proxy_url || undefined,
@@ -177,10 +210,32 @@ export default function Providers() {
         await providersApi.create(data);
       }
 
+      const persistedProviderName = editName ?? providerName;
       setShowModal(false);
-      fetchProviders();
+      setForm(emptyForm);
+
+      try {
+        const refreshedProviders = await fetchProviders({ surfaceError: false });
+        const providerExists = refreshedProviders.some((provider) => provider.name === persistedProviderName);
+        setNotice(
+          providerExists
+            ? {
+                type: 'success',
+                message: `Provider "${persistedProviderName}" ${editName ? 'updated' : 'created'} successfully.`,
+              }
+            : {
+                type: 'warning',
+                message: `Provider "${persistedProviderName}" ${editName ? 'updated' : 'created'} successfully, but the refreshed list did not include it.`,
+              }
+        );
+      } catch (refreshErr) {
+        setNotice({
+          type: 'warning',
+          message: `Provider "${persistedProviderName}" ${editName ? 'updated' : 'created'} successfully, but refreshing the list failed: ${extractErrorMessage(refreshErr, 'Failed to fetch providers')}`,
+        });
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save provider');
+      setError(extractErrorMessage(err, 'Failed to save provider'));
     } finally {
       setSaving(false);
     }
@@ -193,9 +248,21 @@ export default function Providers() {
 
     try {
       await providersApi.delete(name);
-      fetchProviders();
+      try {
+        await fetchProviders({ surfaceError: false });
+        setNotice({ type: 'success', message: `Provider "${name}" deleted successfully.` });
+      } catch (refreshErr) {
+        setNotice({
+          type: 'warning',
+          message: `Provider "${name}" deleted successfully, but refreshing the list failed: ${extractErrorMessage(refreshErr, 'Failed to fetch providers')}`,
+        });
+      }
     } catch (err) {
       console.error('Failed to delete provider:', err);
+      setNotice({
+        type: 'error',
+        message: extractErrorMessage(err, `Failed to delete provider "${name}"`),
+      });
     }
   };
 
@@ -252,6 +319,12 @@ export default function Providers() {
           Add Provider
         </button>
       </div>
+
+      {notice && (
+        <div className={`alert alert-${notice.type}`} style={{ marginBottom: '1.5rem' }}>
+          {notice.message}
+        </div>
+      )}
 
       <div className="card">
         <div className="table-wrapper">


### PR DESCRIPTION
## Summary
- Remove `api_key`-based deduplication from `sanitize_entries()` — multiple providers may legitimately share the same API key (e.g. Bailian OpenAI + Bailian Claude)
- Improve dashboard provider create/update/delete feedback with success/warning/error notices
- Update reference docs to reflect the sanitization change

Closes #201

## Changes

### `crates/core/`
- `config.rs`: Remove `api_key` dedup logic from `sanitize_entries()`; update unit test to verify two providers with the same key both survive sanitization

### `crates/server/`
- `tests/dashboard_tests.rs`: Add regression test for shared-key provider creation

### `web/`
- `src/pages/Providers.tsx`: Add `NoticeState` feedback (success/warning/error banners), verify persisted provider appears in refreshed list, extract error messages from API responses
- `src/__tests__/pages/Providers.test.tsx`: New frontend test file

### `docs/`
- `docs/reference/types/config.md`: Remove outdated dedup mention from sanitization docs

## Spec & Reference Doc Impact
- No spec required (bug fix)
- `docs/reference/types/config.md` updated in this PR

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (553 tests)
- [x] Core: `sanitize_entries` keeps two providers with same `api_key` but different names/formats
- [x] Dashboard: creating a second provider with a shared API key persists both providers