### PR TITLE
feat: add auth key reveal endpoint for dashboard copy

### DIFF
--- a/crates/server/src/handler/dashboard/auth_keys.rs
+++ b/crates/server/src/handler/dashboard/auth_keys.rs
@@ -177,6 +177,23 @@ pub async fn update_auth_key(
     }
 }
 
+/// POST /api/dashboard/auth-keys/:id/reveal
+pub async fn reveal_auth_key(
+    State(state): State<AppState>,
+    Path(id): Path<usize>,
+) -> impl IntoResponse {
+    let config = state.config.load();
+    if let Some(entry) = config.auth_keys.get(id) {
+        tracing::info!(key_id = id, name = ?entry.name, "Auth key revealed via dashboard");
+        (StatusCode::OK, Json(json!({ "key": entry.key })))
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "not_found", "message": "Auth key not found"})),
+        )
+    }
+}
+
 /// DELETE /api/dashboard/auth-keys/:id
 pub async fn delete_auth_key(
     State(state): State<AppState>,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -174,6 +174,10 @@ pub fn build_router(state: AppState) -> Router {
             axum::routing::patch(handler::dashboard::auth_keys::update_auth_key)
                 .delete(handler::dashboard::auth_keys::delete_auth_key),
         )
+        .route(
+            "/api/dashboard/auth-keys/{id}/reveal",
+            axum::routing::post(handler::dashboard::auth_keys::reveal_auth_key),
+        )
         // Routing
         .route(
             "/api/dashboard/routing",

--- a/web/src/pages/AuthKeys.tsx
+++ b/web/src/pages/AuthKeys.tsx
@@ -76,6 +76,8 @@ export default function AuthKeys() {
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedRowId, setCopiedRowId] = useState<number | null>(null);
+  const [copyingRowId, setCopyingRowId] = useState<number | null>(null);
 
   const fetchKeys = async () => {
     try {
@@ -190,6 +192,20 @@ export default function AuthKeys() {
     }
   };
 
+  const handleCopyKey = async (id: number) => {
+    setCopyingRowId(id);
+    try {
+      const key = await authKeysApi.reveal(id);
+      await navigator.clipboard.writeText(key);
+      setCopiedRowId(id);
+      setTimeout(() => setCopiedRowId(null), 2000);
+    } catch {
+      console.error('Failed to copy key');
+    } finally {
+      setCopyingRowId(null);
+    }
+  };
+
   const renderLimits = (key: AuthKey) => {
     const parts: string[] = [];
     if (key.rate_limit?.rpm) parts.push(`${key.rate_limit.rpm} RPM`);
@@ -265,6 +281,14 @@ export default function AuthKeys() {
                     </td>
                     <td>
                       <div className="action-btns">
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          onClick={() => handleCopyKey(key.id)}
+                          disabled={copyingRowId === key.id}
+                          title="Copy key"
+                        >
+                          {copiedRowId === key.id ? <Check size={14} /> : <Copy size={14} />}
+                        </button>
                         <button
                           className="btn btn-ghost btn-sm"
                           onClick={() => openEdit(key)}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -164,6 +164,9 @@ export const authKeysApi = {
     api.patch(`/auth-keys/${id}`, data),
 
   delete: (id: number | string) => api.delete(`/auth-keys/${id}`),
+
+  reveal: (id: number | string) =>
+    api.post<{ key: string }>(`/auth-keys/${id}/reveal`).then((res) => res.data.key),
 };
 
 // ── Routing ──


### PR DESCRIPTION
## Summary
- Add `POST /api/dashboard/auth-keys/{id}/reveal` endpoint that returns the full plaintext key (JWT-protected, audit-logged)
- Add per-row copy button in the dashboard auth keys table — fetches key on demand and copies to clipboard without rendering plaintext in the UI
- List endpoint remains masked; plaintext never appears in table rendering

Closes #204

## Changes
### `crates/server/`
- `handler/dashboard/auth_keys.rs` — new `reveal_auth_key` handler with `tracing::info!` audit log
- `lib.rs` — register `/api/dashboard/auth-keys/{id}/reveal` route

### `web/`
- `services/api.ts` — add `authKeysApi.reveal(id)` method
- `pages/AuthKeys.tsx` — add copy button per row (Copy → Check icon feedback)

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes
- [x] `npx tsc --noEmit` passes
- [ ] Manual: click copy button → key copied to clipboard, table stays masked

🤖 Generated with [Claude Code](https://claude.com/claude-code)