### PR TITLE
feat: canonical IR, tri-protocol adapters & control plane (SPEC-065)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
  "futures",
  "moka",
  "notify",
+ "prism-domain",
  "prism-lifecycle",
  "prism-types",
  "rand 0.10.0",
@@ -1872,6 +1873,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prism-domain"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "prism-lifecycle"
 version = "0.1.0"
 dependencies = [
@@ -1887,6 +1898,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prism-protocol"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "prism-domain",
+ "prism-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "prism-provider"
 version = "0.1.0"
 dependencies = [
@@ -1897,6 +1919,7 @@ dependencies = [
  "dashmap",
  "futures",
  "prism-core",
+ "prism-domain",
  "reqwest",
  "serde",
  "serde_json",
@@ -1923,7 +1946,9 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "prism-core",
+ "prism-domain",
  "prism-lifecycle",
+ "prism-protocol",
  "prism-provider",
  "prism-translator",
  "rand 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "crates/types",
     "crates/lifecycle",
+    "crates/domain",
+    "crates/protocol",
     "crates/core",
     "crates/provider",
     "crates/translator",
@@ -66,6 +68,8 @@ moka = { version = "0.12", features = ["future"] }
 dashmap = "6"
 
 # workspace internal
+prism-domain = { path = "crates/domain" }
+prism-protocol = { path = "crates/protocol" }
 prism-types = { path = "crates/types", default-features = false }
 prism-lifecycle = { path = "crates/lifecycle" }
 prism-core = { path = "crates/core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+prism-domain = { workspace = true }
 prism-types = { workspace = true, features = ["reqwest", "axum"] }
 prism-lifecycle = { workspace = true }
 tokio = { workspace = true }

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -11,6 +11,17 @@ use tokio_stream::Stream;
 // Re-export Format and WireApi from prism-types (canonical source).
 pub use prism_types::format::{Format, WireApi};
 
+use prism_domain::capability::UpstreamProtocol;
+
+/// Convert a wire format to the corresponding upstream protocol.
+pub fn upstream_protocol(format: Format) -> UpstreamProtocol {
+    match format {
+        Format::OpenAI => UpstreamProtocol::OpenAi,
+        Format::Claude => UpstreamProtocol::Anthropic,
+        Format::Gemini => UpstreamProtocol::Gemini,
+    }
+}
+
 /// Credentials for executing a request against a specific provider.
 #[derive(Clone)]
 pub struct AuthRecord {

--- a/crates/core/src/routing/explain.rs
+++ b/crates/core/src/routing/explain.rs
@@ -71,6 +71,8 @@ mod tests {
                         weight: 100.0,
                         ..Default::default()
                     },
+                    execution_mode: None,
+                    upstream_protocol: None,
                 },
                 RouteAttemptPlan {
                     model: "gpt-4".to_string(),
@@ -82,6 +84,8 @@ mod tests {
                         weight: 50.0,
                         ..Default::default()
                     },
+                    execution_mode: None,
+                    upstream_protocol: None,
                 },
             ],
             trace: RouteTrace {

--- a/crates/core/src/routing/match_engine.rs
+++ b/crates/core/src/routing/match_engine.rs
@@ -183,6 +183,7 @@ mod tests {
             region: None,
             stream: false,
             headers: BTreeMap::new(),
+            required_capabilities: None,
         }
     }
 

--- a/crates/core/src/routing/planner.rs
+++ b/crates/core/src/routing/planner.rs
@@ -20,6 +20,10 @@ pub struct ProviderEntry {
     pub format: Format,
     pub name: String,
     pub credentials: Vec<CredentialEntry>,
+    /// Declared capabilities for this provider (default derived from format).
+    pub capabilities: prism_domain::capability::ProviderCapabilities,
+    /// The upstream protocol this provider speaks.
+    pub upstream_protocol: prism_domain::capability::UpstreamProtocol,
 }
 
 #[derive(Debug, Clone)]
@@ -146,15 +150,31 @@ impl RoutePlanner {
             .collect();
 
         // 5. Build attempt list
+        // Derive execution mode from ingress protocol vs upstream protocol
+        let ingress = match features.endpoint {
+            RouteEndpoint::ChatCompletions | RouteEndpoint::Responses | RouteEndpoint::Models => {
+                prism_domain::operation::IngressProtocol::OpenAi
+            }
+            RouteEndpoint::Messages => prism_domain::operation::IngressProtocol::Claude,
+            RouteEndpoint::GenerateContent | RouteEndpoint::StreamGenerateContent => {
+                prism_domain::operation::IngressProtocol::Gemini
+            }
+        };
+
         let attempts: Vec<RouteAttemptPlan> = scored
             .iter()
-            .map(|s| RouteAttemptPlan {
-                model: s.model.clone(),
-                provider: s.format,
-                credential_id: s.credential_id.clone(),
-                credential_name: s.credential_name.clone(),
-                rank: s.rank,
-                score: s.score.clone(),
+            .map(|s| {
+                let exec_mode = s.upstream_protocol.execution_mode_for(ingress);
+                RouteAttemptPlan {
+                    model: s.model.clone(),
+                    provider: s.format,
+                    credential_id: s.credential_id.clone(),
+                    credential_name: s.credential_name.clone(),
+                    rank: s.rank,
+                    score: s.score.clone(),
+                    execution_mode: Some(exec_mode),
+                    upstream_protocol: Some(s.upstream_protocol),
+                }
             })
             .collect();
 
@@ -178,6 +198,7 @@ struct CandidateInfo {
     model: String,
     weight: u32,
     _region: Option<String>,
+    upstream_protocol: prism_domain::capability::UpstreamProtocol,
 }
 
 #[derive(Debug, Clone)]
@@ -189,6 +210,7 @@ struct ScoredCandidate {
     model: String,
     score: RouteScore,
     rank: u32,
+    upstream_protocol: prism_domain::capability::UpstreamProtocol,
 }
 
 fn collect_candidates(
@@ -213,13 +235,29 @@ fn collect_candidates(
             continue;
         }
 
+        // Capability check: if required capabilities are specified, filter out providers
+        // that cannot satisfy them.
+        if let Some(ref required) = features.required_capabilities {
+            let missing = provider.capabilities.missing_capabilities(required);
+            if !missing.is_empty() {
+                rejections.push(RouteRejection {
+                    candidate: provider.name.clone(),
+                    reason: RejectReason::MissingCapability {
+                        capabilities: missing,
+                    },
+                });
+                continue;
+            }
+        }
+
         for cred in &provider.credentials {
-            let cand_label = format!("{}/{}", provider.name, cred.name);
+            // Lazy label — only computed on first rejection
+            let cand_label = || format!("{}/{}", provider.name, cred.name);
 
             // Disabled
             if cred.disabled {
                 rejections.push(RouteRejection {
-                    candidate: cand_label,
+                    candidate: cand_label(),
                     reason: RejectReason::CredentialDisabled,
                 });
                 continue;
@@ -231,7 +269,7 @@ fn collect_candidates(
             let excluded = cred.excluded_models.iter().any(|m| glob_match(m, model));
             if !supports || excluded {
                 rejections.push(RouteRejection {
-                    candidate: cand_label,
+                    candidate: cand_label(),
                     reason: RejectReason::ModelNotSupported,
                 });
                 continue;
@@ -243,7 +281,7 @@ fn collect_candidates(
                 && !glob_match(req_region, cred_region)
             {
                 rejections.push(RouteRejection {
-                    candidate: cand_label,
+                    candidate: cand_label(),
                     reason: RejectReason::RegionMismatch,
                 });
                 continue;
@@ -253,21 +291,21 @@ fn collect_candidates(
             if let Some(ch) = health.credentials.get(&cred.id) {
                 if ch.circuit_open {
                     rejections.push(RouteRejection {
-                        candidate: cand_label,
+                        candidate: cand_label(),
                         reason: RejectReason::CircuitBreakerOpen,
                     });
                     continue;
                 }
                 if ch.ejected {
                     rejections.push(RouteRejection {
-                        candidate: cand_label,
+                        candidate: cand_label(),
                         reason: RejectReason::OutlierEjected,
                     });
                     continue;
                 }
                 if ch.cooldown_active {
                     rejections.push(RouteRejection {
-                        candidate: cand_label,
+                        candidate: cand_label(),
                         reason: RejectReason::CooldownActive,
                     });
                     continue;
@@ -282,6 +320,7 @@ fn collect_candidates(
                 model: model.to_string(),
                 weight: cred.weight,
                 _region: cred.region.clone(),
+                upstream_protocol: provider.upstream_protocol,
             });
         }
     }
@@ -315,6 +354,7 @@ fn score_candidates(
                     health_penalty: 0.0,
                 },
                 rank: 0,
+                upstream_protocol: c.upstream_protocol,
             }
         })
         .collect()
@@ -381,10 +421,12 @@ mod tests {
             region: None,
             stream: false,
             headers: BTreeMap::new(),
+            required_capabilities: None,
         }
     }
 
     fn test_inventory() -> InventorySnapshot {
+        use prism_domain::capability::{UpstreamProtocol, default_capabilities_for_protocol};
         InventorySnapshot {
             providers: vec![
                 ProviderEntry {
@@ -399,6 +441,8 @@ mod tests {
                         weight: 100,
                         disabled: false,
                     }],
+                    capabilities: default_capabilities_for_protocol(UpstreamProtocol::OpenAi),
+                    upstream_protocol: UpstreamProtocol::OpenAi,
                 },
                 ProviderEntry {
                     format: Format::Claude,
@@ -412,6 +456,8 @@ mod tests {
                         weight: 100,
                         disabled: false,
                     }],
+                    capabilities: default_capabilities_for_protocol(UpstreamProtocol::Anthropic),
+                    upstream_protocol: UpstreamProtocol::Anthropic,
                 },
             ],
         }
@@ -646,6 +692,10 @@ mod tests {
                         disabled: false,
                     },
                 ],
+                capabilities: prism_domain::capability::default_capabilities_for_protocol(
+                    prism_domain::capability::UpstreamProtocol::OpenAi,
+                ),
+                upstream_protocol: prism_domain::capability::UpstreamProtocol::OpenAi,
             }],
         };
 
@@ -710,6 +760,10 @@ mod tests {
                     weight: 100,
                     disabled: false,
                 }],
+                capabilities: prism_domain::capability::default_capabilities_for_protocol(
+                    prism_domain::capability::UpstreamProtocol::OpenAi,
+                ),
+                upstream_protocol: prism_domain::capability::UpstreamProtocol::OpenAi,
             }],
         };
         let health = healthy();

--- a/crates/core/src/routing/types.rs
+++ b/crates/core/src/routing/types.rs
@@ -1,4 +1,7 @@
 use crate::provider::Format;
+use prism_domain::capability::UpstreamProtocol;
+use prism_domain::operation::ExecutionMode;
+use prism_domain::request::RequiredCapabilities;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -16,6 +19,10 @@ pub struct RouteRequestFeatures {
     pub stream: bool,
     #[serde(default)]
     pub headers: BTreeMap<String, String>,
+    /// Capabilities required by the canonical request.
+    /// When set, the planner filters out providers that cannot satisfy them.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_capabilities: Option<RequiredCapabilities>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -24,6 +31,8 @@ pub enum RouteEndpoint {
     ChatCompletions,
     Messages,
     Responses,
+    GenerateContent,
+    StreamGenerateContent,
     Models,
 }
 
@@ -47,6 +56,12 @@ pub struct RouteAttemptPlan {
     pub credential_name: String,
     pub rank: u32,
     pub score: RouteScore,
+    /// How this route will execute relative to the ingress protocol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_mode: Option<ExecutionMode>,
+    /// The provider's upstream protocol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_protocol: Option<UpstreamProtocol>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -120,7 +135,7 @@ pub struct RouteRejection {
     pub reason: RejectReason,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RejectReason {
     ModelNotSupported,
@@ -131,6 +146,10 @@ pub enum RejectReason {
     CredentialDisabled,
     AccessDenied,
     CooldownActive,
+    /// Provider is missing one or more required capabilities.
+    MissingCapability {
+        capabilities: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -244,6 +263,8 @@ mod tests {
                     weight: 100.0,
                     ..Default::default()
                 },
+                execution_mode: None,
+                upstream_protocol: None,
             }],
             trace: RouteTrace {
                 resolved_profile: "balanced".to_string(),

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "prism-domain"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+bytes = { workspace = true }

--- a/crates/domain/src/capability.rs
+++ b/crates/domain/src/capability.rs
@@ -1,0 +1,127 @@
+use serde::{Deserialize, Serialize};
+
+use crate::operation::{ExecutionMode, IngressProtocol};
+use crate::request::RequiredCapabilities;
+
+/// Declared capabilities of a provider or model.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProviderCapabilities {
+    #[serde(default)]
+    pub supports_stream: bool,
+    #[serde(default)]
+    pub supports_tools: bool,
+    #[serde(default)]
+    pub supports_parallel_tools: bool,
+    #[serde(default)]
+    pub supports_json_schema: bool,
+    #[serde(default)]
+    pub supports_reasoning: bool,
+    #[serde(default)]
+    pub supports_images: bool,
+    #[serde(default)]
+    pub supports_count_tokens: bool,
+}
+
+impl ProviderCapabilities {
+    /// Returns the list of capabilities that are required but not supported.
+    pub fn missing_capabilities(&self, required: &RequiredCapabilities) -> Vec<String> {
+        let mut missing = Vec::new();
+        if required.supports_stream && !self.supports_stream {
+            missing.push("supports_stream".into());
+        }
+        if required.supports_tools && !self.supports_tools {
+            missing.push("supports_tools".into());
+        }
+        if required.supports_parallel_tools && !self.supports_parallel_tools {
+            missing.push("supports_parallel_tools".into());
+        }
+        if required.supports_json_schema && !self.supports_json_schema {
+            missing.push("supports_json_schema".into());
+        }
+        if required.supports_reasoning && !self.supports_reasoning {
+            missing.push("supports_reasoning".into());
+        }
+        if required.supports_images && !self.supports_images {
+            missing.push("supports_images".into());
+        }
+        if required.supports_count_tokens && !self.supports_count_tokens {
+            missing.push("supports_count_tokens".into());
+        }
+        missing
+    }
+
+    /// Check whether all required capabilities are satisfied.
+    pub fn satisfies(&self, required: &RequiredCapabilities) -> bool {
+        (!required.supports_stream || self.supports_stream)
+            && (!required.supports_tools || self.supports_tools)
+            && (!required.supports_parallel_tools || self.supports_parallel_tools)
+            && (!required.supports_json_schema || self.supports_json_schema)
+            && (!required.supports_reasoning || self.supports_reasoning)
+            && (!required.supports_images || self.supports_images)
+            && (!required.supports_count_tokens || self.supports_count_tokens)
+    }
+}
+
+/// Which upstream protocol a provider speaks natively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpstreamProtocol {
+    OpenAi,
+    Anthropic,
+    Gemini,
+}
+
+impl UpstreamProtocol {
+    /// Determine the execution mode when serving the given ingress protocol.
+    pub fn execution_mode_for(&self, ingress: IngressProtocol) -> ExecutionMode {
+        match (ingress, self) {
+            (IngressProtocol::OpenAi, UpstreamProtocol::OpenAi) => ExecutionMode::Native,
+            (IngressProtocol::Claude, UpstreamProtocol::Anthropic) => ExecutionMode::Native,
+            (IngressProtocol::Gemini, UpstreamProtocol::Gemini) => ExecutionMode::Native,
+            _ => ExecutionMode::LosslessAdapted,
+        }
+    }
+}
+
+/// Full capability declaration for a provider-model combination.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelCapabilityEntry {
+    pub provider_name: String,
+    pub model_id: String,
+    pub upstream_protocol: UpstreamProtocol,
+    pub capabilities: ProviderCapabilities,
+}
+
+/// Default capabilities inferred from an upstream protocol.
+/// These serve as sensible defaults when the user doesn't declare capabilities.
+pub fn default_capabilities_for_protocol(protocol: UpstreamProtocol) -> ProviderCapabilities {
+    match protocol {
+        UpstreamProtocol::OpenAi => ProviderCapabilities {
+            supports_stream: true,
+            supports_tools: true,
+            supports_parallel_tools: true,
+            supports_json_schema: true,
+            supports_reasoning: false,
+            supports_images: true,
+            supports_count_tokens: false,
+        },
+        UpstreamProtocol::Anthropic => ProviderCapabilities {
+            supports_stream: true,
+            supports_tools: true,
+            supports_parallel_tools: false,
+            supports_json_schema: false,
+            supports_reasoning: true,
+            supports_images: true,
+            supports_count_tokens: true,
+        },
+        UpstreamProtocol::Gemini => ProviderCapabilities {
+            supports_stream: true,
+            supports_tools: true,
+            supports_parallel_tools: false,
+            supports_json_schema: true,
+            supports_reasoning: true,
+            supports_images: true,
+            supports_count_tokens: true,
+        },
+    }
+}

--- a/crates/domain/src/content.rs
+++ b/crates/domain/src/content.rs
@@ -1,0 +1,100 @@
+use serde::{Deserialize, Serialize};
+
+/// A conversation is an ordered list of messages.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Conversation {
+    /// Optional system instruction (extracted from messages or top-level field).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<SystemContent>,
+    /// The message history.
+    pub messages: Vec<Message>,
+}
+
+/// System-level instruction content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SystemContent {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
+}
+
+/// A single message in the conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: Vec<ContentBlock>,
+    /// Optional message name (used by some protocols).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Message roles in the conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    User,
+    Assistant,
+    /// Tool/function result.
+    Tool,
+}
+
+/// A block of content within a message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text {
+        text: String,
+    },
+    Image {
+        source: ImageSource,
+    },
+    Audio {
+        #[serde(flatten)]
+        data: AudioData,
+    },
+    File {
+        #[serde(flatten)]
+        data: FileData,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: Vec<ContentBlock>,
+        #[serde(default)]
+        is_error: bool,
+    },
+    Thinking {
+        thinking: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+    RedactedThinking {
+        data: String,
+    },
+}
+
+/// Image source in a content block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSource {
+    Base64 { media_type: String, data: String },
+    Url { url: String },
+}
+
+/// Audio data in a content block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioData {
+    pub format: String,
+    pub data: String,
+}
+
+/// File attachment data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileData {
+    pub media_type: String,
+    pub data: String,
+}

--- a/crates/domain/src/error.rs
+++ b/crates/domain/src/error.rs
@@ -1,0 +1,30 @@
+use crate::request::{Rejection, RequiredCapabilities};
+
+/// Errors from the canonical runtime pipeline.
+#[derive(Debug, thiserror::Error)]
+pub enum DomainError {
+    #[error("no provider can serve this request: {reason}")]
+    NoCapableProvider {
+        reason: String,
+        rejections: Vec<Rejection>,
+        required: RequiredCapabilities,
+    },
+
+    #[error("unsupported operation: {0}")]
+    UnsupportedOperation(String),
+
+    #[error("ingress adapter error: {0}")]
+    IngressError(String),
+
+    #[error("egress adapter error: {0}")]
+    EgressError(String),
+
+    #[error("provider execution error: {0}")]
+    ExecutionError(String),
+
+    #[error("model not found: {0}")]
+    ModelNotFound(String),
+
+    #[error("{0}")]
+    Internal(String),
+}

--- a/crates/domain/src/event.rs
+++ b/crates/domain/src/event.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+use crate::content::ContentBlock;
+use crate::response::{StopReason, Usage};
+
+/// A canonical streaming event emitted by the runtime.
+/// Protocol egress adapters translate these into protocol-specific SSE events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CanonicalEvent {
+    /// Stream has started — contains metadata.
+    StreamStart { id: String, model: String },
+
+    /// A new content block has started.
+    ContentBlockStart { index: u32, block: ContentBlock },
+
+    /// Incremental text delta within a content block.
+    TextDelta { index: u32, text: String },
+
+    /// Incremental thinking text delta.
+    ThinkingDelta { index: u32, thinking: String },
+
+    /// Incremental tool input JSON delta.
+    ToolInputDelta { index: u32, partial_json: String },
+
+    /// A content block has finished.
+    ContentBlockStop { index: u32 },
+
+    /// Final usage and stop reason.
+    StreamEnd {
+        stop_reason: StopReason,
+        usage: Usage,
+    },
+
+    /// Keepalive / ping event.
+    Ping,
+}

--- a/crates/domain/src/lib.rs
+++ b/crates/domain/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod capability;
+pub mod content;
+pub mod error;
+pub mod event;
+pub mod operation;
+pub mod request;
+pub mod response;
+pub mod tool;

--- a/crates/domain/src/operation.rs
+++ b/crates/domain/src/operation.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+/// The public ingress protocol used by the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngressProtocol {
+    OpenAi,
+    Claude,
+    Gemini,
+}
+
+impl std::fmt::Display for IngressProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OpenAi => f.write_str("openai"),
+            Self::Claude => f.write_str("claude"),
+            Self::Gemini => f.write_str("gemini"),
+        }
+    }
+}
+
+/// The high-level operation requested by the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operation {
+    /// Generate a completion (chat, messages, generateContent).
+    Generate,
+    /// Count tokens for a request without executing it.
+    CountTokens,
+    /// List available models.
+    ListModels,
+}
+
+/// The specific public endpoint that received the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Endpoint {
+    /// POST /v1/chat/completions
+    ChatCompletions,
+    /// POST /v1/responses
+    Responses,
+    /// POST /v1/messages
+    Messages,
+    /// POST /v1/messages/count_tokens
+    MessagesCountTokens,
+    /// POST /v1beta/models/{model}:generateContent
+    GenerateContent,
+    /// POST /v1beta/models/{model}:streamGenerateContent
+    StreamGenerateContent,
+    /// GET /v1/models or /v1beta/models
+    Models,
+}
+
+impl Endpoint {
+    pub fn operation(&self) -> Operation {
+        match self {
+            Self::ChatCompletions | Self::Responses | Self::Messages => Operation::Generate,
+            Self::GenerateContent | Self::StreamGenerateContent => Operation::Generate,
+            Self::MessagesCountTokens => Operation::CountTokens,
+            Self::Models => Operation::ListModels,
+        }
+    }
+
+    pub fn ingress_protocol(&self) -> IngressProtocol {
+        match self {
+            Self::ChatCompletions | Self::Responses | Self::Models => IngressProtocol::OpenAi,
+            Self::Messages | Self::MessagesCountTokens => IngressProtocol::Claude,
+            Self::GenerateContent | Self::StreamGenerateContent => IngressProtocol::Gemini,
+        }
+    }
+}
+
+/// How the provider will execute this request relative to the ingress protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionMode {
+    /// Provider speaks the same protocol as the ingress — no translation needed.
+    Native,
+    /// Request is translated losslessly to the provider's native protocol.
+    LosslessAdapted,
+}

--- a/crates/domain/src/request.rs
+++ b/crates/domain/src/request.rs
@@ -1,0 +1,220 @@
+use serde::{Deserialize, Serialize};
+
+use crate::content::Conversation;
+use crate::operation::{Endpoint, ExecutionMode, IngressProtocol, Operation};
+use crate::tool::{ResponseFormat, ToolChoice, ToolSpec};
+
+/// The canonical runtime request — protocol-agnostic representation
+/// of any public inference request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalRequest {
+    /// Which public protocol the client used.
+    pub ingress_protocol: IngressProtocol,
+    /// The high-level operation.
+    pub operation: Operation,
+    /// The specific endpoint that received this request.
+    pub endpoint: Endpoint,
+    /// Requested model identifier.
+    pub model: String,
+    /// Whether streaming was requested.
+    pub stream: bool,
+
+    // ── Content ──────────────────────────────────────────────────────
+    /// The conversation (system + messages).
+    pub input: Conversation,
+    /// Tool definitions.
+    #[serde(default)]
+    pub tools: Vec<ToolSpec>,
+    /// Tool choice strategy.
+    #[serde(default)]
+    pub tool_choice: ToolChoice,
+    /// Requested response format.
+    #[serde(default)]
+    pub response_format: ResponseFormat,
+
+    // ── Reasoning ────────────────────────────────────────────────────
+    /// Extended thinking / reasoning configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ReasoningConfig>,
+
+    // ── Limits ───────────────────────────────────────────────────────
+    pub limits: RequestLimits,
+
+    // ── Routing context ──────────────────────────────────────────────
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+
+    /// Original raw body bytes (preserved for native passthrough).
+    #[serde(skip)]
+    pub raw_body: Option<bytes::Bytes>,
+}
+
+/// Reasoning / extended thinking configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningConfig {
+    /// Whether thinking is enabled.
+    pub enabled: bool,
+    /// Budget tokens for thinking (Claude) or reasoning effort.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_tokens: Option<u64>,
+    /// Thinking effort level (e.g., "low", "medium", "high" for OpenAI).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// Token and generation limits.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RequestLimits {
+    /// Maximum tokens to generate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    /// Sampling temperature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    /// Top-p sampling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+    /// Top-k sampling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    /// Stop sequences.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stop: Vec<String>,
+}
+
+/// The required capabilities derived from a CanonicalRequest.
+/// Used by the planner to filter candidate providers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RequiredCapabilities {
+    pub supports_generate: bool,
+    pub supports_stream: bool,
+    pub supports_tools: bool,
+    pub supports_parallel_tools: bool,
+    pub supports_json_schema: bool,
+    pub supports_reasoning: bool,
+    pub supports_images: bool,
+    pub supports_count_tokens: bool,
+}
+
+impl CanonicalRequest {
+    /// Derive the set of capabilities that a provider must have
+    /// in order to serve this request.
+    pub fn required_capabilities(&self) -> RequiredCapabilities {
+        let has_images = self.input.messages.iter().any(|m| {
+            m.content
+                .iter()
+                .any(|c| matches!(c, crate::content::ContentBlock::Image { .. }))
+        });
+
+        RequiredCapabilities {
+            supports_generate: self.operation == Operation::Generate,
+            supports_stream: self.stream,
+            supports_tools: !self.tools.is_empty(),
+            supports_parallel_tools: false, // derived from tool_choice if needed
+            supports_json_schema: matches!(self.response_format, ResponseFormat::JsonSchema { .. }),
+            supports_reasoning: self.reasoning.as_ref().is_some_and(|r| r.enabled),
+            supports_images: has_images,
+            supports_count_tokens: self.operation == Operation::CountTokens,
+        }
+    }
+}
+
+/// A planner explain request — used by the control plane
+/// to explain routing decisions without executing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExplainRequest {
+    pub ingress_protocol: IngressProtocol,
+    pub operation: Operation,
+    pub endpoint: Endpoint,
+    pub model: String,
+    pub stream: bool,
+    /// Feature flags instead of full content.
+    #[serde(default)]
+    pub features: ExplainFeatures,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+}
+
+/// Lightweight feature flags for explain requests.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExplainFeatures {
+    #[serde(default)]
+    pub tools: bool,
+    #[serde(default)]
+    pub json_schema: bool,
+    #[serde(default)]
+    pub reasoning: bool,
+    #[serde(default)]
+    pub images: bool,
+    #[serde(default)]
+    pub count_tokens: bool,
+}
+
+impl ExplainRequest {
+    /// Convert explain features to required capabilities.
+    pub fn required_capabilities(&self) -> RequiredCapabilities {
+        RequiredCapabilities {
+            supports_generate: self.operation == Operation::Generate,
+            supports_stream: self.stream,
+            supports_tools: self.features.tools,
+            supports_parallel_tools: false,
+            supports_json_schema: self.features.json_schema,
+            supports_reasoning: self.features.reasoning,
+            supports_images: self.features.images,
+            supports_count_tokens: self.features.count_tokens,
+        }
+    }
+}
+
+/// Planner explain response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExplainResponse {
+    /// The selected route (if any).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected: Option<SelectedRoute>,
+    /// Alternate candidates that could serve this request.
+    #[serde(default)]
+    pub alternates: Vec<SelectedRoute>,
+    /// Candidates that were rejected and why.
+    #[serde(default)]
+    pub rejections: Vec<Rejection>,
+    /// The capabilities that were required.
+    pub required_capabilities: RequiredCapabilities,
+}
+
+/// A selected route for execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectedRoute {
+    pub provider: String,
+    pub credential: String,
+    pub model: String,
+    pub execution_mode: ExecutionMode,
+}
+
+/// A rejected candidate with a structured reason.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rejection {
+    pub candidate: String,
+    pub reason: RejectionReason,
+}
+
+/// Structured rejection reason.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RejectionReason {
+    MissingCapability { capability: String },
+    ModelNotSupported { model: String },
+    CredentialUnavailable,
+    RegionMismatch { required: String, actual: String },
+    TenantNotAllowed,
+    CircuitOpen,
+    Disabled,
+}

--- a/crates/domain/src/response.rs
+++ b/crates/domain/src/response.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use crate::content::ContentBlock;
+use crate::operation::ExecutionMode;
+
+/// Canonical response from a provider execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CanonicalResponse {
+    /// Unique response ID.
+    pub id: String,
+    /// Model that generated the response.
+    pub model: String,
+    /// The response content blocks.
+    pub content: Vec<ContentBlock>,
+    /// Stop reason.
+    pub stop_reason: StopReason,
+    /// Token usage.
+    pub usage: Usage,
+    /// How this response was produced.
+    pub execution_mode: ExecutionMode,
+    /// Provider that served the request.
+    pub provider: String,
+    /// Credential that was used.
+    pub credential: String,
+}
+
+/// Why the model stopped generating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopReason {
+    /// Natural end of generation.
+    EndTurn,
+    /// Hit a stop sequence.
+    StopSequence,
+    /// Reached max tokens limit.
+    MaxTokens,
+    /// Model decided to use a tool.
+    ToolUse,
+}
+
+/// Token usage information.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Usage {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_tokens: u64,
+    #[serde(default)]
+    pub reasoning_tokens: u64,
+}
+
+/// Canonical count-tokens response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CountTokensResponse {
+    pub input_tokens: u64,
+}

--- a/crates/domain/src/tool.rs
+++ b/crates/domain/src/tool.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+/// A tool specification describing a callable function.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolSpec {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub parameters: serde_json::Value,
+}
+
+/// How the model should choose tools.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolChoice {
+    /// Let the model decide.
+    #[default]
+    Auto,
+    /// Never use tools.
+    None,
+    /// Must use at least one tool.
+    Required,
+    /// Must use the specified tool.
+    Tool { name: String },
+}
+
+/// Requested response format.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResponseFormat {
+    /// Unstructured text output.
+    #[default]
+    Text,
+    /// JSON output (optionally with a schema).
+    JsonSchema {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        schema: Option<serde_json::Value>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(default)]
+        strict: bool,
+    },
+    /// Raw JSON mode without schema.
+    JsonObject,
+}

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "prism-protocol"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+prism-domain = { workspace = true }
+prism-types = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+bytes = { workspace = true }

--- a/crates/protocol/src/claude.rs
+++ b/crates/protocol/src/claude.rs
@@ -1,0 +1,814 @@
+use prism_domain::content::{
+    ContentBlock, Conversation, ImageSource, Message, Role, SystemContent,
+};
+use prism_domain::event::CanonicalEvent;
+use prism_domain::operation::Endpoint;
+use prism_domain::request::{CanonicalRequest, ReasoningConfig, RequestLimits};
+use prism_domain::response::{CanonicalResponse, StopReason};
+use prism_domain::tool::{ResponseFormat, ToolChoice, ToolSpec};
+use prism_types::types::claude::*;
+
+// ─── Ingress: Claude → Canonical ────────────────────────────────────────────
+
+/// Parse a ClaudeMessagesRequest into a CanonicalRequest.
+pub fn ingress_messages(req: &ClaudeMessagesRequest, endpoint: Endpoint) -> CanonicalRequest {
+    let system = convert_system(&req.system);
+    let messages = convert_messages(&req.messages);
+    let tools = convert_tools(&req.tools);
+    let tool_choice = convert_tool_choice(&req.tool_choice);
+    let reasoning = extract_reasoning(req);
+
+    CanonicalRequest {
+        ingress_protocol: prism_domain::operation::IngressProtocol::Claude,
+        operation: endpoint.operation(),
+        endpoint,
+        model: req.model.clone(),
+        stream: req.stream.unwrap_or(false),
+        input: Conversation { system, messages },
+        tools,
+        tool_choice,
+        response_format: ResponseFormat::Text,
+        reasoning,
+        limits: RequestLimits {
+            max_tokens: Some(req.max_tokens),
+            temperature: req.temperature,
+            top_p: req.top_p,
+            top_k: req.top_k,
+            stop: req.stop_sequences.clone().unwrap_or_default(),
+        },
+        tenant_id: None,
+        api_key_id: None,
+        region: None,
+        raw_body: None,
+    }
+}
+
+fn convert_system(system: &Option<ClaudeSystem>) -> Option<SystemContent> {
+    system.as_ref().map(|s| match s {
+        ClaudeSystem::Text(t) => SystemContent::Text(t.clone()),
+        ClaudeSystem::Blocks(blocks) => {
+            SystemContent::Blocks(blocks.iter().map(convert_claude_content).collect())
+        }
+    })
+}
+
+fn convert_messages(messages: &[ClaudeMessage]) -> Vec<Message> {
+    messages
+        .iter()
+        .map(|m| {
+            let role = match m.role.as_str() {
+                "assistant" => Role::Assistant,
+                _ => Role::User,
+            };
+
+            let content = match &m.content {
+                ClaudeMessageContent::Text(t) => vec![ContentBlock::Text { text: t.clone() }],
+                ClaudeMessageContent::Blocks(blocks) => {
+                    blocks.iter().map(convert_claude_content).collect()
+                }
+            };
+
+            Message {
+                role,
+                content,
+                name: None,
+            }
+        })
+        .collect()
+}
+
+fn convert_claude_content(block: &ClaudeContent) -> ContentBlock {
+    match block {
+        ClaudeContent::Text { text, .. } => ContentBlock::Text { text: text.clone() },
+        ClaudeContent::Image { source } => ContentBlock::Image {
+            source: ImageSource::Base64 {
+                media_type: source.media_type.clone(),
+                data: source.data.clone(),
+            },
+        },
+        ClaudeContent::ToolUse { id, name, input } => ContentBlock::ToolUse {
+            id: id.clone(),
+            name: name.clone(),
+            input: input.clone(),
+        },
+        ClaudeContent::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => {
+            let inner = content
+                .as_ref()
+                .map(|c| match c {
+                    ClaudeMessageContent::Text(t) => {
+                        vec![ContentBlock::Text { text: t.clone() }]
+                    }
+                    ClaudeMessageContent::Blocks(blocks) => {
+                        blocks.iter().map(convert_claude_content).collect()
+                    }
+                })
+                .unwrap_or_default();
+            ContentBlock::ToolResult {
+                tool_use_id: tool_use_id.clone(),
+                content: inner,
+                is_error: is_error.unwrap_or(false),
+            }
+        }
+        ClaudeContent::Thinking {
+            thinking,
+            signature,
+        } => ContentBlock::Thinking {
+            thinking: thinking.clone(),
+            signature: signature.clone(),
+        },
+        ClaudeContent::RedactedThinking { data } => {
+            ContentBlock::RedactedThinking { data: data.clone() }
+        }
+    }
+}
+
+fn convert_tools(tools: &Option<Vec<ClaudeTool>>) -> Vec<ToolSpec> {
+    tools
+        .as_ref()
+        .map(|ts| {
+            ts.iter()
+                .map(|t| ToolSpec {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    parameters: t.input_schema.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn convert_tool_choice(tc: &Option<serde_json::Value>) -> ToolChoice {
+    match tc {
+        None => ToolChoice::Auto,
+        Some(v) => match v.get("type").and_then(|t| t.as_str()) {
+            Some("none") => ToolChoice::None,
+            Some("any") => ToolChoice::Required,
+            Some("tool") => {
+                if let Some(name) = v.get("name").and_then(|n| n.as_str()) {
+                    ToolChoice::Tool {
+                        name: name.to_string(),
+                    }
+                } else {
+                    ToolChoice::Required
+                }
+            }
+            _ => ToolChoice::Auto,
+        },
+    }
+}
+
+fn extract_reasoning(req: &ClaudeMessagesRequest) -> Option<ReasoningConfig> {
+    req.extra.get("thinking").map(|v| {
+        let enabled = v.get("type").and_then(|t| t.as_str()) == Some("enabled");
+        let budget = v.get("budget_tokens").and_then(|b| b.as_u64());
+        ReasoningConfig {
+            enabled,
+            budget_tokens: budget,
+            effort: None,
+        }
+    })
+}
+
+fn stop_reason_to_claude(reason: &StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn => "end_turn",
+        StopReason::StopSequence => "stop_sequence",
+        StopReason::MaxTokens => "max_tokens",
+        StopReason::ToolUse => "tool_use",
+    }
+}
+
+fn claude_to_stop_reason(s: Option<&str>) -> StopReason {
+    match s {
+        Some("end_turn") => StopReason::EndTurn,
+        Some("stop_sequence") => StopReason::StopSequence,
+        Some("max_tokens") => StopReason::MaxTokens,
+        Some("tool_use") => StopReason::ToolUse,
+        _ => StopReason::EndTurn,
+    }
+}
+
+// ─── Egress: Canonical → Claude ─────────────────────────────────────────────
+
+/// Convert a CanonicalResponse into a ClaudeMessagesResponse.
+pub fn egress_response(resp: &CanonicalResponse) -> ClaudeMessagesResponse {
+    let content: Vec<ClaudeContent> = resp
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(ClaudeContent::Text {
+                text: text.clone(),
+                extra: Default::default(),
+            }),
+            ContentBlock::ToolUse { id, name, input } => Some(ClaudeContent::ToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                input: input.clone(),
+            }),
+            ContentBlock::Thinking {
+                thinking,
+                signature,
+            } => Some(ClaudeContent::Thinking {
+                thinking: thinking.clone(),
+                signature: signature.clone(),
+            }),
+            ContentBlock::RedactedThinking { data } => {
+                Some(ClaudeContent::RedactedThinking { data: data.clone() })
+            }
+            _ => None,
+        })
+        .collect();
+
+    ClaudeMessagesResponse {
+        id: resp.id.clone(),
+        response_type: "message".to_string(),
+        role: "assistant".to_string(),
+        model: resp.model.clone(),
+        content,
+        stop_reason: Some(stop_reason_to_claude(&resp.stop_reason).to_string()),
+        stop_sequence: None,
+        usage: ClaudeUsage {
+            input_tokens: resp.usage.input_tokens,
+            output_tokens: resp.usage.output_tokens,
+            cache_creation_input_tokens: resp.usage.cache_creation_tokens,
+            cache_read_input_tokens: resp.usage.cache_read_tokens,
+        },
+    }
+}
+
+/// Convert a CanonicalEvent into Claude SSE event (event_type, data_json).
+pub fn egress_event(event: &CanonicalEvent) -> Vec<(String, String)> {
+    match event {
+        CanonicalEvent::StreamStart { id, model } => {
+            let msg = serde_json::json!({
+                "type": "message_start",
+                "message": {
+                    "id": id,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": model,
+                    "content": [],
+                    "stop_reason": null,
+                    "stop_sequence": null,
+                    "usage": { "input_tokens": 0, "output_tokens": 0 }
+                }
+            });
+            vec![(
+                "message_start".into(),
+                serde_json::to_string(&msg).unwrap_or_default(),
+            )]
+        }
+        CanonicalEvent::ContentBlockStart { index, block } => {
+            let cb = match block {
+                ContentBlock::Text { text } => serde_json::json!({
+                    "type": "text",
+                    "text": text
+                }),
+                ContentBlock::ToolUse { id, name, .. } => serde_json::json!({
+                    "type": "tool_use",
+                    "id": id,
+                    "name": name,
+                    "input": {}
+                }),
+                ContentBlock::Thinking { .. } => serde_json::json!({
+                    "type": "thinking",
+                    "thinking": ""
+                }),
+                _ => serde_json::json!({}),
+            };
+            let data = serde_json::json!({
+                "type": "content_block_start",
+                "index": index,
+                "content_block": cb
+            });
+            vec![(
+                "content_block_start".into(),
+                serde_json::to_string(&data).unwrap_or_default(),
+            )]
+        }
+        CanonicalEvent::TextDelta { index, text } => {
+            let data = serde_json::json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": { "type": "text_delta", "text": text }
+            });
+            vec![(
+                "content_block_delta".into(),
+                serde_json::to_string(&data).unwrap_or_default(),
+            )]
+        }
+        CanonicalEvent::ThinkingDelta { index, thinking } => {
+            let data = serde_json::json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": { "type": "thinking_delta", "thinking": thinking }
+            });
+            vec![(
+                "content_block_delta".into(),
+                serde_json::to_string(&data).unwrap_or_default(),
+            )]
+        }
+        CanonicalEvent::ToolInputDelta {
+            index,
+            partial_json,
+        } => {
+            let data = serde_json::json!({
+                "type": "content_block_delta",
+                "index": index,
+                "delta": { "type": "input_json_delta", "partial_json": partial_json }
+            });
+            vec![(
+                "content_block_delta".into(),
+                serde_json::to_string(&data).unwrap_or_default(),
+            )]
+        }
+        CanonicalEvent::ContentBlockStop { index } => {
+            let data = serde_json::json!({
+                "type": "content_block_stop",
+                "index": index
+            });
+            vec![(
+                "content_block_stop".into(),
+                serde_json::to_string(&data).unwrap_or_default(),
+            )]
+        }
+        CanonicalEvent::StreamEnd { stop_reason, usage } => {
+            let delta = serde_json::json!({
+                "type": "message_delta",
+                "delta": { "stop_reason": stop_reason_to_claude(stop_reason) },
+                "usage": { "output_tokens": usage.output_tokens }
+            });
+            let stop = serde_json::json!({ "type": "message_stop" });
+            vec![
+                (
+                    "message_delta".into(),
+                    serde_json::to_string(&delta).unwrap_or_default(),
+                ),
+                (
+                    "message_stop".into(),
+                    serde_json::to_string(&stop).unwrap_or_default(),
+                ),
+            ]
+        }
+        CanonicalEvent::Ping => {
+            vec![("ping".into(), r#"{"type":"ping"}"#.into())]
+        }
+    }
+}
+
+// ─── Provider-facing: Canonical → Claude request ────────────────────────────
+
+/// Convert a CanonicalRequest into a ClaudeMessagesRequest (to send TO Claude).
+pub fn egress_request(canonical: &CanonicalRequest) -> ClaudeMessagesRequest {
+    let system = canonical.input.system.as_ref().map(|sys| match sys {
+        SystemContent::Text(t) => ClaudeSystem::Text(t.clone()),
+        SystemContent::Blocks(blocks) => ClaudeSystem::Blocks(
+            blocks
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } => Some(ClaudeContent::Text {
+                        text: text.clone(),
+                        extra: Default::default(),
+                    }),
+                    _ => None,
+                })
+                .collect(),
+        ),
+    });
+
+    let messages: Vec<ClaudeMessage> = canonical
+        .input
+        .messages
+        .iter()
+        .map(|msg| {
+            let role = match msg.role {
+                Role::User | Role::Tool => "user",
+                Role::Assistant => "assistant",
+            };
+
+            let content =
+                if msg.content.len() == 1 && matches!(&msg.content[0], ContentBlock::Text { .. }) {
+                    if let ContentBlock::Text { text } = &msg.content[0] {
+                        ClaudeMessageContent::Text(text.clone())
+                    } else {
+                        unreachable!()
+                    }
+                } else {
+                    ClaudeMessageContent::Blocks(
+                        msg.content.iter().map(canonical_block_to_claude).collect(),
+                    )
+                };
+
+            ClaudeMessage {
+                role: role.to_string(),
+                content,
+            }
+        })
+        .collect();
+
+    let tools = if canonical.tools.is_empty() {
+        None
+    } else {
+        Some(
+            canonical
+                .tools
+                .iter()
+                .map(|t| ClaudeTool {
+                    name: t.name.clone(),
+                    description: t.description.clone(),
+                    input_schema: t.parameters.clone(),
+                })
+                .collect(),
+        )
+    };
+
+    let tool_choice = match &canonical.tool_choice {
+        ToolChoice::None => Some(serde_json::json!({"type": "none"})),
+        ToolChoice::Required => Some(serde_json::json!({"type": "any"})),
+        ToolChoice::Tool { name } => Some(serde_json::json!({"type": "tool", "name": name})),
+        ToolChoice::Auto => None,
+    };
+
+    ClaudeMessagesRequest {
+        model: canonical.model.clone(),
+        messages,
+        max_tokens: canonical.limits.max_tokens.unwrap_or(4096),
+        system,
+        temperature: canonical.limits.temperature,
+        top_p: canonical.limits.top_p,
+        top_k: canonical.limits.top_k,
+        stop_sequences: if canonical.limits.stop.is_empty() {
+            None
+        } else {
+            Some(canonical.limits.stop.clone())
+        },
+        stream: Some(canonical.stream),
+        tools,
+        tool_choice,
+        metadata: None,
+        extra: Default::default(),
+    }
+}
+
+fn canonical_block_to_claude(block: &ContentBlock) -> ClaudeContent {
+    match block {
+        ContentBlock::Text { text } => ClaudeContent::Text {
+            text: text.clone(),
+            extra: Default::default(),
+        },
+        ContentBlock::Image { source } => match source {
+            ImageSource::Base64 { media_type, data } => ClaudeContent::Image {
+                source: prism_types::types::claude::ImageSource {
+                    source_type: "base64".to_string(),
+                    media_type: media_type.clone(),
+                    data: data.clone(),
+                },
+            },
+            // Claude API only supports base64 images; URL images cannot be converted
+            ImageSource::Url { .. } => ClaudeContent::Text {
+                text: "[image: unsupported URL source]".to_string(),
+                extra: Default::default(),
+            },
+        },
+        ContentBlock::ToolUse { id, name, input } => ClaudeContent::ToolUse {
+            id: id.clone(),
+            name: name.clone(),
+            input: input.clone(),
+        },
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => ClaudeContent::ToolResult {
+            tool_use_id: tool_use_id.clone(),
+            content: Some(ClaudeMessageContent::Blocks(
+                content.iter().map(canonical_block_to_claude).collect(),
+            )),
+            is_error: Some(*is_error),
+        },
+        ContentBlock::Thinking {
+            thinking,
+            signature,
+        } => ClaudeContent::Thinking {
+            thinking: thinking.clone(),
+            signature: signature.clone(),
+        },
+        ContentBlock::RedactedThinking { data } => {
+            ClaudeContent::RedactedThinking { data: data.clone() }
+        }
+        _ => ClaudeContent::Text {
+            text: String::new(),
+            extra: Default::default(),
+        },
+    }
+}
+
+// ─── Provider-facing: Claude response → Canonical ───────────────────────────
+
+/// Parse a Claude API response into a CanonicalResponse.
+pub fn parse_response(
+    data: &[u8],
+    provider: &str,
+    credential: &str,
+) -> Result<CanonicalResponse, String> {
+    let resp: ClaudeMessagesResponse = serde_json::from_slice(data)
+        .map_err(|e| format!("failed to parse Claude response: {e}"))?;
+
+    let content: Vec<ContentBlock> = resp
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ClaudeContent::Text { text, .. } => Some(ContentBlock::Text { text: text.clone() }),
+            ClaudeContent::ToolUse { id, name, input } => Some(ContentBlock::ToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                input: input.clone(),
+            }),
+            ClaudeContent::Thinking {
+                thinking,
+                signature,
+            } => Some(ContentBlock::Thinking {
+                thinking: thinking.clone(),
+                signature: signature.clone(),
+            }),
+            ClaudeContent::RedactedThinking { data } => {
+                Some(ContentBlock::RedactedThinking { data: data.clone() })
+            }
+            _ => None,
+        })
+        .collect();
+
+    let stop_reason = claude_to_stop_reason(resp.stop_reason.as_deref());
+
+    let usage = prism_domain::response::Usage {
+        input_tokens: resp.usage.input_tokens,
+        output_tokens: resp.usage.output_tokens,
+        cache_creation_tokens: resp.usage.cache_creation_input_tokens,
+        cache_read_tokens: resp.usage.cache_read_input_tokens,
+        reasoning_tokens: 0,
+    };
+
+    Ok(CanonicalResponse {
+        id: resp.id,
+        model: resp.model,
+        content,
+        stop_reason,
+        usage,
+        execution_mode: prism_domain::operation::ExecutionMode::Native,
+        provider: provider.to_string(),
+        credential: credential.to_string(),
+    })
+}
+
+/// Parse a Claude SSE event into a CanonicalEvent.
+pub fn parse_event(event_type: &str, data: &str) -> Option<CanonicalEvent> {
+    let v: serde_json::Value = serde_json::from_str(data).ok()?;
+
+    match event_type {
+        "message_start" => {
+            let msg = v.get("message")?;
+            let id = msg.get("id")?.as_str()?.to_string();
+            let model = msg.get("model")?.as_str()?.to_string();
+            Some(CanonicalEvent::StreamStart { id, model })
+        }
+        "content_block_start" => {
+            let index = v.get("index")?.as_u64()? as u32;
+            let cb = v.get("content_block")?;
+            let block = match cb.get("type")?.as_str()? {
+                "text" => ContentBlock::Text {
+                    text: String::new(),
+                },
+                "tool_use" => ContentBlock::ToolUse {
+                    id: cb.get("id")?.as_str()?.to_string(),
+                    name: cb.get("name")?.as_str()?.to_string(),
+                    input: serde_json::Value::Null,
+                },
+                "thinking" => ContentBlock::Thinking {
+                    thinking: String::new(),
+                    signature: None,
+                },
+                _ => return None,
+            };
+            Some(CanonicalEvent::ContentBlockStart { index, block })
+        }
+        "content_block_delta" => {
+            let index = v.get("index")?.as_u64()? as u32;
+            let delta = v.get("delta")?;
+            match delta.get("type")?.as_str()? {
+                "text_delta" => Some(CanonicalEvent::TextDelta {
+                    index,
+                    text: delta.get("text")?.as_str()?.to_string(),
+                }),
+                "thinking_delta" => Some(CanonicalEvent::ThinkingDelta {
+                    index,
+                    thinking: delta.get("thinking")?.as_str()?.to_string(),
+                }),
+                "input_json_delta" => Some(CanonicalEvent::ToolInputDelta {
+                    index,
+                    partial_json: delta.get("partial_json")?.as_str()?.to_string(),
+                }),
+                _ => None,
+            }
+        }
+        "content_block_stop" => {
+            let index = v.get("index")?.as_u64()? as u32;
+            Some(CanonicalEvent::ContentBlockStop { index })
+        }
+        "message_delta" => {
+            let delta = v.get("delta")?;
+            let stop_reason = claude_to_stop_reason(delta.get("stop_reason")?.as_str());
+            let usage = v
+                .get("usage")
+                .map(|u| prism_domain::response::Usage {
+                    input_tokens: u.get("input_tokens").and_then(|t| t.as_u64()).unwrap_or(0),
+                    output_tokens: u.get("output_tokens").and_then(|t| t.as_u64()).unwrap_or(0),
+                    ..Default::default()
+                })
+                .unwrap_or_default();
+            Some(CanonicalEvent::StreamEnd { stop_reason, usage })
+        }
+        "ping" => Some(CanonicalEvent::Ping),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prism_domain::response::Usage;
+
+    fn minimal_claude_request() -> ClaudeMessagesRequest {
+        ClaudeMessagesRequest {
+            model: "claude-sonnet-4-5".to_string(),
+            messages: vec![ClaudeMessage {
+                role: "user".to_string(),
+                content: ClaudeMessageContent::Text("Hello".to_string()),
+            }],
+            max_tokens: 1024,
+            system: None,
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            stop_sequences: None,
+            stream: None,
+            tools: None,
+            tool_choice: None,
+            metadata: None,
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_ingress_basic() {
+        let req = minimal_claude_request();
+        let canonical = ingress_messages(&req, Endpoint::Messages);
+        assert_eq!(canonical.model, "claude-sonnet-4-5");
+        assert!(!canonical.stream);
+        assert_eq!(canonical.limits.max_tokens, Some(1024));
+        assert_eq!(canonical.input.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_ingress_with_system() {
+        let req = ClaudeMessagesRequest {
+            system: Some(ClaudeSystem::Text("You are helpful".to_string())),
+            ..minimal_claude_request()
+        };
+        let canonical = ingress_messages(&req, Endpoint::Messages);
+        assert!(canonical.input.system.is_some());
+    }
+
+    #[test]
+    fn test_ingress_thinking() {
+        let mut req = minimal_claude_request();
+        req.messages = vec![ClaudeMessage {
+            role: "assistant".to_string(),
+            content: ClaudeMessageContent::Blocks(vec![
+                ClaudeContent::Thinking {
+                    thinking: "Let me think...".to_string(),
+                    signature: Some("sig123".to_string()),
+                },
+                ClaudeContent::Text {
+                    text: "Answer".to_string(),
+                    extra: Default::default(),
+                },
+            ]),
+        }];
+        let canonical = ingress_messages(&req, Endpoint::Messages);
+        assert_eq!(canonical.input.messages[0].content.len(), 2);
+        assert!(matches!(
+            &canonical.input.messages[0].content[0],
+            ContentBlock::Thinking { .. }
+        ));
+    }
+
+    #[test]
+    fn test_egress_response() {
+        let canonical = CanonicalResponse {
+            id: "msg-1".to_string(),
+            model: "claude-sonnet-4-5".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Hello!".to_string(),
+            }],
+            stop_reason: StopReason::EndTurn,
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                ..Default::default()
+            },
+            execution_mode: prism_domain::operation::ExecutionMode::Native,
+            provider: "anthropic".to_string(),
+            credential: "cred-1".to_string(),
+        };
+        let resp = egress_response(&canonical);
+        assert_eq!(resp.id, "msg-1");
+        assert_eq!(resp.stop_reason, Some("end_turn".to_string()));
+        assert_eq!(resp.content.len(), 1);
+    }
+
+    #[test]
+    fn test_egress_stream_events() {
+        let events = egress_event(&CanonicalEvent::TextDelta {
+            index: 0,
+            text: "Hi".to_string(),
+        });
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, "content_block_delta");
+        let json: serde_json::Value = serde_json::from_str(&events[0].1).unwrap();
+        assert_eq!(json["delta"]["text"].as_str().unwrap(), "Hi");
+    }
+
+    // ── Provider-facing tests ──
+
+    #[test]
+    fn test_egress_request_basic() {
+        let canonical = ingress_messages(&minimal_claude_request(), Endpoint::Messages);
+        let wire = egress_request(&canonical);
+        assert_eq!(wire.model, "claude-sonnet-4-5");
+        assert_eq!(wire.max_tokens, 1024);
+        assert_eq!(wire.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_egress_request_with_tools() {
+        let mut req = minimal_claude_request();
+        req.tools = Some(vec![ClaudeTool {
+            name: "get_weather".to_string(),
+            description: Some("Get weather info".to_string()),
+            input_schema: serde_json::json!({"type": "object"}),
+        }]);
+        let canonical = ingress_messages(&req, Endpoint::Messages);
+        let wire = egress_request(&canonical);
+        assert_eq!(wire.tools.as_ref().unwrap().len(), 1);
+        assert_eq!(wire.tools.as_ref().unwrap()[0].name, "get_weather");
+    }
+
+    #[test]
+    fn test_parse_response_basic() {
+        let wire_resp = serde_json::json!({
+            "id": "msg-123",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0
+            }
+        });
+        let data = serde_json::to_vec(&wire_resp).unwrap();
+        let canonical = parse_response(&data, "anthropic", "cred-1").unwrap();
+        assert_eq!(canonical.id, "msg-123");
+        assert_eq!(canonical.model, "claude-sonnet-4-5");
+        assert_eq!(canonical.content.len(), 1);
+        assert_eq!(canonical.stop_reason, StopReason::EndTurn);
+    }
+
+    #[test]
+    fn test_parse_event_text_delta() {
+        let data =
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#;
+        let event = parse_event("content_block_delta", data).unwrap();
+        assert!(matches!(event, CanonicalEvent::TextDelta { text, .. } if text == "Hi"));
+    }
+
+    #[test]
+    fn test_parse_event_message_start() {
+        let data = r#"{"type":"message_start","message":{"id":"msg-1","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let event = parse_event("message_start", data).unwrap();
+        if let CanonicalEvent::StreamStart { id, model } = event {
+            assert_eq!(id, "msg-1");
+            assert_eq!(model, "claude-sonnet-4-5");
+        } else {
+            panic!("expected StreamStart");
+        }
+    }
+}

--- a/crates/protocol/src/gemini.rs
+++ b/crates/protocol/src/gemini.rs
@@ -1,0 +1,665 @@
+use prism_domain::content::{
+    ContentBlock, Conversation, ImageSource, Message, Role, SystemContent,
+};
+use prism_domain::event::CanonicalEvent;
+use prism_domain::operation::Endpoint;
+use prism_domain::request::{CanonicalRequest, RequestLimits};
+use prism_domain::response::Usage;
+use prism_domain::response::{CanonicalResponse, StopReason};
+use prism_domain::tool::{ResponseFormat, ToolChoice, ToolSpec};
+use prism_types::types::gemini::*;
+
+// ─── Ingress: Gemini → Canonical ────────────────────────────────────────────
+
+/// Parse a GeminiRequest into a CanonicalRequest.
+pub fn ingress_generate(req: &GeminiRequest, model: &str, endpoint: Endpoint) -> CanonicalRequest {
+    let system = convert_system(&req.system_instruction);
+    let messages = convert_contents(&req.contents);
+    let tools = convert_tools(&req.tools);
+    let (response_format, limits) = convert_generation_config(&req.generation_config);
+
+    CanonicalRequest {
+        ingress_protocol: prism_domain::operation::IngressProtocol::Gemini,
+        operation: endpoint.operation(),
+        endpoint,
+        model: model.to_string(),
+        stream: endpoint == Endpoint::StreamGenerateContent,
+        input: Conversation { system, messages },
+        tools,
+        tool_choice: ToolChoice::Auto,
+        response_format,
+        reasoning: None,
+        limits,
+        tenant_id: None,
+        api_key_id: None,
+        region: None,
+        raw_body: None,
+    }
+}
+
+fn convert_system(sys: &Option<GeminiContent>) -> Option<SystemContent> {
+    sys.as_ref().map(|c| {
+        let text = c
+            .parts
+            .iter()
+            .filter_map(|p| match p {
+                GeminiPart::Text(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        SystemContent::Text(text)
+    })
+}
+
+fn convert_contents(contents: &[GeminiContent]) -> Vec<Message> {
+    contents
+        .iter()
+        .map(|c| {
+            let role = match c.role.as_deref() {
+                Some("model") => Role::Assistant,
+                _ => Role::User,
+            };
+            let content = c.parts.iter().map(convert_part).collect();
+            Message {
+                role,
+                content,
+                name: None,
+            }
+        })
+        .collect()
+}
+
+fn convert_part(part: &GeminiPart) -> ContentBlock {
+    match part {
+        GeminiPart::Text(t) => ContentBlock::Text { text: t.clone() },
+        GeminiPart::InlineData { mime_type, data } => ContentBlock::Image {
+            source: ImageSource::Base64 {
+                media_type: mime_type.clone(),
+                data: data.clone(),
+            },
+        },
+        GeminiPart::FunctionCall { name, args } => ContentBlock::ToolUse {
+            id: format!("call_{}", name),
+            name: name.clone(),
+            input: args.clone(),
+        },
+        GeminiPart::FunctionResponse { name, response } => ContentBlock::ToolResult {
+            tool_use_id: format!("call_{}", name),
+            content: vec![ContentBlock::Text {
+                text: serde_json::to_string(response).unwrap_or_default(),
+            }],
+            is_error: false,
+        },
+    }
+}
+
+fn convert_tools(tools: &Option<Vec<GeminiToolDeclaration>>) -> Vec<ToolSpec> {
+    tools
+        .as_ref()
+        .map(|ts| {
+            ts.iter()
+                .flat_map(|td| {
+                    td.function_declarations.iter().map(|f| ToolSpec {
+                        name: f.name.clone(),
+                        description: Some(f.description.clone()),
+                        parameters: f.parameters.clone().unwrap_or_default(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn convert_generation_config(gc: &Option<GenerationConfig>) -> (ResponseFormat, RequestLimits) {
+    let gc = match gc {
+        Some(c) => c,
+        None => {
+            return (ResponseFormat::Text, RequestLimits::default());
+        }
+    };
+
+    let response_format = match gc.response_mime_type.as_deref() {
+        Some("application/json") => ResponseFormat::JsonObject,
+        _ => ResponseFormat::Text,
+    };
+
+    let limits = RequestLimits {
+        max_tokens: gc.max_output_tokens,
+        temperature: gc.temperature,
+        top_p: gc.top_p,
+        top_k: gc.top_k,
+        stop: gc.stop_sequences.clone().unwrap_or_default(),
+    };
+
+    (response_format, limits)
+}
+
+fn stop_reason_to_gemini(reason: &StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn | StopReason::StopSequence | StopReason::ToolUse => "STOP",
+        StopReason::MaxTokens => "MAX_TOKENS",
+    }
+}
+
+fn gemini_to_stop_reason(s: Option<&str>) -> StopReason {
+    match s {
+        Some("STOP") => StopReason::EndTurn,
+        Some("MAX_TOKENS") => StopReason::MaxTokens,
+        _ => StopReason::EndTurn,
+    }
+}
+
+// ─── Egress: Canonical → Gemini ─────────────────────────────────────────────
+
+/// Convert a CanonicalResponse into a GeminiResponse.
+pub fn egress_response(resp: &CanonicalResponse) -> GeminiResponse {
+    let parts: Vec<GeminiPart> = resp
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(GeminiPart::Text(text.clone())),
+            ContentBlock::ToolUse { name, input, .. } => Some(GeminiPart::FunctionCall {
+                name: name.clone(),
+                args: input.clone(),
+            }),
+            _ => None,
+        })
+        .collect();
+
+    let finish_reason = stop_reason_to_gemini(&resp.stop_reason).to_string();
+
+    GeminiResponse {
+        candidates: Some(vec![GeminiCandidate {
+            content: Some(GeminiContent {
+                role: Some("model".to_string()),
+                parts,
+            }),
+            finish_reason: Some(finish_reason),
+            safety_ratings: None,
+            index: Some(0),
+        }]),
+        usage_metadata: Some(GeminiUsageMetadata {
+            prompt_token_count: resp.usage.input_tokens,
+            candidates_token_count: resp.usage.output_tokens,
+            total_token_count: resp.usage.input_tokens + resp.usage.output_tokens,
+        }),
+        model_version: None,
+    }
+}
+
+/// Convert a CanonicalEvent into Gemini streaming JSON.
+/// Gemini streams by emitting GeminiResponse objects line by line.
+pub fn egress_event(event: &CanonicalEvent, model: &str) -> Vec<String> {
+    match event {
+        CanonicalEvent::TextDelta { text, .. } => {
+            let resp = serde_json::json!({
+                "candidates": [{
+                    "content": {
+                        "role": "model",
+                        "parts": [{ "text": text }]
+                    },
+                    "finishReason": null,
+                    "index": 0
+                }]
+            });
+            vec![serde_json::to_string(&resp).unwrap_or_default()]
+        }
+        CanonicalEvent::ContentBlockStart { block, .. } => {
+            if let ContentBlock::ToolUse { name, input, .. } = block {
+                let resp = serde_json::json!({
+                    "candidates": [{
+                        "content": {
+                            "role": "model",
+                            "parts": [{
+                                "functionCall": { "name": name, "args": input }
+                            }]
+                        },
+                        "index": 0
+                    }]
+                });
+                vec![serde_json::to_string(&resp).unwrap_or_default()]
+            } else {
+                vec![]
+            }
+        }
+        CanonicalEvent::StreamEnd { stop_reason, usage } => {
+            let fr = stop_reason_to_gemini(stop_reason);
+            let resp = serde_json::json!({
+                "candidates": [{
+                    "content": { "role": "model", "parts": [] },
+                    "finishReason": fr,
+                    "index": 0
+                }],
+                "usageMetadata": {
+                    "promptTokenCount": usage.input_tokens,
+                    "candidatesTokenCount": usage.output_tokens,
+                    "totalTokenCount": usage.input_tokens + usage.output_tokens
+                },
+                "modelVersion": model
+            });
+            vec![serde_json::to_string(&resp).unwrap_or_default()]
+        }
+        _ => vec![],
+    }
+}
+
+// ─── Provider-facing: Canonical → Gemini request ────────────────────────────
+
+/// Convert a CanonicalRequest into a GeminiRequest (to send TO a Gemini provider).
+pub fn egress_request(canonical: &CanonicalRequest) -> GeminiRequest {
+    let system_instruction = canonical.input.system.as_ref().map(|sys| {
+        let text = match sys {
+            SystemContent::Text(t) => t.clone(),
+            SystemContent::Blocks(blocks) => blocks
+                .iter()
+                .filter_map(|b| {
+                    if let ContentBlock::Text { text } = b {
+                        Some(text.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        };
+        GeminiContent {
+            role: None,
+            parts: vec![GeminiPart::Text(text)],
+        }
+    });
+
+    let contents: Vec<GeminiContent> = canonical
+        .input
+        .messages
+        .iter()
+        .map(|msg| {
+            let role = match msg.role {
+                Role::User | Role::Tool => Some("user".to_string()),
+                Role::Assistant => Some("model".to_string()),
+            };
+            let parts = msg
+                .content
+                .iter()
+                .filter_map(|block| match block {
+                    ContentBlock::Text { text } => Some(GeminiPart::Text(text.clone())),
+                    ContentBlock::Image { source } => {
+                        if let ImageSource::Base64 { media_type, data } = source {
+                            Some(GeminiPart::InlineData {
+                                mime_type: media_type.clone(),
+                                data: data.clone(),
+                            })
+                        } else {
+                            None
+                        }
+                    }
+                    ContentBlock::ToolUse { name, input, .. } => Some(GeminiPart::FunctionCall {
+                        name: name.clone(),
+                        args: input.clone(),
+                    }),
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => {
+                        let response = content
+                            .iter()
+                            .find_map(|c| {
+                                if let ContentBlock::Text { text } = c {
+                                    serde_json::from_str(text).ok()
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or(serde_json::Value::Null);
+                        // Extract function name from tool_use_id (format: "call_{name}")
+                        let name = tool_use_id
+                            .strip_prefix("call_")
+                            .unwrap_or(tool_use_id)
+                            .to_string();
+                        Some(GeminiPart::FunctionResponse { name, response })
+                    }
+                    _ => None,
+                })
+                .collect();
+            GeminiContent { role, parts }
+        })
+        .collect();
+
+    let tools = if canonical.tools.is_empty() {
+        None
+    } else {
+        Some(vec![GeminiToolDeclaration {
+            function_declarations: canonical
+                .tools
+                .iter()
+                .map(|t| GeminiFunctionDeclaration {
+                    name: t.name.clone(),
+                    description: t.description.clone().unwrap_or_default(),
+                    parameters: if t.parameters.is_null() {
+                        None
+                    } else {
+                        Some(t.parameters.clone())
+                    },
+                })
+                .collect(),
+        }])
+    };
+
+    let generation_config = Some(GenerationConfig {
+        temperature: canonical.limits.temperature,
+        top_p: canonical.limits.top_p,
+        top_k: canonical.limits.top_k,
+        max_output_tokens: canonical.limits.max_tokens,
+        stop_sequences: if canonical.limits.stop.is_empty() {
+            None
+        } else {
+            Some(canonical.limits.stop.clone())
+        },
+        candidate_count: None,
+        response_mime_type: match &canonical.response_format {
+            ResponseFormat::JsonObject | ResponseFormat::JsonSchema { .. } => {
+                Some("application/json".to_string())
+            }
+            _ => None,
+        },
+    });
+
+    GeminiRequest {
+        contents,
+        system_instruction,
+        generation_config,
+        tools,
+        safety_settings: None,
+    }
+}
+
+// ─── Provider-facing: Gemini response → Canonical ───────────────────────────
+
+/// Parse a Gemini API response into a CanonicalResponse.
+pub fn parse_response(
+    data: &[u8],
+    provider: &str,
+    credential: &str,
+) -> Result<CanonicalResponse, String> {
+    let resp: GeminiResponse = serde_json::from_slice(data)
+        .map_err(|e| format!("failed to parse Gemini response: {e}"))?;
+
+    let candidate = resp.candidates.as_ref().and_then(|c| c.first());
+
+    let content: Vec<ContentBlock> = candidate
+        .and_then(|c| c.content.as_ref())
+        .map(|c| {
+            c.parts
+                .iter()
+                .filter_map(|part| match part {
+                    GeminiPart::Text(text) => Some(ContentBlock::Text { text: text.clone() }),
+                    GeminiPart::FunctionCall { name, args } => Some(ContentBlock::ToolUse {
+                        id: format!("call_{name}"),
+                        name: name.clone(),
+                        input: args.clone(),
+                    }),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let stop_reason = gemini_to_stop_reason(candidate.and_then(|c| c.finish_reason.as_deref()));
+
+    let usage = resp
+        .usage_metadata
+        .map(|u| Usage {
+            input_tokens: u.prompt_token_count,
+            output_tokens: u.candidates_token_count,
+            ..Default::default()
+        })
+        .unwrap_or_default();
+
+    let model = resp.model_version.unwrap_or_default();
+
+    Ok(CanonicalResponse {
+        id: String::new(),
+        model,
+        content,
+        stop_reason,
+        usage,
+        execution_mode: prism_domain::operation::ExecutionMode::Native,
+        provider: provider.to_string(),
+        credential: credential.to_string(),
+    })
+}
+
+/// Parse a Gemini streaming JSON line into a CanonicalEvent.
+pub fn parse_event(data: &str) -> Option<CanonicalEvent> {
+    let v: serde_json::Value = serde_json::from_str(data).ok()?;
+    let candidates = v.get("candidates")?.as_array()?;
+    let candidate = candidates.first()?;
+
+    // Finish event
+    if let Some(fr) = candidate.get("finishReason").and_then(|f| f.as_str()) {
+        let stop_reason = gemini_to_stop_reason(Some(fr));
+        let usage = v
+            .get("usageMetadata")
+            .map(|u| Usage {
+                input_tokens: u
+                    .get("promptTokenCount")
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0),
+                output_tokens: u
+                    .get("candidatesTokenCount")
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0),
+                ..Default::default()
+            })
+            .unwrap_or_default();
+        return Some(CanonicalEvent::StreamEnd { stop_reason, usage });
+    }
+
+    // Content delta
+    let content = candidate.get("content")?;
+    let parts = content.get("parts")?.as_array()?;
+
+    for part in parts {
+        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+            return Some(CanonicalEvent::TextDelta {
+                index: 0,
+                text: text.to_string(),
+            });
+        }
+        if let Some(fc) = part.get("functionCall") {
+            let name = fc.get("name")?.as_str()?.to_string();
+            let args = fc.get("args").cloned().unwrap_or(serde_json::Value::Null);
+            return Some(CanonicalEvent::ContentBlockStart {
+                index: 0,
+                block: ContentBlock::ToolUse {
+                    id: format!("call_{name}"),
+                    name,
+                    input: args,
+                },
+            });
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prism_domain::response::Usage;
+
+    fn minimal_gemini_request() -> GeminiRequest {
+        GeminiRequest {
+            contents: vec![GeminiContent {
+                role: Some("user".to_string()),
+                parts: vec![GeminiPart::Text("Hello".to_string())],
+            }],
+            system_instruction: None,
+            generation_config: None,
+            tools: None,
+            safety_settings: None,
+        }
+    }
+
+    #[test]
+    fn test_ingress_basic() {
+        let req = minimal_gemini_request();
+        let canonical = ingress_generate(&req, "gemini-pro", Endpoint::GenerateContent);
+        assert_eq!(canonical.model, "gemini-pro");
+        assert!(!canonical.stream);
+        assert_eq!(canonical.input.messages.len(), 1);
+        assert_eq!(canonical.input.messages[0].role, Role::User);
+    }
+
+    #[test]
+    fn test_ingress_with_system() {
+        let req = GeminiRequest {
+            system_instruction: Some(GeminiContent {
+                role: None,
+                parts: vec![GeminiPart::Text("You are helpful".to_string())],
+            }),
+            ..minimal_gemini_request()
+        };
+        let canonical = ingress_generate(&req, "gemini-pro", Endpoint::GenerateContent);
+        assert!(canonical.input.system.is_some());
+    }
+
+    #[test]
+    fn test_ingress_stream_endpoint() {
+        let req = minimal_gemini_request();
+        let canonical = ingress_generate(&req, "gemini-pro", Endpoint::StreamGenerateContent);
+        assert!(canonical.stream);
+    }
+
+    #[test]
+    fn test_ingress_with_tools() {
+        let req = GeminiRequest {
+            tools: Some(vec![GeminiToolDeclaration {
+                function_declarations: vec![GeminiFunctionDeclaration {
+                    name: "get_weather".to_string(),
+                    description: "Get weather".to_string(),
+                    parameters: Some(serde_json::json!({"type": "object"})),
+                }],
+            }]),
+            ..minimal_gemini_request()
+        };
+        let canonical = ingress_generate(&req, "gemini-pro", Endpoint::GenerateContent);
+        assert_eq!(canonical.tools.len(), 1);
+        assert_eq!(canonical.tools[0].name, "get_weather");
+    }
+
+    #[test]
+    fn test_egress_response() {
+        let canonical = CanonicalResponse {
+            id: "resp-1".to_string(),
+            model: "gemini-pro".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Hello!".to_string(),
+            }],
+            stop_reason: StopReason::EndTurn,
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                ..Default::default()
+            },
+            execution_mode: prism_domain::operation::ExecutionMode::Native,
+            provider: "gemini".to_string(),
+            credential: "cred-1".to_string(),
+        };
+        let resp = egress_response(&canonical);
+        let candidates = resp.candidates.unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].finish_reason, Some("STOP".to_string()));
+    }
+
+    #[test]
+    fn test_egress_stream_text() {
+        let events = egress_event(
+            &CanonicalEvent::TextDelta {
+                index: 0,
+                text: "Hi".to_string(),
+            },
+            "gemini-pro",
+        );
+        assert_eq!(events.len(), 1);
+        let json: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+        assert_eq!(
+            json["candidates"][0]["content"]["parts"][0]["text"]
+                .as_str()
+                .unwrap(),
+            "Hi"
+        );
+    }
+
+    // ── Provider-facing tests ──
+
+    #[test]
+    fn test_egress_request_basic() {
+        let canonical = ingress_generate(
+            &minimal_gemini_request(),
+            "gemini-pro",
+            Endpoint::GenerateContent,
+        );
+        let wire = egress_request(&canonical);
+        assert_eq!(wire.contents.len(), 1);
+        assert_eq!(wire.contents[0].role.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn test_egress_request_with_system() {
+        let req = GeminiRequest {
+            system_instruction: Some(GeminiContent {
+                role: None,
+                parts: vec![GeminiPart::Text("Be helpful".to_string())],
+            }),
+            ..minimal_gemini_request()
+        };
+        let canonical = ingress_generate(&req, "gemini-pro", Endpoint::GenerateContent);
+        let wire = egress_request(&canonical);
+        assert!(wire.system_instruction.is_some());
+    }
+
+    #[test]
+    fn test_parse_response_basic() {
+        let wire_resp = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "role": "model",
+                    "parts": [{"text": "Hello!"}]
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15
+            }
+        });
+        let data = serde_json::to_vec(&wire_resp).unwrap();
+        let canonical = parse_response(&data, "gemini", "cred-1").unwrap();
+        assert_eq!(canonical.content.len(), 1);
+        assert_eq!(canonical.stop_reason, StopReason::EndTurn);
+        assert_eq!(canonical.usage.input_tokens, 10);
+    }
+
+    #[test]
+    fn test_parse_event_text() {
+        let data = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]},"finishReason":null,"index":0}]}"#;
+        let event = parse_event(data).unwrap();
+        assert!(matches!(event, CanonicalEvent::TextDelta { text, .. } if text == "Hi"));
+    }
+
+    #[test]
+    fn test_parse_event_finish() {
+        let data = r#"{"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#;
+        let event = parse_event(data).unwrap();
+        if let CanonicalEvent::StreamEnd { stop_reason, usage } = event {
+            assert_eq!(stop_reason, StopReason::EndTurn);
+            assert_eq!(usage.input_tokens, 10);
+        } else {
+            panic!("expected StreamEnd");
+        }
+    }
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod claude;
+pub mod gemini;
+pub mod openai;

--- a/crates/protocol/src/openai.rs
+++ b/crates/protocol/src/openai.rs
@@ -1,0 +1,938 @@
+use prism_domain::content::{
+    ContentBlock, Conversation, ImageSource, Message, Role, SystemContent,
+};
+use prism_domain::event::CanonicalEvent;
+use prism_domain::operation::Endpoint;
+use prism_domain::request::{CanonicalRequest, ReasoningConfig, RequestLimits};
+use prism_domain::response::{CanonicalResponse, StopReason, Usage};
+use prism_domain::tool::{ResponseFormat, ToolChoice, ToolSpec};
+use prism_types::types::openai::*;
+
+// ─── Ingress: OpenAI → Canonical ────────────────────────────────────────────
+
+/// Parse an OpenAI ChatCompletionRequest into a CanonicalRequest.
+pub fn ingress_chat(req: &ChatCompletionRequest, endpoint: Endpoint) -> CanonicalRequest {
+    let system = extract_system(&req.messages);
+    let messages = convert_messages(&req.messages);
+    let tools = convert_tools(&req.tools);
+    let tool_choice = convert_tool_choice(&req.tool_choice);
+    let response_format = convert_response_format(&req.response_format);
+    let reasoning = extract_reasoning(req);
+    let stop = match &req.stop {
+        Some(StopSequence::Single(s)) => vec![s.clone()],
+        Some(StopSequence::Multiple(v)) => v.clone(),
+        None => vec![],
+    };
+
+    CanonicalRequest {
+        ingress_protocol: prism_domain::operation::IngressProtocol::OpenAi,
+        operation: endpoint.operation(),
+        endpoint,
+        model: req.model.clone(),
+        stream: req.stream.unwrap_or(false),
+        input: Conversation { system, messages },
+        tools,
+        tool_choice,
+        response_format,
+        reasoning,
+        limits: RequestLimits {
+            max_tokens: req.max_completion_tokens.or(req.max_tokens),
+            temperature: req.temperature,
+            top_p: req.top_p,
+            top_k: None,
+            stop,
+        },
+        tenant_id: None,
+        api_key_id: None,
+        region: None,
+        raw_body: None,
+    }
+}
+
+fn extract_system(messages: &[ChatMessage]) -> Option<SystemContent> {
+    messages
+        .iter()
+        .find(|m| m.role == "system")
+        .map(|m| match &m.content {
+            Some(MessageContent::Text(t)) => SystemContent::Text(t.clone()),
+            _ => SystemContent::Text(String::new()),
+        })
+}
+
+fn convert_messages(messages: &[ChatMessage]) -> Vec<Message> {
+    messages
+        .iter()
+        .filter(|m| m.role != "system")
+        .map(|m| {
+            let role = match m.role.as_str() {
+                "assistant" => Role::Assistant,
+                "tool" | "function" => Role::Tool,
+                _ => Role::User,
+            };
+
+            let content = match &m.content {
+                Some(MessageContent::Text(t)) => vec![ContentBlock::Text { text: t.clone() }],
+                Some(MessageContent::Parts(parts)) => parts.iter().map(convert_part).collect(),
+                None => vec![],
+            };
+
+            // Add tool calls if present
+            let mut blocks = content;
+            if let Some(tool_calls) = &m.tool_calls {
+                for tc in tool_calls {
+                    let input: serde_json::Value =
+                        serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+                    blocks.push(ContentBlock::ToolUse {
+                        id: tc.id.clone(),
+                        name: tc.function.name.clone(),
+                        input,
+                    });
+                }
+            }
+
+            // Tool result
+            if role == Role::Tool
+                && let Some(ref tool_call_id) = m.tool_call_id
+            {
+                let inner = std::mem::take(&mut blocks);
+                blocks = vec![ContentBlock::ToolResult {
+                    tool_use_id: tool_call_id.clone(),
+                    content: inner,
+                    is_error: false,
+                }];
+            }
+
+            Message {
+                role,
+                content: blocks,
+                name: m.name.clone(),
+            }
+        })
+        .collect()
+}
+
+fn convert_part(part: &ContentPart) -> ContentBlock {
+    match part {
+        ContentPart::Text { text } => ContentBlock::Text { text: text.clone() },
+        ContentPart::ImageUrl { image_url } => ContentBlock::Image {
+            source: ImageSource::Url {
+                url: image_url.url.clone(),
+            },
+        },
+    }
+}
+
+fn convert_tools(tools: &Option<Vec<Tool>>) -> Vec<ToolSpec> {
+    tools
+        .as_ref()
+        .map(|ts| {
+            ts.iter()
+                .map(|t| ToolSpec {
+                    name: t.function.name.clone(),
+                    description: t.function.description.clone(),
+                    parameters: t.function.parameters.clone().unwrap_or_default(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn convert_tool_choice(tc: &Option<serde_json::Value>) -> ToolChoice {
+    match tc {
+        None => ToolChoice::Auto,
+        Some(v) if v.is_string() => match v.as_str().unwrap_or("auto") {
+            "none" => ToolChoice::None,
+            "required" => ToolChoice::Required,
+            _ => ToolChoice::Auto,
+        },
+        Some(v) => {
+            if let Some(name) = v
+                .get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+            {
+                ToolChoice::Tool {
+                    name: name.to_string(),
+                }
+            } else {
+                ToolChoice::Auto
+            }
+        }
+    }
+}
+
+fn convert_response_format(rf: &Option<serde_json::Value>) -> ResponseFormat {
+    match rf {
+        None => ResponseFormat::Text,
+        Some(v) => match v.get("type").and_then(|t| t.as_str()) {
+            Some("json_schema") => {
+                let schema = v.get("json_schema").and_then(|s| s.get("schema")).cloned();
+                let name = v
+                    .get("json_schema")
+                    .and_then(|s| s.get("name"))
+                    .and_then(|n| n.as_str())
+                    .map(String::from);
+                let strict = v
+                    .get("json_schema")
+                    .and_then(|s| s.get("strict"))
+                    .and_then(|s| s.as_bool())
+                    .unwrap_or(false);
+                ResponseFormat::JsonSchema {
+                    schema,
+                    name,
+                    strict,
+                }
+            }
+            Some("json_object") => ResponseFormat::JsonObject,
+            _ => ResponseFormat::Text,
+        },
+    }
+}
+
+fn extract_reasoning(req: &ChatCompletionRequest) -> Option<ReasoningConfig> {
+    req.extra
+        .get("reasoning_effort")
+        .map(|effort| ReasoningConfig {
+            enabled: true,
+            budget_tokens: None,
+            effort: effort.as_str().map(String::from),
+        })
+}
+
+fn stop_reason_to_openai(reason: &StopReason) -> &'static str {
+    match reason {
+        StopReason::EndTurn | StopReason::StopSequence => "stop",
+        StopReason::MaxTokens => "length",
+        StopReason::ToolUse => "tool_calls",
+    }
+}
+
+fn openai_to_stop_reason(s: Option<&str>) -> StopReason {
+    match s {
+        Some("stop") => StopReason::EndTurn,
+        Some("length") => StopReason::MaxTokens,
+        Some("tool_calls") => StopReason::ToolUse,
+        _ => StopReason::EndTurn,
+    }
+}
+
+// ─── Egress: Canonical → OpenAI ─────────────────────────────────────────────
+
+/// Convert a CanonicalResponse into an OpenAI ChatCompletionResponse.
+pub fn egress_response(resp: &CanonicalResponse) -> ChatCompletionResponse {
+    let mut message_content = String::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+
+    for block in &resp.content {
+        match block {
+            ContentBlock::Text { text } => {
+                if !message_content.is_empty() {
+                    message_content.push('\n');
+                }
+                message_content.push_str(text);
+            }
+            ContentBlock::ToolUse { id, name, input } => {
+                tool_calls.push(ToolCall {
+                    id: id.clone(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: name.clone(),
+                        arguments: serde_json::to_string(input).unwrap_or_default(),
+                    },
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let finish_reason = stop_reason_to_openai(&resp.stop_reason).to_string();
+
+    ChatCompletionResponse {
+        id: resp.id.clone(),
+        object: "chat.completion".to_string(),
+        created: chrono_now_secs(),
+        model: resp.model.clone(),
+        choices: vec![Choice {
+            index: 0,
+            message: ChatMessage {
+                role: "assistant".to_string(),
+                content: if message_content.is_empty() {
+                    None
+                } else {
+                    Some(MessageContent::Text(message_content))
+                },
+                name: None,
+                tool_calls: if tool_calls.is_empty() {
+                    None
+                } else {
+                    Some(tool_calls)
+                },
+                tool_call_id: None,
+                extra: Default::default(),
+            },
+            finish_reason: Some(finish_reason),
+        }],
+        usage: Some(openai_usage(&resp.usage)),
+        system_fingerprint: None,
+    }
+}
+
+/// Convert a CanonicalEvent into OpenAI SSE chunk JSON lines.
+pub fn egress_event(event: &CanonicalEvent, model: &str) -> Vec<String> {
+    match event {
+        CanonicalEvent::StreamStart { id, .. } => {
+            let chunk = serde_json::json!({
+                "id": id,
+                "object": "chat.completion.chunk",
+                "created": chrono_now_secs(),
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": { "role": "assistant", "content": "" },
+                    "finish_reason": null
+                }]
+            });
+            vec![serde_json::to_string(&chunk).unwrap_or_default()]
+        }
+        CanonicalEvent::TextDelta { text, .. } => {
+            let chunk = serde_json::json!({
+                "id": "",
+                "object": "chat.completion.chunk",
+                "created": chrono_now_secs(),
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": { "content": text },
+                    "finish_reason": null
+                }]
+            });
+            vec![serde_json::to_string(&chunk).unwrap_or_default()]
+        }
+        CanonicalEvent::ToolInputDelta {
+            index,
+            partial_json,
+        } => {
+            let chunk = serde_json::json!({
+                "id": "",
+                "object": "chat.completion.chunk",
+                "created": chrono_now_secs(),
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": index,
+                            "function": { "arguments": partial_json }
+                        }]
+                    },
+                    "finish_reason": null
+                }]
+            });
+            vec![serde_json::to_string(&chunk).unwrap_or_default()]
+        }
+        CanonicalEvent::ContentBlockStart { index, block } => {
+            if let ContentBlock::ToolUse { id, name, .. } = block {
+                let chunk = serde_json::json!({
+                    "id": "",
+                    "object": "chat.completion.chunk",
+                    "created": chrono_now_secs(),
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [{
+                                "index": index,
+                                "id": id,
+                                "type": "function",
+                                "function": { "name": name, "arguments": "" }
+                            }]
+                        },
+                        "finish_reason": null
+                    }]
+                });
+                vec![serde_json::to_string(&chunk).unwrap_or_default()]
+            } else {
+                vec![]
+            }
+        }
+        CanonicalEvent::StreamEnd { stop_reason, usage } => {
+            let finish_reason = stop_reason_to_openai(stop_reason);
+            let chunk = serde_json::json!({
+                "id": "",
+                "object": "chat.completion.chunk",
+                "created": chrono_now_secs(),
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": finish_reason
+                }],
+                "usage": {
+                    "prompt_tokens": usage.input_tokens,
+                    "completion_tokens": usage.output_tokens,
+                    "total_tokens": usage.input_tokens + usage.output_tokens
+                }
+            });
+            vec![serde_json::to_string(&chunk).unwrap_or_default()]
+        }
+        CanonicalEvent::Ping | CanonicalEvent::ContentBlockStop { .. } => vec![],
+        CanonicalEvent::ThinkingDelta { .. } => vec![],
+    }
+}
+
+fn openai_usage(usage: &Usage) -> prism_types::types::openai::Usage {
+    prism_types::types::openai::Usage {
+        prompt_tokens: usage.input_tokens,
+        completion_tokens: usage.output_tokens,
+        total_tokens: usage.input_tokens + usage.output_tokens,
+        prompt_tokens_details: None,
+        completion_tokens_details: None,
+    }
+}
+
+fn chrono_now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+// ─── Provider-facing: Canonical → OpenAI request ────────────────────────────
+
+/// Convert a CanonicalRequest into an OpenAI ChatCompletionRequest (to send TO an OpenAI provider).
+pub fn egress_request(canonical: &CanonicalRequest) -> ChatCompletionRequest {
+    let mut messages = Vec::new();
+
+    // System message
+    if let Some(ref sys) = canonical.input.system {
+        let text = match sys {
+            SystemContent::Text(t) => t.clone(),
+            SystemContent::Blocks(blocks) => blocks
+                .iter()
+                .filter_map(|b| {
+                    if let ContentBlock::Text { text } = b {
+                        Some(text.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        };
+        messages.push(ChatMessage {
+            role: "system".to_string(),
+            content: Some(MessageContent::Text(text)),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+            extra: Default::default(),
+        });
+    }
+
+    for msg in &canonical.input.messages {
+        messages.push(canonical_msg_to_openai(msg));
+    }
+
+    let tools = if canonical.tools.is_empty() {
+        None
+    } else {
+        Some(
+            canonical
+                .tools
+                .iter()
+                .map(|t| Tool {
+                    tool_type: "function".to_string(),
+                    function: FunctionDef {
+                        name: t.name.clone(),
+                        description: t.description.clone(),
+                        parameters: Some(t.parameters.clone()),
+                    },
+                })
+                .collect(),
+        )
+    };
+
+    let tool_choice = match &canonical.tool_choice {
+        ToolChoice::Auto => None,
+        ToolChoice::None => Some(serde_json::json!("none")),
+        ToolChoice::Required => Some(serde_json::json!("required")),
+        ToolChoice::Tool { name } => {
+            Some(serde_json::json!({"type": "function", "function": {"name": name}}))
+        }
+    };
+
+    let stop = if canonical.limits.stop.is_empty() {
+        None
+    } else if canonical.limits.stop.len() == 1 {
+        Some(StopSequence::Single(canonical.limits.stop[0].clone()))
+    } else {
+        Some(StopSequence::Multiple(canonical.limits.stop.clone()))
+    };
+
+    let has_reasoning = canonical.reasoning.as_ref().is_some_and(|r| r.enabled);
+
+    ChatCompletionRequest {
+        model: canonical.model.clone(),
+        messages,
+        temperature: canonical.limits.temperature,
+        top_p: canonical.limits.top_p,
+        n: None,
+        stream: Some(canonical.stream),
+        stop,
+        max_tokens: if has_reasoning {
+            None
+        } else {
+            canonical.limits.max_tokens
+        },
+        max_completion_tokens: if has_reasoning {
+            canonical.limits.max_tokens
+        } else {
+            None
+        },
+        presence_penalty: None,
+        frequency_penalty: None,
+        user: None,
+        tools,
+        tool_choice,
+        response_format: None,
+        extra: Default::default(),
+    }
+}
+
+fn canonical_msg_to_openai(msg: &Message) -> ChatMessage {
+    let role = match msg.role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+        Role::Tool => "tool",
+    };
+
+    let mut text_parts = Vec::new();
+    let mut tool_calls_vec = Vec::new();
+    let mut tool_call_id = None;
+    let mut has_image = false;
+    let mut content_parts = Vec::new();
+
+    for block in &msg.content {
+        match block {
+            ContentBlock::Text { text } => {
+                text_parts.push(text.clone());
+                content_parts.push(ContentPart::Text { text: text.clone() });
+            }
+            ContentBlock::Image { source } => {
+                has_image = true;
+                let url = match source {
+                    ImageSource::Url { url } => url.clone(),
+                    ImageSource::Base64 {
+                        media_type, data, ..
+                    } => format!("data:{media_type};base64,{data}"),
+                };
+                content_parts.push(ContentPart::ImageUrl {
+                    image_url: ImageUrl { url, detail: None },
+                });
+            }
+            ContentBlock::ToolUse { id, name, input } => {
+                tool_calls_vec.push(ToolCall {
+                    id: id.clone(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: name.clone(),
+                        arguments: serde_json::to_string(input).unwrap_or_default(),
+                    },
+                });
+            }
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => {
+                tool_call_id = Some(tool_use_id.clone());
+                for c in content {
+                    if let ContentBlock::Text { text } = c {
+                        text_parts.push(text.clone());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let content = if has_image {
+        Some(MessageContent::Parts(content_parts))
+    } else if !text_parts.is_empty() {
+        Some(MessageContent::Text(text_parts.join("")))
+    } else {
+        None
+    };
+
+    ChatMessage {
+        role: role.to_string(),
+        content,
+        name: msg.name.clone(),
+        tool_calls: if tool_calls_vec.is_empty() {
+            None
+        } else {
+            Some(tool_calls_vec)
+        },
+        tool_call_id,
+        extra: Default::default(),
+    }
+}
+
+// ─── Provider-facing: OpenAI response → Canonical ───────────────────────────
+
+/// Parse an OpenAI ChatCompletionResponse into a CanonicalResponse.
+pub fn parse_response(
+    data: &[u8],
+    provider: &str,
+    credential: &str,
+) -> Result<CanonicalResponse, String> {
+    let resp: ChatCompletionResponse = serde_json::from_slice(data)
+        .map_err(|e| format!("failed to parse OpenAI response: {e}"))?;
+
+    let choice = resp.choices.first();
+    let mut content = Vec::new();
+
+    if let Some(choice) = choice {
+        if let Some(MessageContent::Text(ref text)) = choice.message.content
+            && !text.is_empty()
+        {
+            content.push(ContentBlock::Text { text: text.clone() });
+        }
+        if let Some(ref tool_calls) = choice.message.tool_calls {
+            for tc in tool_calls {
+                let input = serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+                content.push(ContentBlock::ToolUse {
+                    id: tc.id.clone(),
+                    name: tc.function.name.clone(),
+                    input,
+                });
+            }
+        }
+    }
+
+    let stop_reason = openai_to_stop_reason(choice.and_then(|c| c.finish_reason.as_deref()));
+
+    let usage = resp
+        .usage
+        .map(|u| Usage {
+            input_tokens: u.prompt_tokens,
+            output_tokens: u.completion_tokens,
+            ..Default::default()
+        })
+        .unwrap_or_default();
+
+    Ok(CanonicalResponse {
+        id: resp.id,
+        model: resp.model,
+        content,
+        stop_reason,
+        usage,
+        execution_mode: prism_domain::operation::ExecutionMode::Native,
+        provider: provider.to_string(),
+        credential: credential.to_string(),
+    })
+}
+
+/// Parse an OpenAI SSE data line into a CanonicalEvent.
+pub fn parse_event(data: &str) -> Option<CanonicalEvent> {
+    if data == "[DONE]" {
+        return None;
+    }
+
+    let v: serde_json::Value = serde_json::from_str(data).ok()?;
+    let choices = v.get("choices")?.as_array()?;
+    let choice = choices.first()?;
+    let delta = choice.get("delta")?;
+    let finish = choice.get("finish_reason");
+
+    // Finish event
+    if let Some(fr) = finish.and_then(|f| f.as_str()) {
+        let stop_reason = openai_to_stop_reason(Some(fr));
+        let usage = v
+            .get("usage")
+            .map(|u| Usage {
+                input_tokens: u.get("prompt_tokens").and_then(|t| t.as_u64()).unwrap_or(0),
+                output_tokens: u
+                    .get("completion_tokens")
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0),
+                ..Default::default()
+            })
+            .unwrap_or_default();
+        return Some(CanonicalEvent::StreamEnd { stop_reason, usage });
+    }
+
+    // Role delta = stream start
+    if delta.get("role").is_some() {
+        let id = v
+            .get("id")
+            .and_then(|i| i.as_str())
+            .unwrap_or("")
+            .to_string();
+        let model = v
+            .get("model")
+            .and_then(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        return Some(CanonicalEvent::StreamStart { id, model });
+    }
+
+    // Content delta
+    if let Some(text) = delta.get("content").and_then(|c| c.as_str()) {
+        return Some(CanonicalEvent::TextDelta {
+            index: 0,
+            text: text.to_string(),
+        });
+    }
+
+    // Tool call delta
+    if let Some(tool_calls) = delta.get("tool_calls").and_then(|tc| tc.as_array())
+        && let Some(tc) = tool_calls.first()
+    {
+        let index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
+        if let Some(func) = tc.get("function") {
+            if let Some(name) = func.get("name").and_then(|n| n.as_str()) {
+                let id = tc
+                    .get("id")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                return Some(CanonicalEvent::ContentBlockStart {
+                    index,
+                    block: ContentBlock::ToolUse {
+                        id,
+                        name: name.to_string(),
+                        input: serde_json::Value::Null,
+                    },
+                });
+            }
+            if let Some(args) = func.get("arguments").and_then(|a| a.as_str()) {
+                return Some(CanonicalEvent::ToolInputDelta {
+                    index,
+                    partial_json: args.to_string(),
+                });
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_chat_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: Some(MessageContent::Text("Hello".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                extra: Default::default(),
+            }],
+            temperature: None,
+            top_p: None,
+            n: None,
+            stream: Some(false),
+            stop: None,
+            max_tokens: Some(100),
+            max_completion_tokens: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            user: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn test_ingress_basic() {
+        let req = minimal_chat_request();
+        let canonical = ingress_chat(&req, Endpoint::ChatCompletions);
+        assert_eq!(canonical.model, "gpt-4");
+        assert!(!canonical.stream);
+        assert_eq!(canonical.limits.max_tokens, Some(100));
+        assert_eq!(canonical.input.messages.len(), 1);
+        assert_eq!(canonical.input.messages[0].role, Role::User);
+    }
+
+    #[test]
+    fn test_ingress_with_system() {
+        let req = ChatCompletionRequest {
+            messages: vec![
+                ChatMessage {
+                    role: "system".to_string(),
+                    content: Some(MessageContent::Text("You are helpful".to_string())),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                    extra: Default::default(),
+                },
+                ChatMessage {
+                    role: "user".to_string(),
+                    content: Some(MessageContent::Text("Hi".to_string())),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                    extra: Default::default(),
+                },
+            ],
+            ..minimal_chat_request()
+        };
+        let canonical = ingress_chat(&req, Endpoint::ChatCompletions);
+        assert!(canonical.input.system.is_some());
+        // System messages are filtered from the messages list
+        assert_eq!(canonical.input.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_ingress_with_tools() {
+        let req = ChatCompletionRequest {
+            tools: Some(vec![Tool {
+                tool_type: "function".to_string(),
+                function: FunctionDef {
+                    name: "get_weather".to_string(),
+                    description: Some("Get weather".to_string()),
+                    parameters: Some(serde_json::json!({"type": "object"})),
+                },
+            }]),
+            ..minimal_chat_request()
+        };
+        let canonical = ingress_chat(&req, Endpoint::ChatCompletions);
+        assert_eq!(canonical.tools.len(), 1);
+        assert_eq!(canonical.tools[0].name, "get_weather");
+    }
+
+    #[test]
+    fn test_egress_response() {
+        let canonical = CanonicalResponse {
+            id: "resp-1".to_string(),
+            model: "gpt-4".to_string(),
+            content: vec![ContentBlock::Text {
+                text: "Hello!".to_string(),
+            }],
+            stop_reason: StopReason::EndTurn,
+            usage: Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                ..Default::default()
+            },
+            execution_mode: prism_domain::operation::ExecutionMode::Native,
+            provider: "openai".to_string(),
+            credential: "cred-1".to_string(),
+        };
+        let resp = egress_response(&canonical);
+        assert_eq!(resp.id, "resp-1");
+        assert_eq!(resp.choices.len(), 1);
+        assert_eq!(resp.choices[0].finish_reason, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_egress_stream_events() {
+        let events = egress_event(
+            &CanonicalEvent::TextDelta {
+                index: 0,
+                text: "Hi".to_string(),
+            },
+            "gpt-4",
+        );
+        assert_eq!(events.len(), 1);
+        let json: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+        assert_eq!(
+            json["choices"][0]["delta"]["content"].as_str().unwrap(),
+            "Hi"
+        );
+    }
+
+    // ── Provider-facing tests ──
+
+    #[test]
+    fn test_egress_request_basic() {
+        let canonical = ingress_chat(&minimal_chat_request(), Endpoint::ChatCompletions);
+        let wire = egress_request(&canonical);
+        assert_eq!(wire.model, "gpt-4");
+        assert_eq!(wire.messages.len(), 1);
+        assert_eq!(wire.messages[0].role, "user");
+    }
+
+    #[test]
+    fn test_egress_request_with_system() {
+        let mut req = minimal_chat_request();
+        req.messages.insert(
+            0,
+            ChatMessage {
+                role: "system".to_string(),
+                content: Some(MessageContent::Text("You are helpful".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                extra: Default::default(),
+            },
+        );
+        let canonical = ingress_chat(&req, Endpoint::ChatCompletions);
+        let wire = egress_request(&canonical);
+        // System is preserved as first message
+        assert_eq!(wire.messages[0].role, "system");
+        assert_eq!(wire.messages.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_response_basic() {
+        let wire_resp = serde_json::json!({
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 1700000000i64,
+            "model": "gpt-4",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello!"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15
+            }
+        });
+        let data = serde_json::to_vec(&wire_resp).unwrap();
+        let canonical = parse_response(&data, "openai", "cred-1").unwrap();
+        assert_eq!(canonical.id, "chatcmpl-1");
+        assert_eq!(canonical.model, "gpt-4");
+        assert_eq!(canonical.content.len(), 1);
+        assert_eq!(canonical.stop_reason, StopReason::EndTurn);
+        assert_eq!(canonical.usage.input_tokens, 10);
+        assert_eq!(canonical.usage.output_tokens, 5);
+    }
+
+    #[test]
+    fn test_parse_event_text_delta() {
+        let data = r#"{"id":"x","object":"chat.completion.chunk","created":0,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}"#;
+        let event = parse_event(data).unwrap();
+        assert!(matches!(event, CanonicalEvent::TextDelta { text, .. } if text == "Hi"));
+    }
+
+    #[test]
+    fn test_parse_event_done() {
+        assert!(parse_event("[DONE]").is_none());
+    }
+
+    #[test]
+    fn test_parse_event_finish() {
+        let data = r#"{"id":"x","object":"chat.completion.chunk","created":0,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"#;
+        let event = parse_event(data).unwrap();
+        if let CanonicalEvent::StreamEnd { stop_reason, usage } = event {
+            assert_eq!(stop_reason, StopReason::EndTurn);
+            assert_eq!(usage.input_tokens, 10);
+        } else {
+            panic!("expected StreamEnd");
+        }
+    }
+}

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+prism-domain = { workspace = true }
 prism-core = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/provider/src/catalog.rs
+++ b/crates/provider/src/catalog.rs
@@ -1,5 +1,6 @@
 use prism_core::provider::{AuthRecord, Format};
 use prism_core::routing::planner::{CredentialEntry, InventorySnapshot, ProviderEntry};
+use prism_domain::capability::default_capabilities_for_protocol;
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -32,26 +33,31 @@ impl ProviderCatalog {
         InventorySnapshot {
             providers: providers
                 .iter()
-                .map(|p| ProviderEntry {
-                    format: p.format,
-                    name: p.name.clone(),
-                    credentials: p
-                        .credentials
-                        .iter()
-                        .map(|c| CredentialEntry {
-                            id: c.record.id.clone(),
-                            name: c
-                                .record
-                                .credential_name
-                                .clone()
-                                .unwrap_or_else(|| c.record.id.clone()),
-                            models: c.record.models.iter().map(|m| m.id.clone()).collect(),
-                            excluded_models: c.record.excluded_models.clone(),
-                            region: c.record.region.clone(),
-                            weight: c.record.weight,
-                            disabled: c.record.disabled,
-                        })
-                        .collect(),
+                .map(|p| {
+                    let up = prism_core::provider::upstream_protocol(p.format);
+                    ProviderEntry {
+                        format: p.format,
+                        name: p.name.clone(),
+                        credentials: p
+                            .credentials
+                            .iter()
+                            .map(|c| CredentialEntry {
+                                id: c.record.id.clone(),
+                                name: c
+                                    .record
+                                    .credential_name
+                                    .clone()
+                                    .unwrap_or_else(|| c.record.id.clone()),
+                                models: c.record.models.iter().map(|m| m.id.clone()).collect(),
+                                excluded_models: c.record.excluded_models.clone(),
+                                region: c.record.region.clone(),
+                                weight: c.record.weight,
+                                disabled: c.record.disabled,
+                            })
+                            .collect(),
+                        capabilities: default_capabilities_for_protocol(up),
+                        upstream_protocol: up,
+                    }
                 })
                 .collect(),
         }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
+prism-domain = { workspace = true }
+prism-protocol = { workspace = true }
 prism-core = { workspace = true }
 prism-provider = { workspace = true }
 prism-translator = { workspace = true }

--- a/crates/server/src/dispatch/features.rs
+++ b/crates/server/src/dispatch/features.rs
@@ -20,6 +20,7 @@ pub(super) fn extract_features(req: &DispatchRequest) -> RouteRequestFeatures {
         region: req.client_region.clone(),
         stream: req.stream,
         headers: BTreeMap::new(),
+        required_capabilities: None,
     }
 }
 

--- a/crates/server/src/handler/dashboard/control_plane.rs
+++ b/crates/server/src/handler/dashboard/control_plane.rs
@@ -1,0 +1,256 @@
+use axum::Json;
+use axum::extract::State;
+use prism_domain::capability::{
+    ProviderCapabilities, UpstreamProtocol, default_capabilities_for_protocol,
+};
+use prism_domain::operation::{ExecutionMode, IngressProtocol, Operation};
+use prism_domain::request::{
+    ExplainFeatures, ExplainRequest, ExplainResponse, Rejection, RejectionReason, SelectedRoute,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+
+// ─── Protocol Matrix (#219) ────────────────────────────────────────────────
+
+/// GET /api/dashboard/protocols/matrix
+/// Returns which protocols, operations, and execution modes the gateway supports.
+pub async fn protocol_matrix(State(state): State<AppState>) -> Json<ProtocolMatrixResponse> {
+    let config = state.config.load();
+    let mut entries = Vec::new();
+
+    for provider in &config.providers {
+        let up = prism_core::provider::upstream_protocol(provider.format);
+        let caps = default_capabilities_for_protocol(up);
+
+        for protocol in [
+            IngressProtocol::OpenAi,
+            IngressProtocol::Claude,
+            IngressProtocol::Gemini,
+        ] {
+            let exec_mode = up.execution_mode_for(protocol);
+            entries.push(ProtocolMatrixEntry {
+                provider: provider.name.clone(),
+                ingress_protocol: protocol,
+                upstream_protocol: up,
+                execution_mode: exec_mode,
+                supports_generate: true,
+                supports_stream: caps.supports_stream,
+                supports_count_tokens: caps.supports_count_tokens,
+            });
+        }
+    }
+
+    Json(ProtocolMatrixResponse { entries })
+}
+
+/// GET /api/dashboard/providers/capabilities
+/// Returns capability declarations for all providers and their models.
+pub async fn provider_capabilities(
+    State(state): State<AppState>,
+) -> Json<ProviderCapabilitiesResponse> {
+    let config = state.config.load();
+    let mut providers = Vec::new();
+
+    for provider in &config.providers {
+        let up = prism_core::provider::upstream_protocol(provider.format);
+        let caps = default_capabilities_for_protocol(up);
+
+        let model_ids: Vec<String> = if provider.models.is_empty() {
+            vec!["*".to_string()]
+        } else {
+            provider.models.iter().map(|m| m.id.clone()).collect()
+        };
+
+        providers.push(ProviderCapabilityEntry {
+            name: provider.name.clone(),
+            upstream_protocol: up,
+            models: model_ids,
+            capabilities: caps,
+            disabled: provider.disabled,
+        });
+    }
+
+    Json(ProviderCapabilitiesResponse { providers })
+}
+
+// ─── Route Explain & Replay (#220) ─────────────────────────────────────────
+
+/// POST /api/dashboard/routing/explain
+/// Explain routing decisions without executing.
+pub async fn route_explain(
+    State(state): State<AppState>,
+    Json(req): Json<ExplainApiRequest>,
+) -> Json<ExplainResponse> {
+    let ingress = match req.ingress_protocol.as_str() {
+        "claude" => IngressProtocol::Claude,
+        "gemini" => IngressProtocol::Gemini,
+        _ => IngressProtocol::OpenAi,
+    };
+
+    let operation = match req.operation.as_str() {
+        "count_tokens" => Operation::CountTokens,
+        "list_models" => Operation::ListModels,
+        _ => Operation::Generate,
+    };
+
+    let endpoint = match ingress {
+        IngressProtocol::OpenAi => prism_domain::operation::Endpoint::ChatCompletions,
+        IngressProtocol::Claude => prism_domain::operation::Endpoint::Messages,
+        IngressProtocol::Gemini => prism_domain::operation::Endpoint::GenerateContent,
+    };
+
+    let explain_req = ExplainRequest {
+        ingress_protocol: ingress,
+        operation,
+        endpoint,
+        model: req.model.clone(),
+        stream: req.stream,
+        features: req.features.clone(),
+        tenant_id: req.tenant_id.clone(),
+        api_key_id: req.api_key_id.clone(),
+        region: req.region.clone(),
+    };
+
+    let required = explain_req.required_capabilities();
+
+    // Build inventory snapshot and run planner
+    let inventory = state.catalog.snapshot();
+    let health = state.health_manager.snapshot();
+    let config = state.config.load();
+
+    let features = prism_core::routing::types::RouteRequestFeatures {
+        requested_model: req.model.clone(),
+        endpoint: match ingress {
+            IngressProtocol::OpenAi => prism_core::routing::types::RouteEndpoint::ChatCompletions,
+            IngressProtocol::Claude => prism_core::routing::types::RouteEndpoint::Messages,
+            IngressProtocol::Gemini => prism_core::routing::types::RouteEndpoint::GenerateContent,
+        },
+        source_format: match ingress {
+            IngressProtocol::OpenAi => prism_core::provider::Format::OpenAI,
+            IngressProtocol::Claude => prism_core::provider::Format::Claude,
+            IngressProtocol::Gemini => prism_core::provider::Format::Gemini,
+        },
+        tenant_id: req.tenant_id,
+        api_key_id: req.api_key_id,
+        region: req.region,
+        stream: req.stream,
+        headers: Default::default(),
+        required_capabilities: Some(required.clone()),
+    };
+
+    let plan = prism_core::routing::planner::RoutePlanner::plan(
+        &features,
+        &config.routing,
+        &inventory,
+        &health,
+    );
+
+    // Convert plan to ExplainResponse
+    let to_selected = |a: &prism_core::routing::types::RouteAttemptPlan| SelectedRoute {
+        provider: a.credential_name.clone(),
+        credential: a.credential_id.clone(),
+        model: a.model.clone(),
+        execution_mode: a.execution_mode.unwrap_or(ExecutionMode::LosslessAdapted),
+    };
+
+    let selected = plan.attempts.first().map(&to_selected);
+
+    let alternates: Vec<SelectedRoute> = plan.attempts.iter().skip(1).map(to_selected).collect();
+
+    let rejections: Vec<Rejection> = plan
+        .trace
+        .rejections
+        .iter()
+        .map(|r| {
+            let reason = match &r.reason {
+                prism_core::routing::types::RejectReason::ModelNotSupported => {
+                    RejectionReason::ModelNotSupported {
+                        model: req.model.clone(),
+                    }
+                }
+                prism_core::routing::types::RejectReason::CircuitBreakerOpen => {
+                    RejectionReason::CircuitOpen
+                }
+                prism_core::routing::types::RejectReason::CredentialDisabled => {
+                    RejectionReason::Disabled
+                }
+                prism_core::routing::types::RejectReason::MissingCapability { capabilities } => {
+                    RejectionReason::MissingCapability {
+                        capability: capabilities.join(", "),
+                    }
+                }
+                _ => RejectionReason::CredentialUnavailable,
+            };
+            Rejection {
+                candidate: r.candidate.clone(),
+                reason,
+            }
+        })
+        .collect();
+
+    Json(ExplainResponse {
+        selected,
+        alternates,
+        rejections,
+        required_capabilities: required,
+    })
+}
+
+// ─── API Types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ProtocolMatrixResponse {
+    pub entries: Vec<ProtocolMatrixEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProtocolMatrixEntry {
+    pub provider: String,
+    pub ingress_protocol: IngressProtocol,
+    pub upstream_protocol: UpstreamProtocol,
+    pub execution_mode: ExecutionMode,
+    pub supports_generate: bool,
+    pub supports_stream: bool,
+    pub supports_count_tokens: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProviderCapabilitiesResponse {
+    pub providers: Vec<ProviderCapabilityEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProviderCapabilityEntry {
+    pub name: String,
+    pub upstream_protocol: UpstreamProtocol,
+    pub models: Vec<String>,
+    pub capabilities: ProviderCapabilities,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ExplainApiRequest {
+    #[serde(default = "default_openai")]
+    pub ingress_protocol: String,
+    #[serde(default = "default_generate")]
+    pub operation: String,
+    pub model: String,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub features: ExplainFeatures,
+    #[serde(default)]
+    pub tenant_id: Option<String>,
+    #[serde(default)]
+    pub api_key_id: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
+}
+
+fn default_openai() -> String {
+    "openai".to_string()
+}
+fn default_generate() -> String {
+    "generate".to_string()
+}

--- a/crates/server/src/handler/dashboard/mod.rs
+++ b/crates/server/src/handler/dashboard/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod auth_keys;
 pub mod config_ops;
+pub mod control_plane;
 pub mod logs;
 pub mod providers;
 pub mod routing;

--- a/crates/server/src/handler/dashboard/routing.rs
+++ b/crates/server/src/handler/dashboard/routing.rs
@@ -159,6 +159,7 @@ impl PreviewRequest {
             region: self.region,
             stream: self.stream,
             headers: self.headers,
+            required_capabilities: None,
         }
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -192,10 +192,6 @@ pub fn build_router(state: AppState) -> Router {
             "/api/dashboard/routing/preview",
             axum::routing::post(handler::dashboard::routing::preview_route),
         )
-        .route(
-            "/api/dashboard/routing/explain",
-            axum::routing::post(handler::dashboard::routing::explain_route),
-        )
         // Config operations
         .route(
             "/api/dashboard/config/validate",
@@ -251,6 +247,19 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/api/dashboard/tenants/{id}/metrics",
             axum::routing::get(handler::dashboard::tenant::tenant_metrics),
+        )
+        // Control Plane (SPEC-065)
+        .route(
+            "/api/dashboard/protocols/matrix",
+            axum::routing::get(handler::dashboard::control_plane::protocol_matrix),
+        )
+        .route(
+            "/api/dashboard/providers/capabilities",
+            axum::routing::get(handler::dashboard::control_plane::provider_capabilities),
+        )
+        .route(
+            "/api/dashboard/routing/explain",
+            axum::routing::post(handler::dashboard::control_plane::route_explain),
         )
         .layer(axum_mw::from_fn_with_state(
             state.clone(),

--- a/crates/server/tests/dashboard_tests.rs
+++ b/crates/server/tests/dashboard_tests.rs
@@ -1200,8 +1200,10 @@ async fn test_explain_route_empty_inventory() {
     );
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK, "explain failed: {body:?}");
-    assert_eq!(body["profile"], "balanced");
+    // New control-plane explain returns structured ExplainResponse
     assert!(body["selected"].is_null());
+    assert!(body["alternates"].as_array().unwrap().is_empty());
+    assert!(body["required_capabilities"].is_object());
 }
 
 #[tokio::test]
@@ -1267,7 +1269,7 @@ async fn test_preview_route_invalid_body() {
 }
 
 #[tokio::test]
-async fn test_explain_includes_scoring() {
+async fn test_explain_with_provider() {
     let harness = create_test_harness();
     let token = login_and_get_token(&harness).await;
 
@@ -1294,7 +1296,7 @@ async fn test_explain_includes_scoring() {
         .update_from_credentials(&harness.state.router.credential_map());
     harness.state.config.store(Arc::new(new_config));
 
-    // Explain should include scoring (not cleared like preview)
+    // Explain returns structured response with selected route and capabilities
     let req = authed_post(
         "/api/dashboard/routing/explain",
         &token,
@@ -1302,8 +1304,10 @@ async fn test_explain_includes_scoring() {
     );
     let (status, body) = send_request(&harness, req).await;
     assert_eq!(status, StatusCode::OK, "explain failed: {body:?}");
-    // scoring field should be present (may be empty if no candidates scored, but present)
-    assert!(body["scoring"].is_array());
+    // New control-plane explain returns required_capabilities and route info
+    assert!(body["required_capabilities"].is_object());
+    assert!(body["alternates"].is_array());
+    assert!(body["rejections"].is_array());
 }
 
 #[tokio::test]

--- a/docs/specs/_index.md
+++ b/docs/specs/_index.md
@@ -52,6 +52,7 @@ All specifications for the AI Proxy Gateway project.
 | SPEC-062 | Vertex AI Provider                             | Completed | [active/SPEC-062/](active/SPEC-062/) |
 | SPEC-063 | Unified Provider Configuration                 | Completed | [active/SPEC-063/](active/SPEC-063/) |
 | SPEC-064 | Upstream Presentation Layer                    | Draft     | [active/SPEC-064/](active/SPEC-064/) |
+| SPEC-065 | Canonical Multi-Protocol Gateway & Control Plane Redesign | Active | [active/SPEC-065/](active/SPEC-065/) |
 
 ## Retroactively Completed
 

--- a/docs/specs/active/SPEC-065/prd.md
+++ b/docs/specs/active/SPEC-065/prd.md
@@ -1,0 +1,88 @@
+# PRD: Canonical Multi-Protocol Gateway & Control Plane Redesign
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Spec ID   | SPEC-065                                           |
+| Title     | Canonical Multi-Protocol Gateway & Control Plane Redesign |
+| Author    | AI Agent                                           |
+| Status    | Draft                                              |
+| Created   | 2026-03-14                                         |
+| Updated   | 2026-03-14                                         |
+| Parent    | #211                                               |
+| Issues    | #212, #213, #214, #215, #216, #217, #218, #219, #220, #221, #222, #223, #224, #225, #226 |
+
+## Problem Statement
+
+Prism currently exposes multiple public protocols, but the implementation is not protocol-native end to end. The runtime is effectively centered on OpenAI Chat semantics, with Claude and Gemini support layered on through route-specific handling and protocol-to-protocol translation.
+
+This creates four structural problems:
+
+1. Public protocol support is not modeled as a first-class runtime concept.
+2. Routing is based mostly on model availability, not on request semantics and provider capabilities.
+3. Some endpoints bypass the main routing path, making preview, explain, retry, and execution behavior inconsistent.
+4. The dashboard is config-centric and provider-centric, but not protocol-centric or capability-centric, so it does not accurately explain what the gateway can do.
+
+The result is a system that can appear to support OpenAI, Claude, and Gemini equally, while the actual execution model is uneven and difficult to reason about.
+
+## Goals
+
+1. Support OpenAI, Claude, and Gemini as first-class public protocols.
+2. Replace protocol-to-protocol runtime chaining with a canonical internal request, response, and event model.
+3. Route requests based on explicit request semantics and provider/model capabilities, not just model strings.
+4. Ensure all public inference endpoints use one runtime pipeline for planning, explanation, retries, logging, metrics, and execution.
+5. Redesign the dashboard so it explains protocols, capabilities, routing, and runtime behavior clearly.
+6. Make the implementation easy to change in small, testable increments by Claude Code and similar coding agents.
+
+## Non-Goals
+
+- Backward compatibility with the current internal architecture.
+- Incremental migration constraints or compatibility shims for the old dispatch model.
+- Supporting every provider-specific edge case in v1 if it cannot be represented losslessly.
+- Preserving existing dashboard information architecture.
+
+## User Stories
+
+- As a gateway operator, I want to expose OpenAI, Claude, and Gemini APIs from one gateway and know that each public protocol is handled consistently.
+- As a gateway operator, I want routing decisions to account for tools, JSON schema, reasoning, multimodal input, streaming, and token counting support.
+- As a dashboard user, I want to see which protocols and operations are supported, by which providers and models, and why a route was selected or rejected.
+- As a developer, I want public protocol handling to be built around typed adapters and a canonical model so I can add or modify behavior without touching unrelated paths.
+- As an agent-driven contributor, I want work to be divisible into small issues with stable boundaries, clear fixtures, and predictable tests.
+
+## Success Metrics
+
+- All public inference endpoints are served by one canonical runtime pipeline.
+- Route explanation for a request matches actual runtime execution for that same request shape.
+- Provider selection rejects unsupported capability combinations before execution.
+- Protocol adapters are independently testable using golden fixtures.
+- Dashboard clearly exposes protocol matrix, capability matrix, route explanation, and request replay.
+- The redesign can be implemented through small issues, each completable in one PR with focused tests.
+
+## Constraints
+
+- Canonical runtime types must be protocol-agnostic and transport-agnostic.
+- Provider executors must not depend on public protocol DTOs.
+- Route planning must depend on declared capabilities, not implicit translator availability.
+- Lossy conversions are not allowed silently. Unsupported requests must fail explicitly with a structured reason.
+- Dashboard preview and explain must share the same backend planner and capability logic used by the runtime.
+
+## Open Questions
+
+- [x] Should one public protocol be preferred over the others?  
+  **Decision:** No. OpenAI, Claude, and Gemini are all first-class ingress protocols, but they normalize into one canonical model.
+- [x] Should protocol-specific endpoints be allowed to bypass the canonical runtime for performance?  
+  **Decision:** No. All public inference endpoints must use the same runtime pipeline. Operational consistency is more important than endpoint-local optimizations.
+- [x] Should lossy provider fallback be allowed for partially supported features?  
+  **Decision:** No. The planner may only choose `native` or `lossless` execution modes. Unsupported capability combinations are rejected before execution.
+- [x] Should the dashboard remain YAML-first?  
+  **Decision:** No. The control plane should be schema-driven and capability-driven first, with raw config editing treated as an advanced operation.
+
+## Design Decisions
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|--------------------|--------|-----------|
+| Runtime abstraction | OpenAI-centric dispatch vs canonical IR | Canonical IR | Removes protocol bias and makes routing capability-aware |
+| Public protocol support | OpenAI-only primary vs tri-protocol ingress | Tri-protocol ingress | Matches product intent and removes ambiguity |
+| Routing model | Model-only routing vs capability-aware routing | Capability-aware routing | Prevents invalid protocol/provider combinations |
+| Endpoint architecture | Per-endpoint custom handlers vs unified runtime | Unified runtime | Makes explain, preview, retry, and execution consistent |
+| Dashboard focus | Config editor first vs protocol/capability first | Protocol/capability first | Better matches operator mental model |
+| Implementation workflow | Large branch refactor vs issue-driven vertical slices | Issue-driven vertical slices | Easier for Claude Code to modify safely and review incrementally |

--- a/docs/specs/active/SPEC-065/technical-design.md
+++ b/docs/specs/active/SPEC-065/technical-design.md
@@ -1,0 +1,375 @@
+# Technical Design: Canonical Multi-Protocol Gateway & Control Plane Redesign
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Spec ID   | SPEC-065                                           |
+| Title     | Canonical Multi-Protocol Gateway & Control Plane Redesign |
+| Author    | AI Agent                                           |
+| Status    | Draft                                              |
+| Created   | 2026-03-14                                         |
+| Updated   | 2026-03-14                                         |
+| Parent    | #211                                               |
+| Issues    | #212, #213, #214, #215, #216, #217, #218, #219, #220, #221, #222, #223, #224, #225, #226 |
+
+## Overview
+
+This redesign makes OpenAI, Claude, and Gemini first-class ingress protocols while removing protocol bias from the runtime. The new architecture is adapter-core-adapter:
+
+1. Public protocol adapters parse HTTP requests into canonical runtime types.
+2. The runtime plans and executes using canonical request semantics and provider/model capability declarations.
+3. Provider executors speak native upstream protocols.
+4. Egress adapters translate canonical results back into the client's public protocol.
+
+The control plane is redesigned around protocol support, provider capabilities, routing explanation, replay, and schema-driven configuration instead of raw provider-centric forms.
+
+Reference: [PRD](prd.md)
+
+## API Design
+
+Public endpoints remain tri-protocol, but all inference endpoints share one runtime path:
+
+### Public Ingress
+
+```text
+GET  /v1/models
+POST /v1/chat/completions
+POST /v1/responses
+
+POST /v1/messages
+POST /v1/messages/count_tokens
+
+GET  /v1beta/models
+POST /v1beta/models/{model}:generateContent
+POST /v1beta/models/{model}:streamGenerateContent
+```
+
+### Control Plane APIs
+
+New or reshaped dashboard APIs:
+
+```text
+GET  /api/dashboard/protocols/matrix
+GET  /api/dashboard/providers/capabilities
+POST /api/dashboard/routing/explain
+POST /api/dashboard/replay/preview
+POST /api/dashboard/replay/execute
+GET  /api/dashboard/config/schema
+```
+
+### Canonical Explain Request
+
+```json
+{
+  "ingress_protocol": "claude",
+  "operation": "generate",
+  "endpoint": "messages",
+  "model": "claude-sonnet-4-5",
+  "stream": true,
+  "features": {
+    "tools": true,
+    "json_schema": false,
+    "reasoning": true,
+    "images": false,
+    "count_tokens": false
+  },
+  "tenant_id": "tenant-a",
+  "api_key_id": "sk-proxy-abc",
+  "region": "us-east"
+}
+```
+
+### Canonical Explain Response
+
+```json
+{
+  "selected": {
+    "provider": "anthropic-prod",
+    "credential": "anthropic-us-1",
+    "model": "claude-sonnet-4-5",
+    "execution_mode": "native"
+  },
+  "alternates": [],
+  "rejections": [
+    {
+      "candidate": "openai-prod/gpt-5",
+      "reason": "missing_capability: messages_protocol"
+    }
+  ],
+  "required_capabilities": {
+    "supports_stream": true,
+    "supports_tools": true,
+    "supports_reasoning": true
+  }
+}
+```
+
+## Backend Implementation
+
+### Module Structure
+
+```text
+crates/
+├── domain/
+│   ├── request.rs
+│   ├── response.rs
+│   ├── events.rs
+│   ├── capability.rs
+│   └── operation.rs
+├── protocol-openai/
+├── protocol-claude/
+├── protocol-gemini/
+├── capabilities/
+├── router/
+├── runtime/
+├── providers-openai/
+├── providers-anthropic/
+├── providers-gemini/
+└── control-plane-api/
+```
+
+If crate extraction is deferred initially, the same boundaries should still exist as top-level modules with the same ownership.
+
+### Key Types
+
+```rust
+pub enum IngressProtocol {
+    OpenAi,
+    Claude,
+    Gemini,
+}
+
+pub enum Operation {
+    Models,
+    Generate,
+    CountTokens,
+}
+
+pub struct CanonicalRequest {
+    pub ingress_protocol: IngressProtocol,
+    pub operation: Operation,
+    pub endpoint: String,
+    pub model: String,
+    pub stream: bool,
+    pub input: Conversation,
+    pub tools: Vec<ToolSpec>,
+    pub tool_choice: ToolChoice,
+    pub response_format: ResponseFormat,
+    pub reasoning: Option<ReasoningConfig>,
+    pub attachments: Vec<Attachment>,
+    pub limits: RequestLimits,
+    pub tenant_id: Option<String>,
+    pub api_key_id: Option<String>,
+    pub region: Option<String>,
+}
+
+pub struct RequiredCapabilities {
+    pub supports_generate: bool,
+    pub supports_messages_protocol: bool,
+    pub supports_responses_protocol: bool,
+    pub supports_gemini_generate_content: bool,
+    pub supports_stream: bool,
+    pub supports_tools: bool,
+    pub supports_parallel_tools: bool,
+    pub supports_json_schema: bool,
+    pub supports_reasoning: bool,
+    pub supports_images: bool,
+    pub supports_count_tokens: bool,
+}
+
+pub enum ExecutionMode {
+    Native,
+    LosslessAdapted,
+}
+```
+
+### Runtime Flow
+
+```text
+HTTP request
+  -> ingress adapter
+  -> CanonicalRequest
+  -> capability derivation
+  -> planner
+  -> selected provider/model/credential
+  -> provider-native request builder
+  -> upstream executor
+  -> CanonicalResponse / CanonicalEvent stream
+  -> egress adapter
+  -> HTTP response
+```
+
+### Capability Model
+
+Capability declarations are first-class and explicit:
+
+- provider-level defaults
+- model-level overrides
+- operation-level support
+- protocol-specific ingress/egress support
+
+The planner filters candidates by capability compatibility before any cost or latency scoring.
+
+### Routing Rules
+
+Routing input must include:
+
+- ingress protocol
+- operation
+- endpoint semantics
+- stream flag
+- required capabilities
+- tenant
+- api key
+- region
+- model selector
+
+The planner result includes:
+
+- selected route
+- execution mode
+- capability mismatches
+- filtered candidates
+- ranked alternates
+
+### Public Endpoint Unification
+
+No public inference handler may bypass the runtime. In particular:
+
+- `responses` is not a special direct path
+- `messages` is not allowed to rely on hidden Claude-only assumptions
+- `Gemini generateContent` is not mapped to a lossy fallback path implicitly
+
+All explain, preview, replay, and runtime execution must use the same planner and capability filter.
+
+## Configuration Changes
+
+The control plane and runtime config should move from provider-format-centric fields to schema-driven capability and protocol declarations.
+
+### Provider Config Shape
+
+```yaml
+providers:
+  - name: anthropic-prod
+    upstream:
+      type: anthropic
+      credential_ref: env://ANTHROPIC_API_KEY
+      base_url: https://api.anthropic.com
+    models:
+      - id: claude-sonnet-4-5
+        aliases: [claude-default]
+        capabilities:
+          supports_stream: true
+          supports_tools: true
+          supports_reasoning: true
+          supports_count_tokens: true
+```
+
+### Public Protocol Config
+
+```yaml
+public_protocols:
+  openai:
+    enabled: true
+  claude:
+    enabled: true
+  gemini:
+    enabled: true
+```
+
+### Routing Config
+
+```yaml
+routing:
+  profiles:
+    balanced:
+      strategy: weighted-round-robin
+  rules:
+    - name: claude-reasoning
+      match:
+        ingress_protocols: [claude]
+        capabilities: [supports_reasoning]
+      use_profile: balanced
+```
+
+## Provider Compatibility
+
+| Provider Type | Ingress Protocols It Can Back | Execution Mode | Notes |
+|---------------|-------------------------------|----------------|-------|
+| OpenAI-compatible | OpenAI, Claude, Gemini | Native or LosslessAdapted | Depends on declared capabilities |
+| Anthropic Claude | OpenAI, Claude, Gemini | Native or LosslessAdapted | Native for Claude protocol and count tokens |
+| Gemini / Vertex | OpenAI, Claude, Gemini | Native or LosslessAdapted | Native for Gemini generateContent |
+
+## UI Design
+
+### Information Architecture
+
+```text
+Overview
+Protocols
+Providers
+Models & Capabilities
+Routing
+Requests
+Replay
+Tenants & Keys
+Config & Changes
+```
+
+### Page Responsibilities
+
+- `Protocols`: public protocol matrix, endpoint semantics, supported execution modes.
+- `Providers`: upstream connectivity, health, coverage, capability declarations.
+- `Models & Capabilities`: provider/model capability matrix with filters and diff-friendly views.
+- `Routing`: real planner explain, candidate ranking, rejection reasons, execution mode.
+- `Requests`: request log plus canonical request summary and route trace.
+- `Replay`: replay saved or synthetic requests through explain or execution mode.
+- `Config & Changes`: schema-driven editor, validation, diff, apply history.
+
+### UI Principles
+
+- Protocol-first, not raw-format-first.
+- Capability-first, not model-list-first.
+- Explain views must use the same backend logic as runtime.
+- Every request detail should expose ingress protocol, canonical operation, selected provider, execution mode, and rejection reasons.
+- Complex edits should be form/schema-driven, not large free-text config blobs by default.
+
+## Alternative Approaches
+
+| Approach | Pros | Cons | Verdict |
+|----------|------|------|---------|
+| Keep OpenAI-centric core and patch other protocols | Lower immediate rewrite cost | Continues protocol bias and hidden edge cases | Rejected |
+| Protocol-to-protocol translators only | Simple mental model at first | Becomes brittle, lossy, and hard to reason about | Rejected |
+| Single public OpenAI protocol only | Simplest runtime | Does not match product goals | Rejected |
+| Canonical IR with tri-protocol ingress | Clear semantics and scalable architecture | Requires larger upfront reorganization | Chosen |
+
+## Task Breakdown
+
+- [ ] Define canonical domain types for requests, responses, events, operations, and capabilities.
+- [ ] Build capability registry and planner v2 on canonical request semantics.
+- [ ] Add OpenAI ingress and egress adapters using canonical runtime types.
+- [ ] Add Claude ingress and egress adapters using canonical runtime types.
+- [ ] Add Gemini ingress and egress adapters using canonical runtime types.
+- [ ] Rewrite provider executors to consume canonical runtime contracts and emit canonical results.
+- [ ] Unify all public inference handlers on one runtime pipeline.
+- [ ] Add control-plane APIs for protocol matrix, capabilities, route explain, and replay.
+- [ ] Redesign dashboard navigation and page information architecture.
+- [ ] Build protocol matrix and provider capability pages in the dashboard.
+- [ ] Rebuild routing explain, request inspection, and replay UX.
+- [ ] Add golden fixtures, planner contract tests, provider contract tests, and end-to-end protocol matrix tests.
+
+## Test Strategy
+
+- **Unit tests:** canonical type invariants, capability derivation, planner filtering, protocol adapters, provider-native builders.
+- **Golden tests:** protocol request and response fixtures for OpenAI, Claude, and Gemini.
+- **Planner contract tests:** route explanation snapshots for combinations of capabilities and routing rules.
+- **Provider contract tests:** mocked upstream compatibility for OpenAI-compatible, Anthropic, and Gemini executors.
+- **Integration tests:** end-to-end inference for each public protocol through the unified runtime pipeline.
+- **Dashboard tests:** route explain page, protocol matrix page, provider capability page, and replay flow.
+
+## Rollout Plan
+
+1. Land canonical domain and planner infrastructure behind new modules.
+2. Port each public protocol adapter and provider executor in focused issues.
+3. Switch public handlers and explain APIs to the unified runtime.
+4. Rebuild dashboard pages on top of the new APIs.
+5. Remove obsolete endpoint-local logic once all tests pass under the new runtime.


### PR DESCRIPTION
## Summary
- Introduces `prism-domain` and `prism-protocol` crates as the foundation for the canonical multi-protocol gateway (SPEC-065 Phases 1–5)
- Adds bidirectional protocol adapters (ingress/egress + provider-facing) for OpenAI, Claude, and Gemini
- Implements capability-aware routing and control plane APIs (protocol_matrix, provider_capabilities, route_explain)

## Changes

### `crates/domain/` (new)
- Canonical IR types: `CanonicalRequest`, `CanonicalResponse`, `CanonicalEvent`
- Domain types: `ContentBlock`, `Message`, `Conversation`, `ToolSpec`, `ResponseFormat`
- Operations: `IngressProtocol`, `Operation`, `Endpoint`, `ExecutionMode`
- Capabilities: `ProviderCapabilities`, `UpstreamProtocol`, `RequiredCapabilities`
- Explain API types: `ExplainRequest`, `ExplainResponse`, `SelectedRoute`

### `crates/protocol/` (new)
- OpenAI adapter: `ingress_chat`, `egress_response`, `egress_event`, `egress_request`, `parse_response`, `parse_event`
- Claude adapter: `ingress_messages`, `egress_response`, `egress_event`, `egress_request`, `parse_response`, `parse_event`
- Gemini adapter: `ingress_generate`, `egress_response`, `egress_event`, `egress_request`, `parse_response`, `parse_event`
- Each adapter includes stop-reason mapping helpers to eliminate duplication

### `crates/core/`
- `provider.rs`: Added `upstream_protocol()` conversion function (Format → UpstreamProtocol)
- `routing/planner.rs`: Capability filtering, execution mode derivation, lazy `cand_label`
- `routing/types.rs`: Added `MissingCapability`, `GenerateContent`/`StreamGenerateContent` endpoints, execution mode fields

### `crates/provider/`
- `catalog.rs`: Derives capabilities and upstream_protocol in snapshots

### `crates/server/`
- New `control_plane.rs` handler: `protocol_matrix`, `provider_capabilities`, `route_explain`
- Updated router with 3 new control plane routes

### Code quality fixes (/simplify)
- Deduplicated `upstream_protocol_from_format()` → single `upstream_protocol()` in prism-core
- Replaced `ExplainFeaturesApi` with `ExplainFeatures` from domain
- Fixed `ImageSource::Url` incorrectly treated as base64 in Claude egress
- Fixed Gemini tool response hardcoded "function" name → uses actual tool name
- Added zero-allocation `satisfies()` fast path for capability checking
- Made `cand_label` lazy in route planner

## Spec & Reference Doc Impact
- SPEC-065 (Active) — Phases 1–5 completed, Phase 6 (dispatch rewrite) remains

## Test Plan
- [x] `make lint` passes (zero clippy warnings)
- [x] `make test` passes (618 tests, 0 failures)
- [x] 32 new protocol adapter tests (ingress, egress, provider-facing)
- [x] Dashboard tests updated for new route_explain response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)