### PR TITLE
test: add golden fixtures, adapter tests, and roundtrip coverage

### DIFF
--- a/crates/protocol/tests/fixtures/claude/messages_basic_request.json
+++ b/crates/protocol/tests/fixtures/claude/messages_basic_request.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-3-5-sonnet-20241022",
+  "system": "You are a helpful assistant.",
+  "messages": [
+    {"role": "user", "content": "What is 2+2?"}
+  ],
+  "max_tokens": 100
+}

--- a/crates/protocol/tests/fixtures/claude/messages_basic_response.json
+++ b/crates/protocol/tests/fixtures/claude/messages_basic_response.json
@@ -1,0 +1,10 @@
+{
+  "id": "msg_golden_1",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-3-5-sonnet-20241022",
+  "content": [{"type": "text", "text": "2+2 equals 4."}],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {"input_tokens": 20, "output_tokens": 8}
+}

--- a/crates/protocol/tests/fixtures/claude/messages_with_tools_request.json
+++ b/crates/protocol/tests/fixtures/claude/messages_with_tools_request.json
@@ -1,0 +1,16 @@
+{
+  "model": "claude-3-5-sonnet-20241022",
+  "messages": [
+    {"role": "user", "content": "What's the weather in SF?"}
+  ],
+  "tools": [{
+    "name": "get_weather",
+    "description": "Get weather for a city",
+    "input_schema": {
+      "type": "object",
+      "properties": {"city": {"type": "string"}},
+      "required": ["city"]
+    }
+  }],
+  "max_tokens": 200
+}

--- a/crates/protocol/tests/fixtures/claude/stream_events.json
+++ b/crates/protocol/tests/fixtures/claude/stream_events.json
@@ -1,0 +1,54 @@
+[
+  {
+    "event": "message_start",
+    "data": {
+      "type": "message_start",
+      "message": {
+        "id": "msg_stream_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20241022",
+        "content": [],
+        "stop_reason": null,
+        "usage": {"input_tokens": 10, "output_tokens": 0}
+      }
+    }
+  },
+  {
+    "event": "content_block_start",
+    "data": {
+      "type": "content_block_start",
+      "index": 0,
+      "content_block": {"type": "text", "text": ""}
+    }
+  },
+  {
+    "event": "content_block_delta",
+    "data": {
+      "type": "content_block_delta",
+      "index": 0,
+      "delta": {"type": "text_delta", "text": "Hello world"}
+    }
+  },
+  {
+    "event": "content_block_stop",
+    "data": {
+      "type": "content_block_stop",
+      "index": 0
+    }
+  },
+  {
+    "event": "message_delta",
+    "data": {
+      "type": "message_delta",
+      "delta": {"stop_reason": "end_turn"},
+      "usage": {"output_tokens": 5}
+    }
+  },
+  {
+    "event": "message_stop",
+    "data": {
+      "type": "message_stop"
+    }
+  }
+]

--- a/crates/protocol/tests/fixtures/gemini/generate_basic_request.json
+++ b/crates/protocol/tests/fixtures/gemini/generate_basic_request.json
@@ -1,0 +1,15 @@
+{
+  "systemInstruction": {
+    "parts": [{"text": "You are a helpful assistant."}]
+  },
+  "contents": [
+    {
+      "role": "user",
+      "parts": [{"text": "What is 2+2?"}]
+    }
+  ],
+  "generationConfig": {
+    "maxOutputTokens": 100,
+    "temperature": 0.7
+  }
+}

--- a/crates/protocol/tests/fixtures/gemini/generate_basic_response.json
+++ b/crates/protocol/tests/fixtures/gemini/generate_basic_response.json
@@ -1,0 +1,15 @@
+{
+  "candidates": [{
+    "content": {
+      "parts": [{"text": "2+2 equals 4."}],
+      "role": "model"
+    },
+    "finishReason": "STOP"
+  }],
+  "modelVersion": "gemini-1.5-pro",
+  "usageMetadata": {
+    "promptTokenCount": 15,
+    "candidatesTokenCount": 8,
+    "totalTokenCount": 23
+  }
+}

--- a/crates/protocol/tests/fixtures/gemini/stream_events.json
+++ b/crates/protocol/tests/fixtures/gemini/stream_events.json
@@ -1,0 +1,24 @@
+[
+  {
+    "candidates": [{
+      "content": {
+        "parts": [{"text": "Hello"}],
+        "role": "model"
+      }
+    }]
+  },
+  {
+    "candidates": [{
+      "content": {
+        "parts": [{"text": " world"}],
+        "role": "model"
+      },
+      "finishReason": "STOP"
+    }],
+    "usageMetadata": {
+      "promptTokenCount": 10,
+      "candidatesTokenCount": 5,
+      "totalTokenCount": 15
+    }
+  }
+]

--- a/crates/protocol/tests/fixtures/openai/chat_basic_request.json
+++ b/crates/protocol/tests/fixtures/openai/chat_basic_request.json
@@ -1,0 +1,9 @@
+{
+  "model": "gpt-4",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is 2+2?"}
+  ],
+  "max_tokens": 100,
+  "temperature": 0.7
+}

--- a/crates/protocol/tests/fixtures/openai/chat_basic_response.json
+++ b/crates/protocol/tests/fixtures/openai/chat_basic_response.json
@@ -1,0 +1,19 @@
+{
+  "id": "chatcmpl-golden-1",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "gpt-4",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "content": "2+2 equals 4."
+    },
+    "finish_reason": "stop"
+  }],
+  "usage": {
+    "prompt_tokens": 20,
+    "completion_tokens": 8,
+    "total_tokens": 28
+  }
+}

--- a/crates/protocol/tests/fixtures/openai/chat_tool_call_response.json
+++ b/crates/protocol/tests/fixtures/openai/chat_tool_call_response.json
@@ -1,0 +1,27 @@
+{
+  "id": "chatcmpl-golden-2",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "gpt-4",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "id": "call_abc123",
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "arguments": "{\"city\":\"SF\"}"
+        }
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }],
+  "usage": {
+    "prompt_tokens": 25,
+    "completion_tokens": 15,
+    "total_tokens": 40
+  }
+}

--- a/crates/protocol/tests/fixtures/openai/chat_with_tools_request.json
+++ b/crates/protocol/tests/fixtures/openai/chat_with_tools_request.json
@@ -1,0 +1,19 @@
+{
+  "model": "gpt-4",
+  "messages": [
+    {"role": "user", "content": "What's the weather in SF?"}
+  ],
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "get_weather",
+      "description": "Get weather for a city",
+      "parameters": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"]
+      }
+    }
+  }],
+  "max_tokens": 200
+}

--- a/crates/protocol/tests/fixtures/openai/stream_events.json
+++ b/crates/protocol/tests/fixtures/openai/stream_events.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "chatcmpl-stream-1",
+    "object": "chat.completion.chunk",
+    "created": 1700000000,
+    "model": "gpt-4",
+    "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": null}]
+  },
+  {
+    "id": "chatcmpl-stream-1",
+    "object": "chat.completion.chunk",
+    "created": 1700000000,
+    "model": "gpt-4",
+    "choices": [{"index": 0, "delta": {"content": "Hello"}, "finish_reason": null}]
+  },
+  {
+    "id": "chatcmpl-stream-1",
+    "object": "chat.completion.chunk",
+    "created": 1700000000,
+    "model": "gpt-4",
+    "choices": [{"index": 0, "delta": {"content": " world"}, "finish_reason": null}]
+  },
+  {
+    "id": "chatcmpl-stream-1",
+    "object": "chat.completion.chunk",
+    "created": 1700000000,
+    "model": "gpt-4",
+    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+  }
+]

--- a/crates/protocol/tests/golden.rs
+++ b/crates/protocol/tests/golden.rs
@@ -1,0 +1,315 @@
+//! Golden tests for protocol adapters.
+//!
+//! These tests load JSON fixtures and verify that ingress/egress adapters produce
+//! correct canonical types and protocol-native output. Adding a new test case is
+//! as simple as adding a fixture file and a test function using the helpers.
+
+use prism_domain::content::Role;
+use prism_domain::event::CanonicalEvent;
+use prism_domain::operation::Endpoint;
+use prism_domain::response::StopReason;
+use prism_types::types::{claude, gemini, openai};
+use serde_json::Value;
+use std::path::PathBuf;
+
+fn fixture_path(protocol: &str, name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(protocol)
+        .join(name)
+}
+
+fn load_fixture(protocol: &str, name: &str) -> Value {
+    let path = fixture_path(protocol, name);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
+    serde_json::from_str(&content)
+        .unwrap_or_else(|e| panic!("failed to parse fixture {}: {e}", path.display()))
+}
+
+// ─── OpenAI Golden Tests ──────────────────────────────────────────────────────
+
+#[test]
+fn golden_openai_ingress_basic() {
+    let fixture = load_fixture("openai", "chat_basic_request.json");
+    let req: openai::ChatCompletionRequest = serde_json::from_value(fixture).unwrap();
+    let canonical = prism_protocol::openai::ingress_chat(&req, Endpoint::ChatCompletions);
+
+    assert_eq!(canonical.model, "gpt-4");
+    assert!(!canonical.stream);
+    assert!(canonical.input.system.is_some());
+    assert_eq!(canonical.input.messages.len(), 1);
+    assert_eq!(canonical.input.messages[0].role, Role::User);
+    assert_eq!(canonical.limits.max_tokens, Some(100));
+    assert_eq!(canonical.limits.temperature, Some(0.7));
+}
+
+#[test]
+fn golden_openai_ingress_with_tools() {
+    let fixture = load_fixture("openai", "chat_with_tools_request.json");
+    let req: openai::ChatCompletionRequest = serde_json::from_value(fixture).unwrap();
+    let canonical = prism_protocol::openai::ingress_chat(&req, Endpoint::ChatCompletions);
+
+    assert_eq!(canonical.tools.len(), 1);
+    assert_eq!(canonical.tools[0].name, "get_weather");
+    assert_eq!(
+        canonical.tools[0].description,
+        Some("Get weather for a city".into())
+    );
+}
+
+#[test]
+fn golden_openai_parse_response() {
+    let fixture = load_fixture("openai", "chat_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let response = prism_protocol::openai::parse_response(&data, "openai", "cred-1").unwrap();
+
+    assert_eq!(response.id, "chatcmpl-golden-1");
+    assert_eq!(response.model, "gpt-4");
+    assert_eq!(response.content.len(), 1);
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    assert_eq!(response.usage.input_tokens, 20);
+    assert_eq!(response.usage.output_tokens, 8);
+}
+
+#[test]
+fn golden_openai_parse_tool_call_response() {
+    let fixture = load_fixture("openai", "chat_tool_call_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let response = prism_protocol::openai::parse_response(&data, "openai", "cred-1").unwrap();
+
+    assert_eq!(response.stop_reason, StopReason::ToolUse);
+    let tool_blocks: Vec<_> = response
+        .content
+        .iter()
+        .filter(|b| matches!(b, prism_domain::content::ContentBlock::ToolUse { .. }))
+        .collect();
+    assert_eq!(tool_blocks.len(), 1);
+}
+
+#[test]
+fn golden_openai_egress_response_roundtrip() {
+    let fixture = load_fixture("openai", "chat_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let canonical = prism_protocol::openai::parse_response(&data, "openai", "cred-1").unwrap();
+    let egress = prism_protocol::openai::egress_response(&canonical);
+
+    // Serialize to JSON for verification
+    let egress_val = serde_json::to_value(&egress).unwrap();
+    assert_eq!(egress_val["object"], "chat.completion");
+    assert_eq!(egress_val["model"], "gpt-4");
+    assert_eq!(egress_val["choices"][0]["finish_reason"], "stop");
+    assert_eq!(egress_val["choices"][0]["message"]["role"], "assistant");
+}
+
+#[test]
+fn golden_openai_stream_events() {
+    let fixture = load_fixture("openai", "stream_events.json");
+    let events: Vec<Value> = serde_json::from_value(fixture).unwrap();
+
+    let mut parsed_events = Vec::new();
+    for event_val in &events {
+        let data_str = serde_json::to_string(event_val).unwrap();
+        if let Some(event) = prism_protocol::openai::parse_event(&data_str) {
+            parsed_events.push(event);
+        }
+    }
+
+    // Should parse at least some events
+    assert!(!parsed_events.is_empty());
+    // Should contain text deltas
+    let text_deltas: Vec<_> = parsed_events
+        .iter()
+        .filter(|e| matches!(e, CanonicalEvent::TextDelta { .. }))
+        .collect();
+    assert!(!text_deltas.is_empty());
+    // Last should be StreamEnd
+    assert!(matches!(
+        parsed_events.last().unwrap(),
+        CanonicalEvent::StreamEnd { .. }
+    ));
+}
+
+// ─── Claude Golden Tests ──────────────────────────────────────────────────────
+
+#[test]
+fn golden_claude_ingress_basic() {
+    let fixture = load_fixture("claude", "messages_basic_request.json");
+    let req: claude::ClaudeMessagesRequest = serde_json::from_value(fixture).unwrap();
+    let canonical = prism_protocol::claude::ingress_messages(&req, Endpoint::Messages);
+
+    assert_eq!(canonical.model, "claude-3-5-sonnet-20241022");
+    assert!(!canonical.stream);
+    assert!(canonical.input.system.is_some());
+    assert_eq!(canonical.input.messages.len(), 1);
+    assert_eq!(canonical.input.messages[0].role, Role::User);
+    assert_eq!(canonical.limits.max_tokens, Some(100));
+}
+
+#[test]
+fn golden_claude_ingress_with_tools() {
+    let fixture = load_fixture("claude", "messages_with_tools_request.json");
+    let req: claude::ClaudeMessagesRequest = serde_json::from_value(fixture).unwrap();
+    let canonical = prism_protocol::claude::ingress_messages(&req, Endpoint::Messages);
+
+    assert_eq!(canonical.tools.len(), 1);
+    assert_eq!(canonical.tools[0].name, "get_weather");
+}
+
+#[test]
+fn golden_claude_parse_response() {
+    let fixture = load_fixture("claude", "messages_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let response = prism_protocol::claude::parse_response(&data, "anthropic", "cred-1").unwrap();
+
+    assert_eq!(response.id, "msg_golden_1");
+    assert_eq!(response.model, "claude-3-5-sonnet-20241022");
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    assert_eq!(response.usage.input_tokens, 20);
+    assert_eq!(response.usage.output_tokens, 8);
+}
+
+#[test]
+fn golden_claude_egress_response_roundtrip() {
+    let fixture = load_fixture("claude", "messages_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let canonical = prism_protocol::claude::parse_response(&data, "anthropic", "cred-1").unwrap();
+    let egress = prism_protocol::claude::egress_response(&canonical);
+
+    let egress_val = serde_json::to_value(&egress).unwrap();
+    assert_eq!(egress_val["type"], "message");
+    assert_eq!(egress_val["role"], "assistant");
+    assert_eq!(egress_val["model"], "claude-3-5-sonnet-20241022");
+    assert_eq!(egress_val["stop_reason"], "end_turn");
+}
+
+#[test]
+fn golden_claude_stream_events() {
+    let fixture = load_fixture("claude", "stream_events.json");
+    let events: Vec<Value> = serde_json::from_value(fixture).unwrap();
+
+    let mut parsed_events = Vec::new();
+    for event_val in &events {
+        let event_type = event_val["event"].as_str().unwrap_or("");
+        let data_str = serde_json::to_string(&event_val["data"]).unwrap();
+        if let Some(event) = prism_protocol::claude::parse_event(event_type, &data_str) {
+            parsed_events.push(event);
+        }
+    }
+
+    assert!(!parsed_events.is_empty());
+    let text_deltas: Vec<_> = parsed_events
+        .iter()
+        .filter(|e| matches!(e, CanonicalEvent::TextDelta { .. }))
+        .collect();
+    assert!(!text_deltas.is_empty());
+    assert!(matches!(
+        parsed_events.last().unwrap(),
+        CanonicalEvent::StreamEnd { .. }
+    ));
+}
+
+// ─── Gemini Golden Tests ──────────────────────────────────────────────────────
+
+#[test]
+fn golden_gemini_ingress_basic() {
+    let fixture = load_fixture("gemini", "generate_basic_request.json");
+    let req: gemini::GeminiRequest = serde_json::from_value(fixture).unwrap();
+    let canonical =
+        prism_protocol::gemini::ingress_generate(&req, "gemini-1.5-pro", Endpoint::GenerateContent);
+
+    assert_eq!(canonical.model, "gemini-1.5-pro");
+    assert!(!canonical.stream);
+    assert!(canonical.input.system.is_some());
+    assert_eq!(canonical.input.messages.len(), 1);
+    assert_eq!(canonical.input.messages[0].role, Role::User);
+}
+
+#[test]
+fn golden_gemini_parse_response() {
+    let fixture = load_fixture("gemini", "generate_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let response = prism_protocol::gemini::parse_response(&data, "gemini", "cred-1").unwrap();
+
+    assert_eq!(response.stop_reason, StopReason::EndTurn);
+    assert_eq!(response.usage.input_tokens, 15);
+    assert_eq!(response.usage.output_tokens, 8);
+}
+
+#[test]
+fn golden_gemini_egress_response_roundtrip() {
+    let fixture = load_fixture("gemini", "generate_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let canonical = prism_protocol::gemini::parse_response(&data, "gemini", "cred-1").unwrap();
+    let egress = prism_protocol::gemini::egress_response(&canonical);
+
+    let egress_val = serde_json::to_value(&egress).unwrap();
+    assert!(
+        egress_val["candidates"][0]["content"]["parts"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("4")
+    );
+    assert_eq!(egress_val["candidates"][0]["finishReason"], "STOP");
+}
+
+#[test]
+fn golden_gemini_stream_events() {
+    let fixture = load_fixture("gemini", "stream_events.json");
+    let events: Vec<Value> = serde_json::from_value(fixture).unwrap();
+
+    let mut parsed_events = Vec::new();
+    for event_val in &events {
+        let data_str = serde_json::to_string(event_val).unwrap();
+        if let Some(event) = prism_protocol::gemini::parse_event(&data_str) {
+            parsed_events.push(event);
+        }
+    }
+
+    let text_deltas: Vec<_> = parsed_events
+        .iter()
+        .filter(|e| matches!(e, CanonicalEvent::TextDelta { .. }))
+        .collect();
+    assert!(!text_deltas.is_empty());
+}
+
+// ─── Cross-Protocol Egress Tests ──────────────────────────────────────────────
+
+#[test]
+fn golden_cross_protocol_openai_to_claude_egress() {
+    let fixture = load_fixture("openai", "chat_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let canonical = prism_protocol::openai::parse_response(&data, "openai", "cred-1").unwrap();
+    let claude_egress = prism_protocol::claude::egress_response(&canonical);
+
+    let val = serde_json::to_value(&claude_egress).unwrap();
+    assert_eq!(val["type"], "message");
+    assert_eq!(val["role"], "assistant");
+    assert_eq!(val["stop_reason"], "end_turn");
+    assert_eq!(val["content"][0]["type"], "text");
+}
+
+#[test]
+fn golden_cross_protocol_claude_to_openai_egress() {
+    let fixture = load_fixture("claude", "messages_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let canonical = prism_protocol::claude::parse_response(&data, "anthropic", "cred-1").unwrap();
+    let openai_egress = prism_protocol::openai::egress_response(&canonical);
+
+    let val = serde_json::to_value(&openai_egress).unwrap();
+    assert_eq!(val["object"], "chat.completion");
+    assert_eq!(val["choices"][0]["finish_reason"], "stop");
+    assert_eq!(val["choices"][0]["message"]["role"], "assistant");
+}
+
+#[test]
+fn golden_cross_protocol_gemini_to_openai_egress() {
+    let fixture = load_fixture("gemini", "generate_basic_response.json");
+    let data = serde_json::to_vec(&fixture).unwrap();
+    let canonical = prism_protocol::gemini::parse_response(&data, "gemini", "cred-1").unwrap();
+    let openai_egress = prism_protocol::openai::egress_response(&canonical);
+
+    let val = serde_json::to_value(&openai_egress).unwrap();
+    assert_eq!(val["object"], "chat.completion");
+    assert_eq!(val["choices"][0]["finish_reason"], "stop");
+}

--- a/crates/translator/tests/roundtrip_tests.rs
+++ b/crates/translator/tests/roundtrip_tests.rs
@@ -297,3 +297,261 @@ fn test_roundtrip_openai_to_claude_streaming() {
     assert_eq!(chunks.len(), 1);
     assert_eq!(chunks[0], "[DONE]");
 }
+
+// ─── Claude → OpenAI roundtrip tests ─────────────────────────────────────────
+
+#[test]
+fn test_roundtrip_claude_to_openai_text() {
+    let reg = build_registry();
+
+    // 1. Translate Claude request → OpenAI format
+    let claude_req = json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "system": "You are helpful.",
+        "messages": [
+            {"role": "user", "content": "What is 2+2?"}
+        ],
+        "max_tokens": 100
+    });
+    let raw = serde_json::to_vec(&claude_req).unwrap();
+    let openai_req = reg
+        .translate_request(Format::Claude, Format::OpenAI, "gpt-4", &raw, false)
+        .unwrap();
+    let openai_req_val: Value = serde_json::from_slice(&openai_req).unwrap();
+
+    // Verify OpenAI request structure
+    assert_eq!(openai_req_val["model"], "gpt-4");
+    assert_eq!(openai_req_val["messages"][0]["role"], "system");
+    assert_eq!(openai_req_val["messages"][0]["content"], "You are helpful.");
+    assert_eq!(openai_req_val["messages"][1]["role"], "user");
+    assert_eq!(openai_req_val["max_tokens"], 100);
+
+    // 2. Simulate OpenAI response
+    let openai_resp = json!({
+        "id": "chatcmpl-roundtrip-1",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gpt-4",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "2+2 equals 4."},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 8, "total_tokens": 23}
+    });
+    let resp_data = serde_json::to_vec(&openai_resp).unwrap();
+
+    // 3. Translate OpenAI response → Claude format
+    let claude_resp = reg
+        .translate_non_stream(Format::Claude, Format::OpenAI, "gpt-4", &raw, &resp_data)
+        .unwrap();
+    let result: Value = serde_json::from_str(&claude_resp).unwrap();
+
+    // 4. Verify Claude response structure
+    assert_eq!(result["type"], "message");
+    assert_eq!(result["role"], "assistant");
+    assert_eq!(result["content"][0]["type"], "text");
+    assert_eq!(result["content"][0]["text"], "2+2 equals 4.");
+    assert_eq!(result["stop_reason"], "end_turn");
+    assert_eq!(result["usage"]["input_tokens"], 15);
+    assert_eq!(result["usage"]["output_tokens"], 8);
+}
+
+#[test]
+fn test_roundtrip_claude_to_openai_tool_call() {
+    let reg = build_registry();
+
+    // 1. Translate Claude request with tools → OpenAI format
+    let claude_req = json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "messages": [{"role": "user", "content": "Weather in SF?"}],
+        "tools": [{
+            "name": "get_weather",
+            "description": "Get weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            }
+        }],
+        "max_tokens": 200
+    });
+    let raw = serde_json::to_vec(&claude_req).unwrap();
+    let openai_req = reg
+        .translate_request(Format::Claude, Format::OpenAI, "gpt-4", &raw, false)
+        .unwrap();
+    let openai_req_val: Value = serde_json::from_slice(&openai_req).unwrap();
+
+    // Verify tools translated
+    assert_eq!(openai_req_val["tools"][0]["type"], "function");
+    assert_eq!(
+        openai_req_val["tools"][0]["function"]["name"],
+        "get_weather"
+    );
+
+    // 2. Simulate OpenAI tool_calls response
+    let openai_resp = json!({
+        "id": "chatcmpl-tool-rt",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "gpt-4",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_rt1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{\"city\":\"SF\"}"}
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 30, "completion_tokens": 20, "total_tokens": 50}
+    });
+    let resp_data = serde_json::to_vec(&openai_resp).unwrap();
+
+    // 3. Translate back to Claude format
+    let claude_resp = reg
+        .translate_non_stream(Format::Claude, Format::OpenAI, "gpt-4", &raw, &resp_data)
+        .unwrap();
+    let result: Value = serde_json::from_str(&claude_resp).unwrap();
+
+    // 4. Verify Claude response has tool_use block
+    assert_eq!(result["stop_reason"], "tool_use");
+    let tool_block = &result["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|b| b["type"] == "tool_use")
+        .unwrap();
+    assert_eq!(tool_block["name"], "get_weather");
+    assert_eq!(tool_block["id"], "call_rt1");
+}
+
+#[test]
+fn test_roundtrip_claude_to_openai_streaming() {
+    let reg = build_registry();
+
+    let claude_req = json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "messages": [{"role": "user", "content": "Say hi"}],
+        "max_tokens": 100
+    });
+    let raw = serde_json::to_vec(&claude_req).unwrap();
+    let _openai_req = reg
+        .translate_request(Format::Claude, Format::OpenAI, "gpt-4", &raw, true)
+        .unwrap();
+
+    // Simulate OpenAI streaming chunks
+    let mut state = TranslateState::default();
+
+    // Role chunk
+    let role_chunk = json!({
+        "id": "chatcmpl-stream-rt",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4",
+        "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": null}]
+    });
+    let chunks = reg
+        .translate_stream(
+            Format::Claude,
+            Format::OpenAI,
+            "gpt-4",
+            &raw,
+            None,
+            &serde_json::to_vec(&role_chunk).unwrap(),
+            &mut state,
+        )
+        .unwrap();
+    // Should produce message_start and content_block_start events
+    assert!(chunks.iter().any(|c| c.contains("message_start")));
+
+    // Content delta
+    let content_chunk = json!({
+        "id": "chatcmpl-stream-rt",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4",
+        "choices": [{"index": 0, "delta": {"content": "Hi!"}, "finish_reason": null}]
+    });
+    let chunks = reg
+        .translate_stream(
+            Format::Claude,
+            Format::OpenAI,
+            "gpt-4",
+            &raw,
+            None,
+            &serde_json::to_vec(&content_chunk).unwrap(),
+            &mut state,
+        )
+        .unwrap();
+    assert!(chunks.iter().any(|c| c.contains("text_delta")));
+
+    // Finish chunk
+    let stop_chunk = json!({
+        "id": "chatcmpl-stream-rt",
+        "object": "chat.completion.chunk",
+        "created": 1700000000,
+        "model": "gpt-4",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    });
+    let chunks = reg
+        .translate_stream(
+            Format::Claude,
+            Format::OpenAI,
+            "gpt-4",
+            &raw,
+            None,
+            &serde_json::to_vec(&stop_chunk).unwrap(),
+            &mut state,
+        )
+        .unwrap();
+    assert!(chunks.iter().any(|c| c.contains("message_stop")));
+}
+
+// ─── Translation registry coverage tests ─────────────────────────────────────
+
+#[test]
+fn test_registered_translation_paths() {
+    let reg = build_registry();
+
+    // Currently registered request translation paths
+    let request_paths = [
+        (Format::OpenAI, Format::Claude),
+        (Format::OpenAI, Format::Gemini),
+        (Format::Claude, Format::OpenAI),
+        (Format::Claude, Format::Gemini),
+    ];
+
+    for (source, target) in &request_paths {
+        let test_body = json!({"model": "test", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10});
+        let raw = serde_json::to_vec(&test_body).unwrap();
+        let result = reg.translate_request(*source, *target, "test-model", &raw, false);
+        assert!(
+            result.is_ok(),
+            "request translation {source:?} → {target:?} should be registered"
+        );
+    }
+}
+
+#[test]
+fn test_same_format_passthrough() {
+    let reg = build_registry();
+
+    // Same format should return body unchanged
+    for format in [Format::OpenAI, Format::Claude, Format::Gemini] {
+        let body = json!({"model": "test", "messages": [], "max_tokens": 10});
+        let raw = serde_json::to_vec(&body).unwrap();
+        let result = reg
+            .translate_request(format, format, "test", &raw, false)
+            .unwrap();
+        assert_eq!(
+            raw, result,
+            "same-format passthrough should return body unchanged for {format:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add 12 JSON fixture files for OpenAI, Claude, and Gemini protocols covering requests, responses, and stream events
- Add 18 golden tests in `crates/protocol/tests/golden.rs` covering ingress, egress, response parsing, streaming, and cross-protocol translation
- Add 5 roundtrip tests in `crates/translator/tests/roundtrip_tests.rs` for Claude↔OpenAI translation paths

## Changes
### `crates/protocol/tests/`
- `fixtures/openai/` — 5 fixtures (basic request/response, tools request, tool call response, stream events)
- `fixtures/claude/` — 4 fixtures (basic request/response, tools request, stream events)
- `fixtures/gemini/` — 3 fixtures (basic request/response, stream events)
- `golden.rs` — 18 tests: ingress, parse response, egress roundtrip, stream events, cross-protocol egress

### `crates/translator/tests/`
- `roundtrip_tests.rs` — 5 new tests: text roundtrip, tool call roundtrip, streaming roundtrip, registered translation paths, same-format passthrough

## Spec & Reference Doc Impact
- Closes #225
- Closes #226
- Part of SPEC-065 (#211)

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (663 tests total, +23 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)