### PR TITLE
feat: redesign dashboard IA with protocol, capability, and replay pages

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -55,6 +55,20 @@
   overflow-y: auto;
 }
 
+.sidebar-section {
+  margin-bottom: 0.25rem;
+}
+
+.sidebar-section-label {
+  padding: 0.5rem 0.875rem 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--sidebar-text);
+  opacity: 0.5;
+}
+
 .sidebar-nav-item {
   display: flex;
   align-items: center;
@@ -612,6 +626,10 @@
   color: var(--color-text-tertiary);
 }
 
+.table-row--highlight {
+  background: rgba(59, 130, 246, 0.08);
+}
+
 .text-mono {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 0.8125rem;
@@ -674,6 +692,24 @@
   background: var(--color-bg-tertiary);
   color: var(--color-text-secondary);
   font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.type-badge--green {
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+}
+
+.type-badge--blue {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+}
+
+.type-badge--red {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
 }
 
 .tag-list {
@@ -1690,6 +1726,14 @@
 }
 
 /* Form inputs */
+
+.form-label {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.25rem;
+}
 
 .form-input,
 .form-select {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,12 +7,14 @@ import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import RequestLogs from './pages/RequestLogs';
 import Providers from './pages/Providers';
-import AuthKeys from './pages/AuthKeys';
 import Routing from './pages/Routing';
 import System from './pages/System';
 import Logs from './pages/Logs';
 import Config from './pages/Config';
 import Tenants from './pages/Tenants';
+import Protocols from './pages/Protocols';
+import ModelsCapabilities from './pages/ModelsCapabilities';
+import Replay from './pages/Replay';
 import './App.css';
 
 export default function App() {
@@ -35,14 +37,19 @@ export default function App() {
           }
         >
           <Route index element={<Dashboard />} />
-          <Route path="request-logs" element={<RequestLogs />} />
+          <Route path="requests" element={<RequestLogs />} />
+          <Route path="protocols" element={<Protocols />} />
           <Route path="providers" element={<Providers />} />
-          <Route path="auth-keys" element={<AuthKeys />} />
+          <Route path="models" element={<ModelsCapabilities />} />
           <Route path="routing" element={<Routing />} />
+          <Route path="replay" element={<Replay />} />
           <Route path="tenants" element={<Tenants />} />
           <Route path="config" element={<Config />} />
           <Route path="system" element={<System />} />
           <Route path="logs" element={<Logs />} />
+          {/* Legacy redirects */}
+          <Route path="request-logs" element={<Navigate to="/requests" replace />} />
+          <Route path="auth-keys" element={<Navigate to="/tenants" replace />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -5,7 +5,8 @@ import {
   LayoutDashboard,
   FileText,
   Server,
-  Key,
+  Network,
+  Layers,
   GitBranch,
   FileCode,
   Users,
@@ -14,19 +15,52 @@ import {
   LogOut,
   Menu,
   X,
+  PlayCircle,
 } from 'lucide-react';
 import { useState } from 'react';
 
-const navItems = [
-  { to: '/', icon: LayoutDashboard, label: 'Dashboard' },
-  { to: '/request-logs', icon: FileText, label: 'Request Logs' },
-  { to: '/providers', icon: Server, label: 'Providers' },
-  { to: '/auth-keys', icon: Key, label: 'Auth Keys' },
-  { to: '/routing', icon: GitBranch, label: 'Routing' },
-  { to: '/tenants', icon: Users, label: 'Tenants' },
-  { to: '/config', icon: FileCode, label: 'Config' },
-  { to: '/system', icon: Activity, label: 'System' },
-  { to: '/logs', icon: ScrollText, label: 'App Logs' },
+interface NavSection {
+  label: string;
+  items: { to: string; icon: React.ComponentType<{ size?: number }>; label: string }[];
+}
+
+const navSections: NavSection[] = [
+  {
+    label: 'Observe',
+    items: [
+      { to: '/', icon: LayoutDashboard, label: 'Overview' },
+      { to: '/requests', icon: FileText, label: 'Requests' },
+    ],
+  },
+  {
+    label: 'Infrastructure',
+    items: [
+      { to: '/protocols', icon: Network, label: 'Protocols' },
+      { to: '/providers', icon: Server, label: 'Providers' },
+      { to: '/models', icon: Layers, label: 'Models & Capabilities' },
+    ],
+  },
+  {
+    label: 'Traffic',
+    items: [
+      { to: '/routing', icon: GitBranch, label: 'Routing' },
+      { to: '/replay', icon: PlayCircle, label: 'Replay' },
+    ],
+  },
+  {
+    label: 'Access Control',
+    items: [
+      { to: '/tenants', icon: Users, label: 'Tenants & Keys' },
+    ],
+  },
+  {
+    label: 'Operations',
+    items: [
+      { to: '/config', icon: FileCode, label: 'Config & Changes' },
+      { to: '/system', icon: Activity, label: 'System' },
+      { to: '/logs', icon: ScrollText, label: 'App Logs' },
+    ],
+  },
 ];
 
 export default function Layout() {
@@ -68,19 +102,24 @@ export default function Layout() {
         </div>
 
         <nav className="sidebar-nav">
-          {navItems.map(({ to, icon: Icon, label }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={to === '/'}
-              className={({ isActive }) =>
-                `sidebar-nav-item ${isActive ? 'sidebar-nav-item--active' : ''}`
-              }
-              onClick={() => setSidebarOpen(false)}
-            >
-              <Icon size={18} />
-              <span>{label}</span>
-            </NavLink>
+          {navSections.map((section) => (
+            <div key={section.label} className="sidebar-section">
+              <div className="sidebar-section-label">{section.label}</div>
+              {section.items.map(({ to, icon: Icon, label }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  end={to === '/'}
+                  className={({ isActive }) =>
+                    `sidebar-nav-item ${isActive ? 'sidebar-nav-item--active' : ''}`
+                  }
+                  onClick={() => setSidebarOpen(false)}
+                >
+                  <Icon size={18} />
+                  <span>{label}</span>
+                </NavLink>
+              ))}
+            </div>
           ))}
         </nav>
 

--- a/web/src/pages/AuthKeys.tsx
+++ b/web/src/pages/AuthKeys.tsx
@@ -65,7 +65,7 @@ function buildBudget(form: FormState): BudgetConfig | undefined {
   return { total_usd: parseFloat(form.budget_total_usd), period: form.budget_period };
 }
 
-export default function AuthKeys() {
+export default function AuthKeys({ embedded }: { embedded?: boolean } = {}) {
   const [keys, setKeys] = useState<AuthKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
@@ -216,17 +216,27 @@ export default function AuthKeys() {
   };
 
   return (
-    <div className="page">
-      <div className="page-header">
-        <div>
-          <h2>API Keys</h2>
-          <p className="page-subtitle">Manage authentication keys for API access</p>
+    <div className={embedded ? '' : 'page'}>
+      {!embedded && (
+        <div className="page-header">
+          <div>
+            <h2>API Keys</h2>
+            <p className="page-subtitle">Manage authentication keys for API access</p>
+          </div>
+          <button className="btn btn-primary" onClick={openCreate}>
+            <Plus size={16} />
+            Create Key
+          </button>
         </div>
-        <button className="btn btn-primary" onClick={openCreate}>
-          <Plus size={16} />
-          Create Key
-        </button>
-      </div>
+      )}
+      {embedded && (
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '1rem' }}>
+          <button className="btn btn-primary" onClick={openCreate}>
+            <Plus size={16} />
+            Create Key
+          </button>
+        </div>
+      )}
 
       <div className="card">
         <div className="table-wrapper">

--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -10,9 +10,30 @@ import {
   Edit3,
   Save,
   RotateCcw,
+  Layers,
+  Clock,
 } from 'lucide-react';
 
-type Tab = 'view' | 'editor';
+type Tab = 'view' | 'editor' | 'schema';
+
+interface ConfigSection {
+  key: string;
+  label: string;
+  description: string;
+}
+
+const CONFIG_SECTIONS: ConfigSection[] = [
+  { key: 'listen', label: 'Server', description: 'Listen address, port, and TLS settings' },
+  { key: 'providers', label: 'Providers', description: 'Upstream provider credentials, base URLs, and model mappings' },
+  { key: 'routing', label: 'Routing', description: 'Routing profiles, rules, and model resolution' },
+  { key: 'auth-keys', label: 'Auth Keys', description: 'API keys for client authentication with model/credential ACLs' },
+  { key: 'dashboard', label: 'Dashboard', description: 'Dashboard authentication and settings' },
+  { key: 'rate-limit', label: 'Rate Limiting', description: 'Global and per-key RPM/TPM limits' },
+  { key: 'cache', label: 'Cache', description: 'Response cache settings (TTL, max entries)' },
+  { key: 'cost', label: 'Cost Tracking', description: 'Custom model pricing overrides' },
+  { key: 'audit', label: 'Audit', description: 'Audit logging backend configuration' },
+  { key: 'logging', label: 'Logging', description: 'Log level, file rotation, and output settings' },
+];
 
 export default function Config() {
   const [activeTab, setActiveTab] = useState<Tab>('view');
@@ -25,6 +46,7 @@ export default function Config() {
   const [isValidating, setIsValidating] = useState(false);
   const [isApplying, setIsApplying] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [expandedSection, setExpandedSection] = useState<string | null>(null);
 
   const fetchConfig = useCallback(async () => {
     setIsLoading(true);
@@ -111,7 +133,7 @@ export default function Config() {
     return (
       <div className="page">
         <div className="page-header">
-          <h2>Configuration</h2>
+          <h2>Config & Changes</h2>
         </div>
         <div className="card">
           <div className="card-body">Loading configuration...</div>
@@ -124,9 +146,9 @@ export default function Config() {
     <div className="page">
       <div className="page-header">
         <div>
-          <h2>Configuration</h2>
+          <h2>Config & Changes</h2>
           <p className="page-subtitle">
-            View and manage gateway configuration
+            View, validate, and apply gateway configuration
             {configPath && <> &mdash; <code>{configPath}</code></>}
           </p>
         </div>
@@ -156,6 +178,13 @@ export default function Config() {
               Current Config
             </button>
             <button
+              className={`btn ${activeTab === 'schema' ? 'btn-primary' : 'btn-ghost'} btn-sm`}
+              onClick={() => setActiveTab('schema')}
+            >
+              <Layers size={14} />
+              Config Schema
+            </button>
+            <button
               className={`btn ${activeTab === 'editor' ? 'btn-primary' : 'btn-ghost'} btn-sm`}
               onClick={() => setActiveTab('editor')}
             >
@@ -166,6 +195,84 @@ export default function Config() {
           </div>
         </div>
       </div>
+
+      {/* Schema Explorer Tab */}
+      {activeTab === 'schema' && (
+        <div className="card">
+          <div className="card-header">
+            <h3><Layers size={18} style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />Configuration Sections</h3>
+          </div>
+          <div className="card-body">
+            <p className="text-muted" style={{ marginBottom: '1rem' }}>
+              Each section of the configuration controls a specific domain. Click a section to see its current values.
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              {CONFIG_SECTIONS.map((section) => {
+                const sectionData = currentConfig?.[section.key];
+                const isExpanded = expandedSection === section.key;
+                return (
+                  <div key={section.key} style={{
+                    border: '1px solid var(--color-border)',
+                    borderRadius: 'var(--radius-sm)',
+                    overflow: 'hidden',
+                  }}>
+                    <button
+                      onClick={() => setExpandedSection(isExpanded ? null : section.key)}
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        width: '100%',
+                        padding: '0.75rem 1rem',
+                        background: isExpanded ? 'var(--bg-secondary)' : 'transparent',
+                        border: 'none',
+                        cursor: 'pointer',
+                        textAlign: 'left',
+                        color: 'var(--text-primary)',
+                      }}
+                    >
+                      <div>
+                        <strong>{section.label}</strong>
+                        <span className="text-muted" style={{ marginLeft: '0.75rem', fontSize: '0.85rem' }}>
+                          {section.description}
+                        </span>
+                      </div>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        {sectionData !== undefined ? (
+                          <span className="type-badge type-badge--green">configured</span>
+                        ) : (
+                          <span className="type-badge">default</span>
+                        )}
+                        <Clock size={14} className="text-muted" style={{ transform: isExpanded ? 'rotate(180deg)' : 'none' }} />
+                      </div>
+                    </button>
+                    {isExpanded && (
+                      <div style={{ padding: '1rem', borderTop: '1px solid var(--color-border)' }}>
+                        {sectionData !== undefined ? (
+                          <pre style={{
+                            background: 'var(--bg-secondary)',
+                            padding: '0.75rem',
+                            borderRadius: 'var(--radius-sm)',
+                            overflow: 'auto',
+                            maxHeight: '300px',
+                            fontSize: '0.8rem',
+                            lineHeight: '1.5',
+                            margin: 0,
+                          }}>
+                            {JSON.stringify(sectionData, null, 2)}
+                          </pre>
+                        ) : (
+                          <p className="text-muted">Using default values. Not explicitly configured.</p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
 
       {activeTab === 'view' && currentConfig && (
         <div className="card">

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -103,7 +103,7 @@ export default function Dashboard() {
     <div className="page">
       <div className="page-header">
         <div>
-          <h2>Dashboard</h2>
+          <h2>Overview</h2>
           <p className="page-subtitle">Gateway overview and analytics</p>
         </div>
         <div className="page-header-actions">

--- a/web/src/pages/ModelsCapabilities.tsx
+++ b/web/src/pages/ModelsCapabilities.tsx
@@ -1,0 +1,279 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { providersApi } from '../services/api';
+import type { Provider } from '../types';
+import {
+  Layers,
+  RefreshCw,
+  Search,
+  CheckCircle,
+  XCircle,
+  Filter,
+} from 'lucide-react';
+
+interface ModelEntry {
+  id: string;
+  alias: string | null;
+  provider: string;
+  format: string;
+}
+
+export default function ModelsCapabilities() {
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterFormat, setFilterFormat] = useState('');
+  const [filterProvider, setFilterProvider] = useState('');
+
+  const fetchProviders = useCallback(async () => {
+    try {
+      const res = await providersApi.list();
+      setProviders(res.data);
+    } catch (err) {
+      console.error('Failed to fetch providers:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProviders();
+  }, [fetchProviders]);
+
+  const allModels = useMemo(() => {
+    const models: ModelEntry[] = [];
+    for (const p of providers) {
+      if (p.disabled) continue;
+      for (const m of p.models) {
+        models.push({
+          id: m.id,
+          alias: m.alias,
+          provider: p.name,
+          format: p.format,
+        });
+      }
+    }
+    return models;
+  }, [providers]);
+
+  const filteredModels = useMemo(() => {
+    let result = allModels;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (m) =>
+          m.id.toLowerCase().includes(q) ||
+          (m.alias && m.alias.toLowerCase().includes(q)) ||
+          m.provider.toLowerCase().includes(q)
+      );
+    }
+    if (filterFormat) {
+      result = result.filter((m) => m.format === filterFormat);
+    }
+    if (filterProvider) {
+      result = result.filter((m) => m.provider === filterProvider);
+    }
+    return result;
+  }, [allModels, searchQuery, filterFormat, filterProvider]);
+
+  // Group models by model ID to show multi-provider availability
+  const modelGroups = useMemo(() => {
+    const groups = new Map<string, ModelEntry[]>();
+    for (const m of filteredModels) {
+      const key = m.alias || m.id;
+      const arr = groups.get(key) || [];
+      arr.push(m);
+      groups.set(key, arr);
+    }
+    return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+  }, [filteredModels]);
+
+  const uniqueFormats = [...new Set(providers.map((p) => p.format))];
+  const activeProviders = providers.filter((p) => !p.disabled);
+  const providerNames = activeProviders.map((p) => p.name);
+
+  // Capability summary per provider
+  const providerCapabilities = useMemo(() => {
+    return activeProviders.map((p) => ({
+      name: p.name,
+      format: p.format,
+      modelsCount: p.models.length,
+      supportsStream: true, // all formats support streaming
+      supportsTools: p.format !== 'gemini', // gemini tools are limited
+      wireApi: p.wire_api,
+      hasPresentation: !!p.upstream_presentation && p.upstream_presentation.profile !== 'native',
+    }));
+  }, [activeProviders]);
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div>
+          <h2>Models & Capabilities</h2>
+          <p className="page-subtitle">
+            {allModels.length} models across {activeProviders.length} active providers
+          </p>
+        </div>
+        <div className="page-header-actions">
+          <button className="btn btn-secondary" onClick={fetchProviders}>
+            <RefreshCw size={16} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Provider Capability Matrix */}
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <div className="card-header">
+          <h3>Provider Capabilities</h3>
+        </div>
+        <div className="card-body">
+          {isLoading ? (
+            <div className="empty-state"><p>Loading...</p></div>
+          ) : providerCapabilities.length === 0 ? (
+            <div className="empty-state">
+              <Layers size={48} />
+              <p>No active providers configured</p>
+            </div>
+          ) : (
+            <div className="table-wrapper">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Provider</th>
+                    <th>Format</th>
+                    <th style={{ textAlign: 'center' }}>Models</th>
+                    <th style={{ textAlign: 'center' }}>Wire API</th>
+                    <th style={{ textAlign: 'center' }}>Streaming</th>
+                    <th style={{ textAlign: 'center' }}>Tools</th>
+                    <th style={{ textAlign: 'center' }}>Presentation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {providerCapabilities.map((cap) => (
+                    <tr key={cap.name}>
+                      <td className="text-bold">{cap.name}</td>
+                      <td><span className="type-badge">{cap.format}</span></td>
+                      <td style={{ textAlign: 'center' }}>{cap.modelsCount}</td>
+                      <td style={{ textAlign: 'center' }}>
+                        <span className="type-badge">{cap.wireApi}</span>
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        <CheckCircle size={14} color="var(--success)" />
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        {cap.supportsTools
+                          ? <CheckCircle size={14} color="var(--success)" />
+                          : <XCircle size={14} color="var(--text-secondary)" />
+                        }
+                      </td>
+                      <td style={{ textAlign: 'center' }}>
+                        {cap.hasPresentation
+                          ? <CheckCircle size={14} color="var(--success)" />
+                          : <span className="text-muted">-</span>
+                        }
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Model Search & Filter */}
+      <div className="card">
+        <div className="card-header card-header--actions">
+          <h3>Model Registry</h3>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <Filter size={14} className="text-muted" />
+            <select
+              className="filter-input"
+              value={filterFormat}
+              onChange={(e) => setFilterFormat(e.target.value)}
+              style={{ minWidth: 100 }}
+            >
+              <option value="">All Formats</option>
+              {uniqueFormats.map((f) => (
+                <option key={f} value={f}>{f}</option>
+              ))}
+            </select>
+            <select
+              className="filter-input"
+              value={filterProvider}
+              onChange={(e) => setFilterProvider(e.target.value)}
+              style={{ minWidth: 120 }}
+            >
+              <option value="">All Providers</option>
+              {providerNames.map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+            <div className="search-input-wrapper">
+              <Search size={14} className="search-icon" />
+              <input
+                type="text"
+                placeholder="Search models..."
+                className="filter-input search-input"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="card-body" style={{ padding: 0 }}>
+          {isLoading ? (
+            <div className="empty-state" style={{ padding: '2rem' }}><p>Loading...</p></div>
+          ) : modelGroups.length === 0 ? (
+            <div className="empty-state" style={{ padding: '2rem' }}>
+              <Layers size={48} />
+              <p>No models match your search</p>
+            </div>
+          ) : (
+            <div className="table-wrapper">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Model</th>
+                    <th>Alias</th>
+                    <th>Available From</th>
+                    <th style={{ textAlign: 'center' }}>Providers</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {modelGroups.map(([key, entries]) => (
+                    <tr key={key}>
+                      <td className="text-mono text-bold" style={{ fontSize: '0.85rem' }}>
+                        {entries[0].id}
+                      </td>
+                      <td className="text-mono" style={{ fontSize: '0.85rem' }}>
+                        {entries[0].alias && entries[0].alias !== entries[0].id ? entries[0].alias : <span className="text-muted">-</span>}
+                      </td>
+                      <td>
+                        <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+                          {entries.map((e) => (
+                            <span key={`${e.provider}-${e.id}`} className="type-badge">
+                              {e.provider}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td style={{ textAlign: 'center' }}>{entries.length}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Summary stats */}
+      {!isLoading && (
+        <div className="text-muted" style={{ marginTop: '1rem', fontSize: '0.8rem' }}>
+          Showing {filteredModels.length} of {allModels.length} models ({modelGroups.length} unique)
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Protocols.tsx
+++ b/web/src/pages/Protocols.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState, useCallback } from 'react';
+import { providersApi } from '../services/api';
+import type { Provider } from '../types';
+import {
+  Network,
+  RefreshCw,
+  CheckCircle,
+  XCircle,
+  ArrowRight,
+} from 'lucide-react';
+
+interface ProtocolEndpoint {
+  method: string;
+  path: string;
+  description: string;
+  stream: boolean;
+}
+
+const PROTOCOLS: {
+  id: string;
+  label: string;
+  format: string;
+  endpoints: ProtocolEndpoint[];
+}[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    format: 'openai',
+    endpoints: [
+      { method: 'POST', path: '/v1/chat/completions', description: 'Chat completions', stream: true },
+      { method: 'POST', path: '/v1/responses', description: 'Responses API', stream: true },
+      { method: 'GET', path: '/v1/models', description: 'List models', stream: false },
+    ],
+  },
+  {
+    id: 'claude',
+    label: 'Claude (Anthropic)',
+    format: 'claude',
+    endpoints: [
+      { method: 'POST', path: '/v1/messages', description: 'Messages API', stream: true },
+    ],
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini (Google)',
+    format: 'gemini',
+    endpoints: [
+      { method: 'POST', path: '/v1beta/models/{model}:generateContent', description: 'Generate content', stream: false },
+      { method: 'POST', path: '/v1beta/models/{model}:streamGenerateContent', description: 'Stream generate content', stream: true },
+      { method: 'GET', path: '/v1beta/models', description: 'List models', stream: false },
+    ],
+  },
+];
+
+type CoverageLevel = 'native' | 'adapted' | 'none';
+
+function getCoverage(protocol: string, providerFormat: string): CoverageLevel {
+  if (protocol === providerFormat) return 'native';
+  // All formats can be reached via translation
+  return 'adapted';
+}
+
+function CoverageBadge({ level }: { level: CoverageLevel }) {
+  if (level === 'native') {
+    return <span className="type-badge type-badge--green"><CheckCircle size={12} /> Native</span>;
+  }
+  if (level === 'adapted') {
+    return <span className="type-badge type-badge--blue"><ArrowRight size={12} /> Adapted</span>;
+  }
+  return <span className="type-badge type-badge--red"><XCircle size={12} /> None</span>;
+}
+
+export default function Protocols() {
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchProviders = useCallback(async () => {
+    try {
+      const res = await providersApi.list();
+      setProviders(res.data.filter((p) => !p.disabled));
+    } catch (err) {
+      console.error('Failed to fetch providers:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProviders();
+  }, [fetchProviders]);
+
+  const uniqueFormats = [...new Set(providers.map((p) => p.format))];
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div>
+          <h2>Protocols</h2>
+          <p className="page-subtitle">
+            Public ingress protocols, endpoint semantics, and provider coverage
+          </p>
+        </div>
+        <div className="page-header-actions">
+          <button className="btn btn-secondary" onClick={fetchProviders}>
+            <RefreshCw size={16} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Protocol Endpoint Reference */}
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <div className="card-header">
+          <h3><Network size={18} style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />Public Endpoints</h3>
+        </div>
+        <div className="card-body">
+          <p className="text-muted" style={{ marginBottom: '1rem' }}>
+            All public inference endpoints share one canonical runtime pipeline. Requests are parsed by protocol-specific ingress adapters, routed through the capability-aware planner, and translated back via egress adapters.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+            {PROTOCOLS.map((proto) => (
+              <div key={proto.id}>
+                <h4 style={{ marginBottom: '0.5rem' }}>{proto.label}</h4>
+                <div className="table-wrapper">
+                  <table className="table">
+                    <thead>
+                      <tr>
+                        <th style={{ width: 80 }}>Method</th>
+                        <th>Path</th>
+                        <th>Description</th>
+                        <th style={{ width: 90 }}>Stream</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {proto.endpoints.map((ep) => (
+                        <tr key={ep.path}>
+                          <td><span className="type-badge">{ep.method}</span></td>
+                          <td className="text-mono" style={{ fontSize: '0.85rem' }}>{ep.path}</td>
+                          <td>{ep.description}</td>
+                          <td>{ep.stream ? <CheckCircle size={14} color="var(--success)" /> : <span className="text-muted">-</span>}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Protocol × Provider Coverage Matrix */}
+      <div className="card">
+        <div className="card-header">
+          <h3>Protocol Coverage Matrix</h3>
+        </div>
+        <div className="card-body">
+          {isLoading ? (
+            <div className="empty-state"><p>Loading providers...</p></div>
+          ) : providers.length === 0 ? (
+            <div className="empty-state">
+              <Network size={48} />
+              <p>No active providers configured</p>
+            </div>
+          ) : (
+            <>
+              <p className="text-muted" style={{ marginBottom: '1rem' }}>
+                <strong>Native</strong>: Provider speaks this protocol natively. <strong>Adapted</strong>: Request is translated through the canonical IR to reach this provider.
+              </p>
+              <div className="table-wrapper">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Provider</th>
+                      <th>Format</th>
+                      {PROTOCOLS.map((p) => (
+                        <th key={p.id} style={{ textAlign: 'center' }}>{p.label}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {providers.map((provider) => (
+                      <tr key={provider.name}>
+                        <td className="text-bold">{provider.name}</td>
+                        <td><span className="type-badge">{provider.format}</span></td>
+                        {PROTOCOLS.map((proto) => (
+                          <td key={proto.id} style={{ textAlign: 'center' }}>
+                            <CoverageBadge level={getCoverage(proto.format, provider.format)} />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Format Distribution */}
+      {!isLoading && providers.length > 0 && (
+        <div className="card" style={{ marginTop: '1.5rem' }}>
+          <div className="card-header">
+            <h3>Provider Format Distribution</h3>
+          </div>
+          <div className="card-body">
+            <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap' }}>
+              {uniqueFormats.map((fmt) => {
+                const count = providers.filter((p) => p.format === fmt).length;
+                return (
+                  <div key={fmt} style={{ textAlign: 'center' }}>
+                    <div style={{ fontSize: '2rem', fontWeight: 700 }}>{count}</div>
+                    <div className="text-muted" style={{ textTransform: 'capitalize' }}>{fmt}</div>
+                  </div>
+                );
+              })}
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontSize: '2rem', fontWeight: 700 }}>{providers.length}</div>
+                <div className="text-muted">Total Active</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Replay.tsx
+++ b/web/src/pages/Replay.tsx
@@ -1,0 +1,328 @@
+import { useState } from 'react';
+import { routingApi } from '../services/api';
+import type { PreviewRequest, RouteExplanation } from '../types';
+import {
+  PlayCircle,
+  Search,
+  AlertCircle,
+  CheckCircle,
+  XCircle,
+  ArrowRight,
+} from 'lucide-react';
+
+export default function Replay() {
+  const [model, setModel] = useState('');
+  const [endpoint, setEndpoint] = useState('chat_completions');
+  const [sourceFormat, setSourceFormat] = useState('openai');
+  const [tenantId, setTenantId] = useState('');
+  const [stream, setStream] = useState(false);
+  const [region, setRegion] = useState('');
+  const [isExplaining, setIsExplaining] = useState(false);
+  const [explanation, setExplanation] = useState<RouteExplanation | null>(null);
+  const [error, setError] = useState('');
+
+  const handleExplain = async () => {
+    if (!model.trim()) {
+      setError('Model name is required');
+      return;
+    }
+    setIsExplaining(true);
+    setError('');
+    setExplanation(null);
+
+    const req: PreviewRequest = {
+      model: model.trim(),
+      endpoint,
+      source_format: sourceFormat,
+      stream,
+    };
+    if (tenantId.trim()) req.tenant_id = tenantId.trim();
+    if (region.trim()) req.region = region.trim();
+
+    try {
+      const res = await routingApi.explain(req);
+      setExplanation(res.data);
+    } catch (err) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const axiosErr = err as { response?: { data?: { message?: string } } };
+        setError(axiosErr.response?.data?.message || 'Explain request failed');
+      } else {
+        setError(err instanceof Error ? err.message : 'Explain request failed');
+      }
+    } finally {
+      setIsExplaining(false);
+    }
+  };
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <div>
+          <h2>Replay</h2>
+          <p className="page-subtitle">
+            Explain routing decisions and preview request execution
+          </p>
+        </div>
+      </div>
+
+      {/* Request Builder */}
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <div className="card-header">
+          <h3><PlayCircle size={18} style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />Route Explain</h3>
+        </div>
+        <div className="card-body">
+          <p className="text-muted" style={{ marginBottom: '1rem' }}>
+            Enter request parameters to see how the routing planner would handle this request. The explain result uses the same backend logic as the runtime.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '1rem' }}>
+            <div>
+              <label className="form-label">Model *</label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="e.g. gpt-4, claude-sonnet-4-5"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleExplain(); }}
+              />
+            </div>
+            <div>
+              <label className="form-label">Ingress Protocol</label>
+              <select className="form-input" value={sourceFormat} onChange={(e) => setSourceFormat(e.target.value)}>
+                <option value="openai">OpenAI</option>
+                <option value="claude">Claude</option>
+                <option value="gemini">Gemini</option>
+              </select>
+            </div>
+            <div>
+              <label className="form-label">Endpoint</label>
+              <select className="form-input" value={endpoint} onChange={(e) => setEndpoint(e.target.value)}>
+                <option value="chat_completions">Chat Completions</option>
+                <option value="messages">Messages</option>
+                <option value="responses">Responses</option>
+                <option value="generate_content">Generate Content</option>
+              </select>
+            </div>
+            <div>
+              <label className="form-label">Tenant ID</label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="Optional"
+                value={tenantId}
+                onChange={(e) => setTenantId(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="form-label">Region</label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="Optional"
+                value={region}
+                onChange={(e) => setRegion(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="form-label">Stream</label>
+              <div style={{ paddingTop: '0.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                  <input type="checkbox" checked={stream} onChange={(e) => setStream(e.target.checked)} />
+                  Enable streaming
+                </label>
+              </div>
+            </div>
+          </div>
+          <div style={{ marginTop: '1rem' }}>
+            <button
+              className="btn btn-primary"
+              onClick={handleExplain}
+              disabled={isExplaining || !model.trim()}
+            >
+              <Search size={16} />
+              {isExplaining ? 'Explaining...' : 'Explain Route'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert-error" style={{ marginBottom: '1.5rem' }}>
+          <AlertCircle size={16} /> {error}
+        </div>
+      )}
+
+      {/* Explain Result */}
+      {explanation && (
+        <>
+          {/* Selected Route */}
+          <div className="card" style={{ marginBottom: '1.5rem' }}>
+            <div className="card-header">
+              <h3>
+                {explanation.selected ? (
+                  <><CheckCircle size={18} color="var(--success)" style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />Route Selected</>
+                ) : (
+                  <><XCircle size={18} color="var(--danger)" style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />No Route Found</>
+                )}
+              </h3>
+            </div>
+            <div className="card-body">
+              {explanation.selected ? (
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '1rem' }}>
+                  <div>
+                    <div className="text-muted" style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Provider</div>
+                    <div className="text-bold">{explanation.selected.provider}</div>
+                  </div>
+                  <div>
+                    <div className="text-muted" style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Credential</div>
+                    <div className="text-mono" style={{ fontSize: '0.85rem' }}>{explanation.selected.credential_name}</div>
+                  </div>
+                  <div>
+                    <div className="text-muted" style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Model</div>
+                    <div className="text-mono" style={{ fontSize: '0.85rem' }}>{explanation.selected.model}</div>
+                  </div>
+                  <div>
+                    <div className="text-muted" style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Profile</div>
+                    <div>{explanation.profile}</div>
+                  </div>
+                  {explanation.matched_rule && (
+                    <div>
+                      <div className="text-muted" style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Matched Rule</div>
+                      <div>{explanation.matched_rule}</div>
+                    </div>
+                  )}
+                  <div>
+                    <div className="text-muted" style={{ fontSize: '0.75rem', marginBottom: '0.25rem' }}>Score</div>
+                    <div>weight={explanation.selected.score.weight} penalty={explanation.selected.score.health_penalty}</div>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-muted">No provider could serve this request. Check rejections below.</p>
+              )}
+            </div>
+          </div>
+
+          {/* Model Resolution */}
+          {explanation.model_resolution.length > 0 && (
+            <div className="card" style={{ marginBottom: '1.5rem' }}>
+              <div className="card-header">
+                <h3>Model Resolution</h3>
+              </div>
+              <div className="card-body">
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                  {explanation.model_resolution.map((step, i) => (
+                    <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                      <span className="type-badge">{step.step}</span>
+                      {step.from && step.to && (
+                        <>
+                          <span className="text-mono" style={{ fontSize: '0.85rem' }}>{step.from}</span>
+                          <ArrowRight size={14} />
+                          <span className="text-mono" style={{ fontSize: '0.85rem' }}>{step.to}</span>
+                        </>
+                      )}
+                      {step.model && <span className="text-mono" style={{ fontSize: '0.85rem' }}>{step.model}</span>}
+                      {step.rule && <span className="text-muted" style={{ fontSize: '0.8rem' }}>({step.rule})</span>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Scoring */}
+          {explanation.scoring.length > 0 && (
+            <div className="card" style={{ marginBottom: '1.5rem' }}>
+              <div className="card-header">
+                <h3>Candidate Scoring</h3>
+              </div>
+              <div className="table-wrapper">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Rank</th>
+                      <th>Candidate</th>
+                      <th style={{ textAlign: 'right' }}>Weight</th>
+                      <th style={{ textAlign: 'right' }}>Latency (ms)</th>
+                      <th style={{ textAlign: 'right' }}>Inflight</th>
+                      <th style={{ textAlign: 'right' }}>Health Penalty</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {explanation.scoring.map((entry) => (
+                      <tr key={entry.candidate} className={entry.rank === 1 ? 'table-row--highlight' : ''}>
+                        <td className="text-bold">{entry.rank}</td>
+                        <td className="text-mono" style={{ fontSize: '0.85rem' }}>{entry.candidate}</td>
+                        <td style={{ textAlign: 'right' }}>{entry.score.weight}</td>
+                        <td style={{ textAlign: 'right' }}>{entry.score.latency_ms ?? '-'}</td>
+                        <td style={{ textAlign: 'right' }}>{entry.score.inflight ?? '-'}</td>
+                        <td style={{ textAlign: 'right' }}>{entry.score.health_penalty}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Alternates */}
+          {explanation.alternates.length > 0 && (
+            <div className="card" style={{ marginBottom: '1.5rem' }}>
+              <div className="card-header">
+                <h3>Alternate Routes</h3>
+              </div>
+              <div className="table-wrapper">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Provider</th>
+                      <th>Credential</th>
+                      <th>Model</th>
+                      <th style={{ textAlign: 'right' }}>Weight</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {explanation.alternates.map((alt, i) => (
+                      <tr key={i}>
+                        <td className="text-bold">{alt.provider}</td>
+                        <td className="text-mono" style={{ fontSize: '0.85rem' }}>{alt.credential_name}</td>
+                        <td className="text-mono" style={{ fontSize: '0.85rem' }}>{alt.model}</td>
+                        <td style={{ textAlign: 'right' }}>{alt.score.weight}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Rejections */}
+          {explanation.rejections.length > 0 && (
+            <div className="card">
+              <div className="card-header">
+                <h3><XCircle size={18} color="var(--danger)" style={{ verticalAlign: 'middle', marginRight: '0.5rem' }} />Rejections</h3>
+              </div>
+              <div className="table-wrapper">
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Candidate</th>
+                      <th>Reason</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {explanation.rejections.map((rej, i) => (
+                      <tr key={i}>
+                        <td className="text-mono" style={{ fontSize: '0.85rem' }}>{rej.candidate}</td>
+                        <td>{rej.reason}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Tenants.tsx
+++ b/web/src/pages/Tenants.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { tenantsApi } from '../services/api';
 import type { TenantSummary, TenantMetricsResponse } from '../types';
 import MetricCard from '../components/MetricCard';
+import AuthKeys from './AuthKeys';
 import {
   Users,
   RefreshCw,
@@ -11,9 +12,13 @@ import {
   Coins,
   Hash,
   Layers,
+  Key,
 } from 'lucide-react';
 
+type Tab = 'tenants' | 'keys';
+
 export default function Tenants() {
+  const [activeTab, setActiveTab] = useState<Tab>('tenants');
   const [tenants, setTenants] = useState<TenantSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -66,125 +71,157 @@ export default function Tenants() {
     <div className="page">
       <div className="page-header">
         <div>
-          <h2>Tenants</h2>
-          <p className="page-subtitle">Per-tenant usage metrics and management</p>
+          <h2>Tenants & Keys</h2>
+          <p className="page-subtitle">Access control, per-tenant usage, and API key management</p>
         </div>
-        <button className="btn btn-secondary" onClick={fetchTenants}>
-          <RefreshCw size={16} />
-          Refresh
-        </button>
+        <div className="page-header-actions">
+          {activeTab === 'tenants' && (
+            <button className="btn btn-secondary" onClick={fetchTenants}>
+              <RefreshCw size={16} />
+              Refresh
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Summary Cards */}
-      <div className="metric-grid">
-        <MetricCard
-          title="Tenants"
-          value={String(tenants.length)}
-          subtitle="active"
-          icon={<Users size={20} />}
-          color="blue"
-        />
-        <MetricCard
-          title="Total Requests"
-          value={formatTokens(totalRequests)}
-          subtitle="across all tenants"
-          icon={<Activity size={20} />}
-          color="green"
-        />
-        <MetricCard
-          title="Total Tokens"
-          value={formatTokens(totalTokens)}
-          subtitle="consumed"
-          icon={<Hash size={20} />}
-          color="purple"
-        />
-        <MetricCard
-          title="Total Cost"
-          value={formatCost(totalCost)}
-          subtitle="accrued"
-          icon={<Coins size={20} />}
-          color="orange"
-        />
+      {/* Tab navigation */}
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <div className="card-body" style={{ padding: '0.5rem 1rem' }}>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
+            <button
+              className={`btn ${activeTab === 'tenants' ? 'btn-primary' : 'btn-ghost'} btn-sm`}
+              onClick={() => setActiveTab('tenants')}
+            >
+              <Users size={14} />
+              Tenants
+            </button>
+            <button
+              className={`btn ${activeTab === 'keys' ? 'btn-primary' : 'btn-ghost'} btn-sm`}
+              onClick={() => setActiveTab('keys')}
+            >
+              <Key size={14} />
+              Auth Keys
+            </button>
+          </div>
+        </div>
       </div>
 
-      {/* Tenant Table */}
-      <div className="card" style={{ marginTop: '1.5rem' }}>
-        <div className="card-header">
-          <h3>Tenant List</h3>
-        </div>
-        <div className="table-wrapper">
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Tenant ID</th>
-                <th style={{ textAlign: 'right' }}>Requests</th>
-                <th style={{ textAlign: 'right' }}>Tokens</th>
-                <th style={{ textAlign: 'right' }}>Cost</th>
-                <th>Details</th>
-              </tr>
-            </thead>
-            <tbody>
-              {isLoading ? (
-                <tr>
-                  <td colSpan={5} className="table-empty">Loading...</td>
-                </tr>
-              ) : tenants.length === 0 ? (
-                <tr>
-                  <td colSpan={5} className="table-empty">
-                    <div className="empty-state">
-                      <Layers size={48} />
-                      <p>No tenants found</p>
-                      <span className="text-muted">Tenants appear when auth keys with tenant_id are used.</span>
-                    </div>
-                  </td>
-                </tr>
-              ) : (
-                tenants.map((tenant) => (
-                  <>
-                    <tr key={tenant.id}>
-                      <td className="text-bold text-mono">{tenant.id}</td>
-                      <td style={{ textAlign: 'right' }}>{tenant.requests.toLocaleString()}</td>
-                      <td style={{ textAlign: 'right' }}>{formatTokens(tenant.tokens)}</td>
-                      <td style={{ textAlign: 'right' }}>{formatCost(tenant.cost_usd)}</td>
-                      <td>
-                        <button
-                          className="btn btn-ghost btn-sm"
-                          onClick={() => toggleExpand(tenant.id)}
-                        >
-                          {expandedId === tenant.id ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-                        </button>
+      {activeTab === 'keys' ? (
+        <AuthKeys embedded />
+      ) : (
+        <>
+          {/* Summary Cards */}
+          <div className="metric-grid">
+            <MetricCard
+              title="Tenants"
+              value={String(tenants.length)}
+              subtitle="active"
+              icon={<Users size={20} />}
+              color="blue"
+            />
+            <MetricCard
+              title="Total Requests"
+              value={formatTokens(totalRequests)}
+              subtitle="across all tenants"
+              icon={<Activity size={20} />}
+              color="green"
+            />
+            <MetricCard
+              title="Total Tokens"
+              value={formatTokens(totalTokens)}
+              subtitle="consumed"
+              icon={<Hash size={20} />}
+              color="purple"
+            />
+            <MetricCard
+              title="Total Cost"
+              value={formatCost(totalCost)}
+              subtitle="accrued"
+              icon={<Coins size={20} />}
+              color="orange"
+            />
+          </div>
+
+          {/* Tenant Table */}
+          <div className="card" style={{ marginTop: '1.5rem' }}>
+            <div className="card-header">
+              <h3>Tenant List</h3>
+            </div>
+            <div className="table-wrapper">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Tenant ID</th>
+                    <th style={{ textAlign: 'right' }}>Requests</th>
+                    <th style={{ textAlign: 'right' }}>Tokens</th>
+                    <th style={{ textAlign: 'right' }}>Cost</th>
+                    <th>Details</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading ? (
+                    <tr>
+                      <td colSpan={5} className="table-empty">Loading...</td>
+                    </tr>
+                  ) : tenants.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="table-empty">
+                        <div className="empty-state">
+                          <Layers size={48} />
+                          <p>No tenants found</p>
+                          <span className="text-muted">Tenants appear when auth keys with tenant_id are used.</span>
+                        </div>
                       </td>
                     </tr>
-                    {expandedId === tenant.id && (
-                      <tr key={`${tenant.id}-detail`}>
-                        <td colSpan={5} style={{ background: 'var(--bg-secondary)', padding: '1rem' }}>
-                          {detailLoading ? (
-                            <span className="text-muted">Loading metrics...</span>
-                          ) : detailMetrics?.metrics ? (
-                            <div style={{ display: 'flex', gap: '2rem' }}>
-                              <div>
-                                <strong>Requests:</strong> {detailMetrics.metrics.requests.toLocaleString()}
-                              </div>
-                              <div>
-                                <strong>Tokens:</strong> {formatTokens(detailMetrics.metrics.tokens)}
-                              </div>
-                              <div>
-                                <strong>Cost:</strong> {formatCost(detailMetrics.metrics.cost_usd)}
-                              </div>
-                            </div>
-                          ) : (
-                            <span className="text-muted">No metrics available for this tenant.</span>
-                          )}
-                        </td>
-                      </tr>
-                    )}
-                  </>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
+                  ) : (
+                    tenants.map((tenant) => (
+                      <>
+                        <tr key={tenant.id}>
+                          <td className="text-bold text-mono">{tenant.id}</td>
+                          <td style={{ textAlign: 'right' }}>{tenant.requests.toLocaleString()}</td>
+                          <td style={{ textAlign: 'right' }}>{formatTokens(tenant.tokens)}</td>
+                          <td style={{ textAlign: 'right' }}>{formatCost(tenant.cost_usd)}</td>
+                          <td>
+                            <button
+                              className="btn btn-ghost btn-sm"
+                              onClick={() => toggleExpand(tenant.id)}
+                            >
+                              {expandedId === tenant.id ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                            </button>
+                          </td>
+                        </tr>
+                        {expandedId === tenant.id && (
+                          <tr key={`${tenant.id}-detail`}>
+                            <td colSpan={5} style={{ background: 'var(--bg-secondary)', padding: '1rem' }}>
+                              {detailLoading ? (
+                                <span className="text-muted">Loading metrics...</span>
+                              ) : detailMetrics?.metrics ? (
+                                <div style={{ display: 'flex', gap: '2rem' }}>
+                                  <div>
+                                    <strong>Requests:</strong> {detailMetrics.metrics.requests.toLocaleString()}
+                                  </div>
+                                  <div>
+                                    <strong>Tokens:</strong> {formatTokens(detailMetrics.metrics.tokens)}
+                                  </div>
+                                  <div>
+                                    <strong>Cost:</strong> {formatCost(detailMetrics.metrics.cost_usd)}
+                                  </div>
+                                </div>
+                              ) : (
+                                <span className="text-muted">No metrics available for this tenant.</span>
+                              )}
+                            </td>
+                          </tr>
+                        )}
+                      </>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesign dashboard navigation with sectioned layout (Observe, Infrastructure, Traffic, Access Control, Operations)
- Add 3 new pages: Protocols, Models & Capabilities, Replay
- Merge Tenants and Auth Keys into unified tabbed page
- Enhance Config page with schema-driven section explorer

## Changes
### Navigation (Layout.tsx)
- Replace flat `navItems` array with `navSections` for grouped navigation
- Add sidebar section labels with CSS styling
- New icons for Protocols (Network), Models (Layers), Replay (PlayCircle)

### New Pages
- `Protocols.tsx` — Public endpoint reference, protocol × provider coverage matrix with native/adapted badges
- `ModelsCapabilities.tsx` — Provider capability matrix, model registry with search/filter/grouping
- `Replay.tsx` — Route explain builder with model resolution trace, candidate scoring table, rejection details

### Enhanced Pages
- `Tenants.tsx` — Merged with AuthKeys via tabs (Tenants | Auth Keys)
- `AuthKeys.tsx` — Added `embedded` prop for rendering inside Tenants without page header
- `Config.tsx` — Added "Config Schema" tab with collapsible section explorer
- `Dashboard.tsx` — Renamed to "Overview"

### Routes (App.tsx)
- `/requests` replaces `/request-logs`
- `/protocols`, `/models`, `/replay` — new routes
- `/tenants` now includes auth keys
- Legacy redirects: `/request-logs` → `/requests`, `/auth-keys` → `/tenants`

### CSS (App.css)
- `.sidebar-section` and `.sidebar-section-label` for nav grouping
- `.type-badge--green`, `.type-badge--blue`, `.type-badge--red` color variants
- `.form-label` for form field labels
- `.table-row--highlight` for selected rows

## Spec & Reference Doc Impact
- Closes #221
- Closes #222
- Closes #223
- Closes #224
- Part of SPEC-065 (#211)

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (663 backend tests)
- [x] `npx tsc --noEmit` passes (frontend type check)
- [x] `npx vitest run` passes (46 frontend tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)