### PR TITLE
fix: return models array in provider list API for Models page

### DIFF
--- a/crates/server/src/handler/dashboard/providers.rs
+++ b/crates/server/src/handler/dashboard/providers.rs
@@ -13,8 +13,9 @@ struct ProviderSummary {
     format: String,
     api_key_masked: String,
     base_url: Option<String>,
-    models_count: usize,
+    models: Vec<prism_core::config::ModelMapping>,
     disabled: bool,
+    wire_api: prism_core::provider::WireApi,
     upstream_presentation: prism_core::presentation::UpstreamPresentationConfig,
 }
 
@@ -101,8 +102,9 @@ pub async fn list_providers(State(state): State<AppState>) -> impl IntoResponse 
             format: entry.format.as_str().to_string(),
             api_key_masked: mask_key(&entry.api_key),
             base_url: entry.base_url.clone(),
-            models_count: entry.models.len(),
+            models: entry.models.clone(),
             disabled: entry.disabled,
+            wire_api: entry.wire_api,
             upstream_presentation: entry.upstream_presentation.clone(),
         });
     }

--- a/web/src/__tests__/pages/Providers.test.tsx
+++ b/web/src/__tests__/pages/Providers.test.tsx
@@ -34,7 +34,7 @@ describe('Providers page', () => {
             format: 'claude',
             api_key_masked: 'sk-a****test',
             base_url: 'https://api.anthropic.com',
-            models_count: 0,
+            models: [],
             disabled: false,
           },
         ],

--- a/web/src/pages/Providers.tsx
+++ b/web/src/pages/Providers.tsx
@@ -476,12 +476,8 @@ export default function Providers() {
                       </div>
                     </td>
                     <td>
-                      {(provider.models || []).length > 0 ? (
-                        <TagList items={(provider.models || []).map((m) => typeof m === 'string' ? m : m.id)} maxVisible={3} />
-                      ) : provider.models_count != null ? (
-                        <div className="tag-list">
-                          <span className="tag">{provider.models_count} models</span>
-                        </div>
+                      {provider.models.length > 0 ? (
+                        <TagList items={provider.models.map((m) => m.id)} maxVisible={3} />
                       ) : (
                         <span className="text-muted">-</span>
                       )}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -22,7 +22,6 @@ export interface Provider {
   prefix: string | null;
   disabled: boolean;
   models: ModelMapping[];
-  models_count: number;
   excluded_models: string[];
   headers?: Record<string, string>;
   wire_api: 'chat' | 'responses';


### PR DESCRIPTION
## Summary
- Models & Capabilities page crashed because `provider.models` was `undefined` in the list API response
- Provider list endpoint now returns full `models` array and `wire_api` instead of just `models_count`

## Changes
**`crates/server/` — providers handler**
- `ProviderSummary`: replaced `models_count: usize` with `models: Vec<ModelMapping>`, added `wire_api: WireApi`
- `list_providers`: populates new fields from config

**`web/` — frontend**
- `types/index.ts`: removed redundant `models_count` field from `Provider`
- `Providers.tsx`: simplified model display to use `provider.models` directly
- `Providers.test.tsx`: updated mock data

## Test Plan
- [x] `make lint` passes
- [x] `make test` passes (664 tests)
- [x] `npx tsc --noEmit` passes
- [ ] Models & Capabilities page loads without crash
- [ ] Providers page still shows model tags correctly